### PR TITLE
Download updated plugin schemas for v3.4.x

### DIFF
--- a/schemas/acl/3.4.x.json
+++ b/schemas/acl/3.4.x.json
@@ -2,50 +2,59 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "allow": {
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "deny": {
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
@@ -56,8 +65,23 @@
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
+    }
+  ],
+  "entity_checks": [
+    {
+      "only_one_of": [
+        "config.allow",
+        "config.deny"
+      ]
+    },
+    {
+      "at_least_one_of": [
+        "config.allow",
+        "config.deny"
+      ]
     }
   ]
 }

--- a/schemas/acme/3.4.x.json
+++ b/schemas/acme/3.4.x.json
@@ -2,107 +2,127 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "service": {
-        "eq": null,
         "reference": "services",
-        "type": "foreign"
+        "description": "A reference to the 'services' table with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "route": {
-        "eq": null,
         "reference": "routes",
-        "type": "foreign"
+        "description": "A reference to the 'routes' table with a null value allowed.",
+        "type": "foreign",
+        "eq": null
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "account_email": {
-              "match": "%w*%p*@+%w*%.?%w*",
-              "encrypted": true,
-              "type": "string",
               "required": true,
-              "referenceable": true
+              "referenceable": true,
+              "encrypted": true,
+              "description": "The account identifier. Can be reused in a different plugin instance.",
+              "type": "string",
+              "match": "%w*%p*@+%w*%.?%w*"
             }
           },
           {
             "account_key": {
               "required": false,
+              "description": "The private key associated with the account.",
+              "type": "record",
               "fields": [
                 {
                   "key_id": {
+                    "description": "The Key ID.",
                     "type": "string",
                     "required": true
                   }
                 },
                 {
                   "key_set": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The ID of the key set to associate the Key ID with."
                   }
                 }
-              ],
-              "type": "record"
+              ]
             }
           },
           {
             "api_uri": {
-              "type": "string",
-              "default": "https://acme-v02.api.letsencrypt.org/directory"
+              "default": "https://acme-v02.api.letsencrypt.org/directory",
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string"
             }
           },
           {
             "tos_accepted": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If you are using Let's Encrypt, you must set this to `true` to agree the terms of service.",
+              "type": "boolean"
             }
           },
           {
             "eab_kid": {
-              "encrypted": true,
               "referenceable": true,
-              "type": "string"
+              "description": "External account binding (EAB) key id. You usually don't need to set this unless it is explicitly required by the CA.",
+              "type": "string",
+              "encrypted": true
             }
           },
           {
             "eab_hmac_key": {
-              "encrypted": true,
               "referenceable": true,
-              "type": "string"
+              "description": "External account binding (EAB) base64-encoded URL string of the HMAC key. You usually don't need to set this unless it is explicitly required by the CA.",
+              "type": "string",
+              "encrypted": true
             }
           },
           {
             "cert_type": {
               "default": "rsa",
+              "description": "The certificate type to create. The possible values are `'rsa'` for RSA certificate or `'ecc'` for EC certificate.",
               "type": "string",
               "one_of": [
                 "rsa",
@@ -113,6 +133,7 @@
           {
             "rsa_key_size": {
               "default": 4096,
+              "description": "RSA private key size for the certificate. The possible values are 2048, 3072, or 4096.",
               "type": "number",
               "one_of": [
                 2048,
@@ -123,12 +144,15 @@
           },
           {
             "renew_threshold_days": {
-              "type": "number",
-              "default": 14
+              "default": 14,
+              "description": "Days remaining to renew the certificate before it expires.",
+              "type": "number"
             }
           },
           {
             "domains": {
+              "description": "An array of strings representing hosts. A valid host is a string containing one or more labels separated by periods, with at most one wildcard label ('*')",
+              "type": "array",
               "elements": {
                 "match_any": {
                   "err": "invalid wildcard: must be placed at leftmost or rightmost label",
@@ -140,30 +164,32 @@
                 },
                 "match_all": [
                   {
-                    "err": "invalid wildcard: must have at most one wildcard",
-                    "pattern": "^[^*]*%*?[^*]*$"
+                    "pattern": "^[^*]*%*?[^*]*$",
+                    "err": "invalid wildcard: must have at most one wildcard"
                   }
                 ],
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "allow_any_domain": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to `true`, the plugin allows all domains and ignores any values in the `domains` list.",
+              "type": "boolean"
             }
           },
           {
             "fail_backoff_minutes": {
-              "type": "number",
-              "default": 5
+              "default": 5,
+              "description": "Minutes to wait for each domain that fails to create a certificate. This applies to both a\nnew certificate and a renewal certificate.",
+              "type": "number"
             }
           },
           {
             "storage": {
               "default": "shm",
+              "description": "The backend storage type to use. The possible values are `'kong'`, `'shm'`, `'redis'`, `'consul'`, or `'vault'`. In DB-less mode, `'kong'` storage is unavailable. Note that `'shm'` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `'kong'`, `'redis'`, `'consul'`, or `'vault'` in production. Please refer to the Hybrid Mode sections below as well.",
               "type": "string",
               "one_of": [
                 "kong",
@@ -176,38 +202,38 @@
           },
           {
             "storage_config": {
-              "required": true,
               "fields": [
                 {
                   "shm": {
-                    "required": true,
                     "fields": [
                       {
                         "shm_name": {
                           "default": "kong",
+                          "description": "Name of shared memory zone used for Kong API gateway storage",
                           "type": "string"
                         }
                       }
                     ],
-                    "type": "record"
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "kong": {
-                    "required": true,
                     "fields": [
 
                     ],
-                    "type": "record"
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "redis": {
-                    "required": true,
                     "fields": [
                       {
                         "host": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "A string representing a host name, such as example.com."
                         }
                       },
                       {
@@ -216,65 +242,74 @@
                             0,
                             65535
                           ],
+                          "description": "An integer representing a port number between 0 and 65535, inclusive.",
                           "type": "integer"
                         }
                       },
                       {
                         "database": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "The index of the Redis database to use."
                         }
                       },
                       {
                         "auth": {
+                          "description": "The Redis password to use for authentication. ",
                           "type": "string",
                           "referenceable": true
                         }
                       },
                       {
                         "ssl": {
-                          "required": true,
                           "default": false,
-                          "type": "boolean"
+                          "description": "Whether to use SSL/TLS encryption when connecting to the Redis server.",
+                          "type": "boolean",
+                          "required": true
                         }
                       },
                       {
                         "ssl_verify": {
-                          "required": true,
                           "default": false,
-                          "type": "boolean"
+                          "description": "Whether to verify the SSL/TLS certificate presented by the Redis server. This should be a boolean value.",
+                          "type": "boolean",
+                          "required": true
                         }
                       },
                       {
                         "ssl_server_name": {
+                          "description": "The expected server name for the SSL/TLS certificate presented by the Redis server.",
                           "type": "string",
                           "required": false
                         }
                       },
                       {
                         "namespace": {
-                          "type": "string",
-                          "len_min": 0,
                           "required": true,
-                          "default": ""
+                          "default": "",
+                          "description": "A namespace to prepend to all keys stored in Redis.",
+                          "type": "string",
+                          "len_min": 0
                         }
                       }
                     ],
-                    "type": "record"
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "consul": {
-                    "required": true,
                     "fields": [
                       {
                         "https": {
-                          "type": "boolean",
-                          "default": false
+                          "default": false,
+                          "description": "Boolean representation of https.",
+                          "type": "boolean"
                         }
                       },
                       {
                         "host": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "A string representing a host name, such as example.com."
                         }
                       },
                       {
@@ -283,42 +318,48 @@
                             0,
                             65535
                           ],
+                          "description": "An integer representing a port number between 0 and 65535, inclusive.",
                           "type": "integer"
                         }
                       },
                       {
                         "kv_path": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "KV prefix path."
                         }
                       },
                       {
                         "timeout": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Timeout in milliseconds."
                         }
                       },
                       {
                         "token": {
+                          "description": "Consul ACL token.",
                           "type": "string",
                           "referenceable": true
                         }
                       }
                     ],
-                    "type": "record"
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "vault": {
-                    "required": true,
                     "fields": [
                       {
                         "https": {
-                          "type": "boolean",
-                          "default": false
+                          "default": false,
+                          "description": "Boolean representation of https.",
+                          "type": "boolean"
                         }
                       },
                       {
                         "host": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "A string representing a host name, such as example.com."
                         }
                       },
                       {
@@ -327,39 +368,46 @@
                             0,
                             65535
                           ],
+                          "description": "An integer representing a port number between 0 and 65535, inclusive.",
                           "type": "integer"
                         }
                       },
                       {
                         "kv_path": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "KV prefix path."
                         }
                       },
                       {
                         "timeout": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Timeout in milliseconds."
                         }
                       },
                       {
                         "token": {
+                          "description": "Consul ACL token.",
                           "type": "string",
                           "referenceable": true
                         }
                       },
                       {
                         "tls_verify": {
-                          "type": "boolean",
-                          "default": true
+                          "default": true,
+                          "description": "Turn on TLS verification.",
+                          "type": "boolean"
                         }
                       },
                       {
                         "tls_server_name": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "SNI used in request, default to host if omitted."
                         }
                       },
                       {
                         "auth_method": {
                           "default": "token",
+                          "description": "Auth Method, default to token, can be 'token' or 'kubernetes'.",
                           "type": "string",
                           "one_of": [
                             "token",
@@ -369,40 +417,73 @@
                       },
                       {
                         "auth_path": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Vault's authentication path to use."
                         }
                       },
                       {
                         "auth_role": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The role to try and assign."
                         }
                       },
                       {
                         "jwt_path": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "The path to the JWT."
                         }
                       }
                     ],
-                    "type": "record"
+                    "type": "record",
+                    "required": true
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "preferred_chain": {
-              "type": "string"
+              "type": "string",
+              "description": "A string value that specifies the preferred certificate chain to use when generating certificates."
             }
           },
           {
             "enable_ipv4_common_name": {
-              "type": "boolean",
-              "default": true
+              "default": true,
+              "description": "A boolean value that controls whether to include the IPv4 address in the common name field of generated certificates.",
+              "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "conditional": {
+        "then_field": "config.tos_accepted",
+        "then_err": "terms of service must be accepted, see https://letsencrypt.org/repository/",
+        "then_match": {
+          "eq": true
+        },
+        "if_match": {
+          "one_of": [
+            "https://acme-v02.api.letsencrypt.org",
+            "https://acme-staging-v02.api.letsencrypt.org"
+          ]
+        },
+        "if_field": "config.api_uri"
+      }
+    },
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config.storage"
+        ]
       }
     }
   ]

--- a/schemas/application-registration/3.4.x.json
+++ b/schemas/application-registration/3.4.x.json
@@ -2,81 +2,99 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "service": {
-        "on_delete": "cascade",
-        "ne": null,
         "reference": "services",
-        "type": "foreign"
+        "on_delete": "cascade",
+        "type": "foreign",
+        "ne": null
       }
     },
     {
       "route": {
-        "eq": null,
         "reference": "routes",
-        "type": "foreign"
+        "description": "A reference to the 'routes' table with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "display_name": {
-              "type": "string",
               "unique": true,
+              "description": "Unique display name used for a Service in the Developer Portal.",
+              "type": "string",
               "required": true
             }
           },
           {
             "description": {
-              "unique": true,
-              "type": "string"
+              "description": "Unique description displayed in information about a Service in the Developer Portal.",
+              "type": "string",
+              "unique": true
             }
           },
           {
             "auto_approve": {
-              "required": true,
+              "default": false,
+              "description": "If enabled, all new Service Contracts requests are automatically approved.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           },
           {
             "show_issuer": {
-              "required": true,
+              "default": false,
+              "description": "Displays the **Issuer URL** in the **Service Details** dialog.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/aws-lambda/3.4.x.json
+++ b/schemas/aws-lambda/3.4.x.json
@@ -2,32 +2,41 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "timeout": {
               "default": 60000,
+              "description": "An optional timeout in milliseconds when invoking the function.",
               "type": "number",
               "required": true
             }
@@ -35,6 +44,7 @@
           {
             "keepalive": {
               "default": 60000,
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
               "type": "number",
               "required": true
             }
@@ -42,6 +52,7 @@
           {
             "aws_key": {
               "referenceable": true,
+              "description": "The AWS key credential to be used when invoking the function.",
               "type": "string",
               "encrypted": true
             }
@@ -49,6 +60,7 @@
           {
             "aws_secret": {
               "referenceable": true,
+              "description": "The AWS secret credential to be used when invoking the function. ",
               "type": "string",
               "encrypted": true
             }
@@ -56,6 +68,7 @@
           {
             "aws_assume_role_arn": {
               "referenceable": true,
+              "description": "The target AWS IAM role ARN used to invoke the Lambda function.",
               "type": "string",
               "encrypted": true
             }
@@ -63,61 +76,69 @@
           {
             "aws_role_session_name": {
               "default": "kong",
+              "description": "The identifier of the assumed role session.",
               "type": "string"
             }
           },
           {
             "aws_region": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "function_name": {
-              "required": false,
-              "type": "string"
+              "description": "The AWS Lambda function name to invoke.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "qualifier": {
-              "type": "string"
+              "type": "string",
+              "description": "The qualifier to use when invoking the function."
             }
           },
           {
             "invocation_type": {
               "required": true,
+              "default": "RequestResponse",
+              "description": "The InvocationType to use when invoking the function. Available types are RequestResponse, Event, DryRun.",
+              "type": "string",
               "one_of": [
                 "RequestResponse",
                 "Event",
                 "DryRun"
-              ],
-              "type": "string",
-              "default": "RequestResponse"
+              ]
             }
           },
           {
             "log_type": {
               "required": true,
+              "default": "Tail",
+              "description": "The LogType to use when invoking the function. By default, None and Tail are supported.",
+              "type": "string",
               "one_of": [
                 "Tail",
                 "None"
-              ],
-              "type": "string",
-              "default": "Tail"
+              ]
             }
           },
           {
             "host": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
+              "default": 443,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "type": "integer",
-              "default": 443
+              ]
             }
           },
           {
@@ -132,75 +153,102 @@
                 100,
                 999
               ],
+              "description": "The response status code to use (instead of the default 200, 202, or 204) in the case of an Unhandled Function Error.",
               "type": "integer"
             }
           },
           {
             "forward_request_method": {
               "default": false,
+              "description": "An optional value that defines whether the original HTTP request method verb is sent in the request_method field of the JSON-encoded request.",
               "type": "boolean"
             }
           },
           {
             "forward_request_uri": {
               "default": false,
+              "description": "An optional value that defines whether the original HTTP request URI is sent in the request_uri field of the JSON-encoded request.",
               "type": "boolean"
             }
           },
           {
             "forward_request_headers": {
               "default": false,
+              "description": "An optional value that defines whether the original HTTP request headers are sent as a map in the request_headers field of the JSON-encoded request.",
               "type": "boolean"
             }
           },
           {
             "forward_request_body": {
               "default": false,
+              "description": "An optional value that defines whether the request body is sent in the request_body field of the JSON-encoded request. If the body arguments can be parsed, they are sent in the separate request_body_args field of the request. ",
               "type": "boolean"
             }
           },
           {
             "is_proxy_integration": {
               "default": false,
+              "description": "An optional value that defines whether the response format to receive from the Lambda to this format.",
               "type": "boolean"
             }
           },
           {
             "awsgateway_compatible": {
               "default": false,
+              "description": "An optional value that defines whether the plugin should wrap requests into the Amazon API gateway.",
               "type": "boolean"
             }
           },
           {
             "proxy_url": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "skip_large_bodies": {
               "default": true,
+              "description": "An optional value that defines whether Kong should send large bodies that are buffered to disk",
               "type": "boolean"
             }
           },
           {
             "base64_encode_body": {
               "default": true,
+              "description": "An optional value that Base64-encodes the request body.",
               "type": "boolean"
             }
           },
           {
             "aws_imds_protocol_version": {
               "required": true,
+              "default": "v1",
+              "description": "Identifier to select the IMDS protocol version to use: `v1` or `v2`.",
+              "type": "string",
               "one_of": [
                 "v1",
                 "v2"
-              ],
-              "type": "string",
-              "default": "v1"
+              ]
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "mutually_required": [
+        "config.aws_key",
+        "config.aws_secret"
+      ]
+    },
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config.proxy_url"
+        ]
       }
     }
   ]

--- a/schemas/azure-functions/3.4.x.json
+++ b/schemas/azure-functions/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,83 +25,101 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "timeout": {
-              "type": "number",
-              "default": 600000
+              "default": 600000,
+              "description": "Timeout in milliseconds before closing a connection to the Azure Functions server.",
+              "type": "number"
             }
           },
           {
             "keepalive": {
-              "type": "number",
-              "default": 60000
+              "default": 60000,
+              "description": "Time in milliseconds during which an idle connection to the Azure Functions server lives before being closed.",
+              "type": "number"
             }
           },
           {
             "https": {
-              "type": "boolean",
-              "default": true
+              "default": true,
+              "description": "Use of HTTPS to connect with the Azure Functions server.",
+              "type": "boolean"
             }
           },
           {
             "https_verify": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Set to `true` to authenticate the Azure Functions server.",
+              "type": "boolean"
             }
           },
           {
             "apikey": {
+              "encrypted": true,
+              "description": "The apikey to access the Azure resources. If provided, it is injected as the `x-functions-key` header.",
               "type": "string",
-              "referenceable": true,
-              "encrypted": true
+              "referenceable": true
             }
           },
           {
             "clientid": {
+              "encrypted": true,
+              "description": "The `clientid` to access the Azure resources. If provided, it is injected as the `x-functions-clientid` header.",
               "type": "string",
-              "referenceable": true,
-              "encrypted": true
+              "referenceable": true
             }
           },
           {
             "appname": {
+              "description": "The Azure app name.",
               "type": "string",
               "required": true
             }
           },
           {
             "hostdomain": {
+              "default": "azurewebsites.net",
+              "description": "The domain where the function resides.",
               "type": "string",
-              "required": true,
-              "default": "azurewebsites.net"
+              "required": true
             }
           },
           {
             "routeprefix": {
-              "type": "string",
-              "default": "api"
+              "default": "api",
+              "description": "Route prefix to use.",
+              "type": "string"
             }
           },
           {
             "functionname": {
+              "description": "Name of the Azure function to invoke.",
               "type": "string",
               "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/basic-auth/3.4.x.json
+++ b/schemas/basic-auth/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -17,7 +18,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,32 +29,42 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "hide_credentials": {
-              "required": true,
               "default": false,
-              "type": "boolean"
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it.",
+              "type": "boolean",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/bot-detection/3.4.x.json
+++ b/schemas/bot-detection/3.4.x.json
@@ -2,63 +2,78 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "allow": {
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "is_regex": true
-              },
               "default": [
 
-              ]
+              ],
+              "description": "An array of regular expressions that should be allowed. The regular expressions will be checked against the `User-Agent` header.",
+              "type": "array",
+              "elements": {
+                "is_regex": true,
+                "type": "string"
+              }
             }
           },
           {
             "deny": {
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "is_regex": true
-              },
               "default": [
 
-              ]
+              ],
+              "description": "An array of regular expressions that should be denied. The regular expressions will be checked against the `User-Agent` header.",
+              "type": "array",
+              "elements": {
+                "is_regex": true,
+                "type": "string"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/canary/3.4.x.json
+++ b/schemas/canary/3.4.x.json
@@ -2,52 +2,56 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "shorthand_fields": [
-          {
-            "hash": {
-              "type": "string"
-            }
-          }
-        ],
-        "required": true,
         "fields": [
           {
             "start": {
-              "type": "number"
+              "type": "number",
+              "description": "Future time in seconds since epoch, when the canary release will start. Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`."
             }
           },
           {
             "hash": {
-              "type": "string",
               "default": "consumer",
+              "description": "Hash algorithm to be used for canary release.\n\n* `consumer`: The hash will be based on the consumer.\n* `ip`: The hash will be based on the client IP address.\n* `none`: No hash will be applied.\n* `allow`: Allows the specified groups to access the canary release.\n* `deny`: Denies the specified groups from accessing the canary release.\n* `header`: The hash will be based on the specified header value.",
+              "type": "string",
               "one_of": [
                 "consumer",
                 "ip",
@@ -60,21 +64,24 @@
           },
           {
             "hash_header": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           },
           {
             "duration": {
               "default": 3600,
-              "gt": 0,
-              "type": "number"
+              "description": "The duration of the canary release in seconds.",
+              "type": "number",
+              "gt": 0
             }
           },
           {
             "steps": {
               "default": 1000,
-              "gt": 1,
-              "type": "number"
+              "description": "The number of steps for the canary release.",
+              "type": "number",
+              "gt": 1
             }
           },
           {
@@ -83,12 +90,14 @@
                 0,
                 100
               ],
+              "description": "The percentage of traffic to be routed to the canary release.",
               "type": "number"
             }
           },
           {
             "upstream_host": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -97,37 +106,84 @@
                 0,
                 65535
               ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer"
             }
           },
           {
             "upstream_uri": {
               "len_min": 1,
+              "description": "The URI of the upstream server to be used for the canary release.",
               "type": "string"
             }
           },
           {
             "upstream_fallback": {
+              "default": false,
+              "description": "Specifies whether to fallback to the upstream server if the canary release fails.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "groups": {
+              "description": "The groups allowed to access the canary release.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "canary_by_header_name": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "shorthand_fields": [
+          {
+            "hash": {
+              "type": "string",
+              "description": "Hash algorithm to be used for canary release. `whitelist` is deprecated. Use `allow` instead `blacklist` is deprecated. Use `deny` instead."
+            }
+          }
+        ],
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.upstream_uri",
+        "config.upstream_host",
+        "config.upstream_port"
+      ]
+    },
+    {
+      "conditional": {
+        "if_field": "config.hash",
+        "then_field": "config.hash_header",
+        "if_match": {
+          "eq": "header"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.upstream_fallback",
+        "then_field": "config.upstream_host",
+        "if_match": {
+          "eq": true
+        },
+        "then_match": {
+          "required": true
+        }
       }
     }
   ]

--- a/schemas/correlation-id/3.4.x.json
+++ b/schemas/correlation-id/3.4.x.json
@@ -2,38 +2,48 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "header_name": {
-              "type": "string",
-              "default": "Kong-Request-ID"
+              "default": "Kong-Request-ID",
+              "description": "The HTTP header name to use for the correlation ID.",
+              "type": "string"
             }
           },
           {
             "generator": {
               "default": "uuid#counter",
+              "description": "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators).",
               "type": "string",
               "one_of": [
                 "uuid",
@@ -44,14 +54,19 @@
           },
           {
             "echo_downstream": {
+              "default": false,
+              "description": "Whether to echo the header back to downstream (the client).",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/cors/3.4.x.json
+++ b/schemas/cors/3.4.x.json
@@ -2,22 +2,26 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
-          "type": "string",
           "len_min": 1,
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,42 +29,49 @@
             "https"
           ],
           "required": true
-        },
-        "required": true,
-        "type": "set"
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "origins": {
+              "description": "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "headers": {
+              "description": "Value for the `Access-Control-Allow-Headers` header.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "exposed_headers": {
+              "description": "Value for the `Access-Control-Expose-Headers` header. If not specified, no custom headers are exposed.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "methods": {
-              "type": "array",
               "default": [
                 "GET",
                 "HEAD",
@@ -72,7 +83,10 @@
                 "TRACE",
                 "CONNECT"
               ],
+              "description": "'Value for the `Access-Control-Allow-Methods` header. Available options include `GET`, `HEAD`, `PUT`, `PATCH`, `POST`, `DELETE`, `OPTIONS`, `TRACE`, `CONNECT`. By default, all options are allowed.'",
+              "type": "array",
               "elements": {
+                "type": "string",
                 "one_of": [
                   "GET",
                   "HEAD",
@@ -83,33 +97,39 @@
                   "OPTIONS",
                   "TRACE",
                   "CONNECT"
-                ],
-                "type": "string"
+                ]
               }
             }
           },
           {
             "max_age": {
-              "type": "number"
+              "type": "number",
+              "description": "Indicates how long the results of the preflight request can be cached, in `seconds`."
             }
           },
           {
             "credentials": {
+              "default": false,
+              "description": "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "preflight_continue": {
+              "default": false,
+              "description": "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/datadog/3.4.x.json
+++ b/schemas/datadog/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,16 +25,307 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "host": {
+              "default": "localhost",
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string",
+              "referenceable": true
+            }
+          },
+          {
+            "port": {
+              "default": 8125,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ]
+            }
+          },
+          {
+            "prefix": {
+              "default": "kong",
+              "description": "String to be attached as a prefix to a metric's name.",
+              "type": "string"
+            }
+          },
+          {
+            "service_name_tag": {
+              "default": "name",
+              "description": "String to be attached as the name of the service.",
+              "type": "string"
+            }
+          },
+          {
+            "status_tag": {
+              "default": "status",
+              "description": "String to be attached as the tag of the HTTP status.",
+              "type": "string"
+            }
+          },
+          {
+            "consumer_tag": {
+              "default": "consumer",
+              "description": "String to be attached as tag of the consumer.",
+              "type": "string"
+            }
+          },
+          {
+            "retry_count": {
+              "type": "integer",
+              "description": "Number of times to retry when sending data to the upstream server."
+            }
+          },
+          {
+            "queue_size": {
+              "type": "integer",
+              "description": "Maximum number of log entries to be sent on each message to the upstream server."
+            }
+          },
+          {
+            "flush_timeout": {
+              "type": "number",
+              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records."
+            }
+          },
+          {
+            "queue": {
+              "fields": [
+                {
+                  "max_batch_size": {
+                    "default": 1,
+                    "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
+                    "between": [
+                      1,
+                      1000000
+                    ]
+                  }
+                },
+                {
+                  "max_coalescing_delay": {
+                    "default": 1,
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
+                    "between": [
+                      0,
+                      3600
+                    ]
+                  }
+                },
+                {
+                  "max_entries": {
+                    "default": 10000,
+                    "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
+                    "between": [
+                      1,
+                      1000000
+                    ]
+                  }
+                },
+                {
+                  "max_bytes": {
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
+                  }
+                },
+                {
+                  "max_retry_time": {
+                    "default": 60,
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
+                    "type": "number"
+                  }
+                },
+                {
+                  "initial_retry_delay": {
+                    "default": 0.01,
+                    "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
+                  }
+                },
+                {
+                  "max_retry_delay": {
+                    "default": 60,
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
+                  }
+                }
+              ],
+              "type": "record",
+              "required": true
+            }
+          },
+          {
+            "metrics": {
+              "required": true,
+              "default": [
+                {
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "stat_type": "counter",
+                  "sample_rate": 1,
+                  "name": "request_count"
+                },
+                {
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "name": "latency",
+                  "consumer_identifier": "custom_id",
+                  "stat_type": "timer"
+                },
+                {
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "name": "request_size",
+                  "consumer_identifier": "custom_id",
+                  "stat_type": "timer"
+                },
+                {
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "name": "response_size",
+                  "consumer_identifier": "custom_id",
+                  "stat_type": "timer"
+                },
+                {
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "name": "upstream_latency",
+                  "consumer_identifier": "custom_id",
+                  "stat_type": "timer"
+                },
+                {
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "name": "kong_latency",
+                  "consumer_identifier": "custom_id",
+                  "stat_type": "timer"
+                }
+              ],
+              "description": "List of metrics to be logged.",
+              "type": "array",
+              "elements": {
+                "fields": [
+                  {
+                    "name": {
+                      "type": "string",
+                      "description": "Datadog metric’s name",
+                      "one_of": [
+                        "kong_latency",
+                        "latency",
+                        "request_count",
+                        "request_size",
+                        "response_size",
+                        "upstream_latency"
+                      ],
+                      "required": true
+                    }
+                  },
+                  {
+                    "stat_type": {
+                      "type": "string",
+                      "description": "Determines what sort of event the metric represents",
+                      "one_of": [
+                        "counter",
+                        "gauge",
+                        "histogram",
+                        "meter",
+                        "set",
+                        "timer",
+                        "distribution"
+                      ],
+                      "required": true
+                    }
+                  },
+                  {
+                    "tags": {
+                      "description": "List of tags",
+                      "type": "array",
+                      "elements": {
+                        "type": "string",
+                        "match": "^.*[^:]$"
+                      }
+                    }
+                  },
+                  {
+                    "sample_rate": {
+                      "between": [
+                        0,
+                        1
+                      ],
+                      "description": "Sampling rate",
+                      "type": "number"
+                    }
+                  },
+                  {
+                    "consumer_identifier": {
+                      "description": "Authenticated user detail",
+                      "type": "string",
+                      "one_of": [
+                        "consumer_id",
+                        "custom_id",
+                        "username"
+                      ]
+                    }
+                  }
+                ],
+                "type": "record",
+                "entity_checks": [
+                  {
+                    "conditional": {
+                      "if_field": "stat_type",
+                      "then_field": "sample_rate",
+                      "if_match": {
+                        "one_of": [
+                          "counter",
+                          "gauge"
+                        ]
+                      },
+                      "then_match": {
+                        "required": true
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
         "required": true,
+        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -40,264 +336,11 @@
               ]
             }
           }
-        ],
-        "fields": [
-          {
-            "host": {
-              "type": "string",
-              "referenceable": true,
-              "default": "localhost"
-            }
-          },
-          {
-            "port": {
-              "between": [
-                0,
-                65535
-              ],
-              "type": "integer",
-              "default": 8125
-            }
-          },
-          {
-            "prefix": {
-              "default": "kong",
-              "type": "string"
-            }
-          },
-          {
-            "service_name_tag": {
-              "default": "name",
-              "type": "string"
-            }
-          },
-          {
-            "status_tag": {
-              "default": "status",
-              "type": "string"
-            }
-          },
-          {
-            "consumer_tag": {
-              "default": "consumer",
-              "type": "string"
-            }
-          },
-          {
-            "retry_count": {
-              "type": "integer"
-            }
-          },
-          {
-            "queue_size": {
-              "type": "integer"
-            }
-          },
-          {
-            "flush_timeout": {
-              "type": "number"
-            }
-          },
-          {
-            "queue": {
-              "required": true,
-              "fields": [
-                {
-                  "max_batch_size": {
-                    "between": [
-                      1,
-                      1000000
-                    ],
-                    "type": "number",
-                    "default": 1
-                  }
-                },
-                {
-                  "max_coalescing_delay": {
-                    "between": [
-                      0,
-                      3600
-                    ],
-                    "type": "number",
-                    "default": 1
-                  }
-                },
-                {
-                  "max_entries": {
-                    "between": [
-                      1,
-                      1000000
-                    ],
-                    "type": "number",
-                    "default": 10000
-                  }
-                },
-                {
-                  "max_bytes": {
-                    "type": "number"
-                  }
-                },
-                {
-                  "max_retry_time": {
-                    "default": 60,
-                    "type": "number"
-                  }
-                },
-                {
-                  "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number"
-                  }
-                },
-                {
-                  "max_retry_delay": {
-                    "default": 60,
-                    "type": "number"
-                  }
-                }
-              ],
-              "type": "record"
-            }
-          },
-          {
-            "metrics": {
-              "default": [
-                {
-                  "stat_type": "counter",
-                  "tags": [
-                    "app:kong"
-                  ],
-                  "consumer_identifier": "custom_id",
-                  "name": "request_count",
-                  "sample_rate": 1
-                },
-                {
-                  "stat_type": "timer",
-                  "consumer_identifier": "custom_id",
-                  "name": "latency",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "stat_type": "timer",
-                  "consumer_identifier": "custom_id",
-                  "name": "request_size",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "stat_type": "timer",
-                  "consumer_identifier": "custom_id",
-                  "name": "response_size",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "stat_type": "timer",
-                  "consumer_identifier": "custom_id",
-                  "name": "upstream_latency",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "stat_type": "timer",
-                  "consumer_identifier": "custom_id",
-                  "name": "kong_latency",
-                  "tags": [
-                    "app:kong"
-                  ]
-                }
-              ],
-              "elements": {
-                "entity_checks": [
-                  {
-                    "conditional": {
-                      "if_match": {
-                        "one_of": [
-                          "counter",
-                          "gauge"
-                        ]
-                      },
-                      "then_field": "sample_rate",
-                      "if_field": "stat_type",
-                      "then_match": {
-                        "required": true
-                      }
-                    }
-                  }
-                ],
-                "fields": [
-                  {
-                    "name": {
-                      "type": "string",
-                      "required": true,
-                      "one_of": [
-                        "kong_latency",
-                        "latency",
-                        "request_count",
-                        "request_size",
-                        "response_size",
-                        "upstream_latency"
-                      ]
-                    }
-                  },
-                  {
-                    "stat_type": {
-                      "type": "string",
-                      "required": true,
-                      "one_of": [
-                        "counter",
-                        "gauge",
-                        "histogram",
-                        "meter",
-                        "set",
-                        "timer",
-                        "distribution"
-                      ]
-                    }
-                  },
-                  {
-                    "tags": {
-                      "elements": {
-                        "match": "^.*[^:]$",
-                        "type": "string"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  {
-                    "sample_rate": {
-                      "between": [
-                        0,
-                        1
-                      ],
-                      "type": "number"
-                    }
-                  },
-                  {
-                    "consumer_identifier": {
-                      "one_of": [
-                        "consumer_id",
-                        "custom_id",
-                        "username"
-                      ],
-                      "type": "string"
-                    }
-                  }
-                ],
-                "type": "record"
-              },
-              "required": true,
-              "type": "array"
-            }
-          }
-        ],
-        "type": "record"
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/degraphql/3.4.x.json
+++ b/schemas/degraphql/3.4.x.json
@@ -2,53 +2,67 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "graphql_server_path": {
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "match_none": [
                 {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
+                  "pattern": "//",
+                  "err": "must not have empty segments"
                 }
               ],
-              "starts_with": "/",
-              "required": true,
               "default": "/graphql",
-              "type": "string"
+              "starts_with": "/",
+              "type": "string",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/exit-transformer/3.4.x.json
+++ b/schemas/exit-transformer/3.4.x.json
@@ -2,28 +2,36 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "functions": {
@@ -37,18 +45,24 @@
           {
             "handle_unknown": {
               "default": false,
+              "description": "Determines whether to handle unknown status codes by transforming their responses.",
               "type": "boolean"
             }
           },
           {
             "handle_unexpected": {
               "default": false,
+              "description": "Determines whether to handle unexpected errors by transforming their responses.",
               "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/file-log/3.4.x.json
+++ b/schemas/file-log/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,28 +25,34 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "path": {
-              "match": "^[^*&%%\\`]+$",
-              "required": true,
               "err": "not a valid filename",
-              "type": "string"
+              "required": true,
+              "description": "The file path of the output log file. The plugin creates the log file if it doesn't exist yet.",
+              "type": "string",
+              "match": "^[^*&%%\\`]+$"
             }
           },
           {
             "reopen": {
               "default": false,
+              "description": "Determines whether the log file is closed and reopened on every request.",
               "type": "boolean",
               "required": true
             }
@@ -49,19 +60,24 @@
           {
             "custom_fields_by_lua": {
               "type": "map",
-              "keys": {
+              "description": "Lua code as a key-value map",
+              "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "values": {
+              "keys": {
                 "type": "string",
                 "len_min": 1
               }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/forward-proxy/3.4.x.json
+++ b/schemas/forward-proxy/3.4.x.json
@@ -2,23 +2,32 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -35,6 +44,7 @@
             }
           }
         ],
+        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -61,22 +71,25 @@
             ]
           }
         ],
+        "type": "record",
         "fields": [
           {
             "x_headers": {
+              "required": true,
+              "default": "append",
+              "description": "Determines how to handle headers when forwarding the request.",
               "type": "string",
               "one_of": [
                 "append",
                 "transparent",
                 "delete"
-              ],
-              "required": true,
-              "default": "append"
+              ]
             }
           },
           {
             "http_proxy_host": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -85,12 +98,14 @@
                 0,
                 65535
               ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer"
             }
           },
           {
             "https_proxy_host": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -99,44 +114,50 @@
                 0,
                 65535
               ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer"
             }
           },
           {
             "proxy_scheme": {
+              "required": true,
+              "default": "http",
+              "description": "The proxy scheme to use when connecting. Only `http` is supported.",
               "type": "string",
               "one_of": [
                 "http"
-              ],
-              "required": true,
-              "default": "http"
+              ]
             }
           },
           {
             "auth_username": {
-              "type": "string",
               "referenceable": true,
+              "description": "The username to authenticate with, if the forward proxy is protected\nby basic authentication.",
+              "type": "string",
               "required": false
             }
           },
           {
             "auth_password": {
-              "type": "string",
               "referenceable": true,
+              "description": "The password to authenticate with, if the forward proxy is protected\nby basic authentication.",
+              "type": "string",
               "required": false
             }
           },
           {
             "https_verify": {
-              "type": "boolean",
               "default": false,
+              "description": "Whether the server certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate.",
+              "type": "boolean",
               "required": true
             }
           }
-        ],
-        "required": true,
-        "type": "record"
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/graphql-proxy-cache-advanced/3.4.x.json
+++ b/schemas/graphql-proxy-cache-advanced/3.4.x.json
@@ -2,72 +2,88 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "strategy": {
               "required": true,
+              "default": "memory",
+              "description": "The backing data store in which to hold cached entities. Accepted value is `memory`.",
+              "type": "string",
               "one_of": [
                 "memory"
-              ],
-              "type": "string",
-              "default": "memory"
+              ]
             }
           },
           {
             "cache_ttl": {
               "default": 300,
               "gt": 0,
-              "type": "integer"
+              "type": "integer",
+              "description": "TTL in seconds of cache entities. Must be a value greater than 0."
             }
           },
           {
             "memory": {
-              "required": true,
               "fields": [
                 {
                   "dictionary_name": {
                     "default": "kong_db_cache",
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. This dictionary currently must be defined manually in the Kong Nginx template.",
                     "type": "string",
                     "required": true
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "vary_headers": {
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/graphql-rate-limiting-advanced/3.4.x.json
+++ b/schemas/graphql-rate-limiting-advanced/3.4.x.json
@@ -2,45 +2,55 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "identifier": {
               "required": true,
+              "default": "consumer",
+              "description": "How to define the rate limit key. Can be `ip`, `credential`, `consumer`.",
+              "type": "string",
               "one_of": [
                 "ip",
                 "credential",
                 "consumer"
-              ],
-              "type": "string",
-              "default": "consumer"
+              ]
             }
           },
           {
             "window_size": {
-              "type": "array",
               "required": true,
+              "description": "One or more window sizes to apply a limit to (defined in seconds).",
+              "type": "array",
               "elements": {
                 "type": "number"
               }
@@ -48,8 +58,9 @@
           },
           {
             "window_type": {
-              "type": "string",
               "default": "sliding",
+              "description": "Sets the time window to either `sliding` or `fixed`.",
+              "type": "string",
               "one_of": [
                 "fixed",
                 "sliding"
@@ -58,8 +69,9 @@
           },
           {
             "limit": {
-              "type": "array",
               "required": true,
+              "description": "One or more requests-per-window limits to apply.",
+              "type": "array",
               "elements": {
                 "type": "number"
               }
@@ -67,44 +79,50 @@
           },
           {
             "sync_rate": {
-              "required": true,
-              "type": "number"
+              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 syncs the counters in that many number of seconds.",
+              "type": "number",
+              "required": true
             }
           },
           {
             "namespace": {
               "auto": true,
-              "type": "string"
+              "type": "string",
+              "description": "The rate limiting library namespace to use for this plugin instance."
             }
           },
           {
             "strategy": {
               "required": true,
+              "default": "cluster",
+              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits.",
+              "type": "string",
               "one_of": [
                 "cluster",
                 "redis"
-              ],
-              "type": "string",
-              "default": "cluster"
+              ]
             }
           },
           {
             "dictionary_name": {
-              "required": true,
+              "default": "kong_rate_limiting_counters",
+              "description": "The shared dictionary where counters will be stored until the next sync cycle.",
               "type": "string",
-              "default": "kong_rate_limiting_counters"
+              "required": true
             }
           },
           {
             "hide_client_headers": {
               "default": false,
+              "description": "Optionally hide informative response headers. Available options: `true` or `false`.",
               "type": "boolean"
             }
           },
           {
             "cost_strategy": {
-              "type": "string",
               "default": "default",
+              "description": "Strategy to use to evaluate query costs. Either `default` or `node_quantifier`.",
+              "type": "string",
               "one_of": [
                 "default",
                 "node_quantifier"
@@ -113,22 +131,189 @@
           },
           {
             "score_factor": {
-              "required": false,
-              "type": "number",
               "gt": 0,
-              "default": 1
+              "required": false,
+              "default": 1,
+              "description": "A scoring factor to multiply (or divide) the cost. The `score_factor` must always be greater than 0.",
+              "type": "number"
             }
           },
           {
             "max_cost": {
-              "required": false,
+              "default": 0,
+              "description": "A defined maximum cost per query. 0 means unlimited.",
               "type": "number",
-              "default": 0
+              "required": false
             }
           },
           {
             "redis": {
+              "fields": [
+                {
+                  "host": {
+                    "type": "string",
+                    "description": "A string representing a host name, such as example.com."
+                  }
+                },
+                {
+                  "port": {
+                    "between": [
+                      0,
+                      65535
+                    ],
+                    "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "timeout": {
+                    "default": 2000,
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer",
+                    "between": [
+                      0,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "connect_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "send_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "read_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "username": {
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "password": {
+                    "encrypted": true,
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "sentinel_username": {
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "sentinel_password": {
+                    "encrypted": true,
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "database": {
+                    "type": "integer",
+                    "default": 0
+                  }
+                },
+                {
+                  "keepalive_pool_size": {
+                    "default": 30,
+                    "type": "integer",
+                    "between": [
+                      1,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "keepalive_backlog": {
+                    "type": "integer",
+                    "between": [
+                      0,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "sentinel_master": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "sentinel_role": {
+                    "type": "string",
+                    "one_of": [
+                      "master",
+                      "slave",
+                      "any"
+                    ]
+                  }
+                },
+                {
+                  "sentinel_addresses": {
+                    "len_min": 1,
+                    "type": "array",
+                    "elements": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "cluster_addresses": {
+                    "len_min": 1,
+                    "type": "array",
+                    "elements": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "ssl": {
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "ssl_verify": {
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "server_name": {
+                    "description": "A string representing an SNI (server name indication) value for TLS.",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              ],
               "required": true,
+              "type": "record",
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -186,169 +371,33 @@
                     "read_timeout"
                   ]
                 }
-              ],
-              "fields": [
-                {
-                  "host": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "port": {
-                    "between": [
-                      0,
-                      65535
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer",
-                    "default": 2000
-                  }
-                },
-                {
-                  "connect_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "send_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "read_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "username": {
-                    "type": "string",
-                    "referenceable": true
-                  }
-                },
-                {
-                  "password": {
-                    "referenceable": true,
-                    "encrypted": true,
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_username": {
-                    "type": "string",
-                    "referenceable": true
-                  }
-                },
-                {
-                  "sentinel_password": {
-                    "referenceable": true,
-                    "encrypted": true,
-                    "type": "string"
-                  }
-                },
-                {
-                  "database": {
-                    "type": "integer",
-                    "default": 0
-                  }
-                },
-                {
-                  "keepalive_pool_size": {
-                    "between": [
-                      1,
-                      2147483646
-                    ],
-                    "default": 30,
-                    "type": "integer"
-                  }
-                },
-                {
-                  "keepalive_backlog": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "sentinel_master": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_role": {
-                    "one_of": [
-                      "master",
-                      "slave",
-                      "any"
-                    ],
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_addresses": {
-                    "len_min": 1,
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                },
-                {
-                  "cluster_addresses": {
-                    "len_min": 1,
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                },
-                {
-                  "ssl": {
-                    "default": false,
-                    "required": false,
-                    "type": "boolean"
-                  }
-                },
-                {
-                  "ssl_verify": {
-                    "default": false,
-                    "required": false,
-                    "type": "boolean"
-                  }
-                },
-                {
-                  "server_name": {
-                    "type": "string",
-                    "required": false
-                  }
-                }
-              ],
-              "type": "record"
+              ]
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config"
+        ]
+      }
+    },
+    {
+      "conditional_at_least_one_of": {
+        "then_at_least_one_of": [
+          "config.redis.host",
+          "config.redis.sentinel_master"
+        ],
+        "if_match": {
+          "eq": "redis"
+        },
+        "if_field": "config.strategy"
       }
     }
   ]

--- a/schemas/grpc-gateway/3.4.x.json
+++ b/schemas/grpc-gateway/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,26 +25,35 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "proto": {
+              "description": "Describes the gRPC types and methods.",
               "type": "string",
               "required": false
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/grpc-web/3.4.x.json
+++ b/schemas/grpc-web/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,39 +25,50 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "proto": {
-              "required": false,
-              "type": "string"
+              "description": "If present, describes the gRPC types and methods. Required to support payload transcoding. When absent, the web client must use application/grpw-web+proto content.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "pass_stripped_path": {
+              "description": "If set to `true` causes the plugin to pass the stripped request path to the upstream gRPC service.",
               "type": "boolean",
               "required": false
             }
           },
           {
             "allow_origin_header": {
-              "type": "string",
               "default": "*",
+              "description": "The value of the `Access-Control-Allow-Origin` header in the response to the gRPC-Web client.",
+              "type": "string",
               "required": false
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/hmac-auth/3.4.x.json
+++ b/schemas/hmac-auth/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -17,7 +18,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,76 +29,96 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "hide_credentials": {
-              "required": true,
+              "default": false,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           },
           {
             "clock_skew": {
-              "type": "number",
+              "default": 300,
               "gt": 0,
-              "default": 300
+              "type": "number",
+              "description": "Clock skew in seconds to prevent replay attacks."
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
             }
           },
           {
             "validate_request_body": {
-              "required": true,
+              "default": false,
+              "description": "A boolean value telling the plugin to enable body validation.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           },
           {
             "enforce_headers": {
+              "default": [
+
+              ],
+              "description": "A list of headers that the client should at least use for HTTP signature creation.",
               "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "default": [
-
-              ]
+              }
             }
           },
           {
             "algorithms": {
-              "type": "array",
-              "elements": {
-                "one_of": [
-                  "hmac-sha1",
-                  "hmac-sha256",
-                  "hmac-sha384",
-                  "hmac-sha512"
-                ],
-                "type": "string"
-              },
               "default": [
                 "hmac-sha1",
                 "hmac-sha256",
                 "hmac-sha384",
                 "hmac-sha512"
-              ]
+              ],
+              "description": "A list of HMAC digest algorithms that the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "hmac-sha1",
+                  "hmac-sha256",
+                  "hmac-sha384",
+                  "hmac-sha512"
+                ]
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config.algorithms"
+        ]
       }
     }
   ]

--- a/schemas/http-log/3.4.x.json
+++ b/schemas/http-log/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,16 +25,20 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -44,16 +53,18 @@
         "fields": [
           {
             "http_endpoint": {
-              "type": "string",
               "required": true,
               "encrypted": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
               "referenceable": true
             }
           },
           {
             "method": {
-              "type": "string",
               "default": "POST",
+              "description": "An optional method used to send data to the HTTP server. Supported values are `POST` (default), `PUT`, and `PATCH`.",
+              "type": "string",
               "one_of": [
                 "POST",
                 "PUT",
@@ -63,8 +74,9 @@
           },
           {
             "content_type": {
-              "type": "string",
               "default": "application/json",
+              "description": "Indicates the type of data sent. The only available option is `application/json`.",
+              "type": "string",
               "one_of": [
                 "application/json",
                 "application/json; charset=utf-8"
@@ -74,133 +86,160 @@
           {
             "timeout": {
               "default": 10000,
+              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
               "type": "number"
             }
           },
           {
             "keepalive": {
               "default": 60000,
+              "description": "An optional value in milliseconds that defines how long an idle connection will live before being closed.",
               "type": "number"
             }
           },
           {
             "retry_count": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of times to retry when sending data to the upstream server."
             }
           },
           {
             "queue_size": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of log entries to be sent on each message to the upstream server."
             }
           },
           {
             "flush_timeout": {
-              "type": "number"
+              "type": "number",
+              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records."
             }
           },
           {
             "headers": {
               "type": "map",
+              "description": "An optional table of headers included in the HTTP message to the upstream server. Values are indexed by header name, and each header name accepts a single string.",
+              "values": {
+                "type": "string",
+                "referenceable": true
+              },
               "keys": {
+                "description": "A string representing an HTTP header name.",
+                "type": "string",
                 "match_none": [
                   {
-                    "err": "cannot contain 'Host' header",
-                    "pattern": "^[Hh][Oo][Ss][Tt]$"
+                    "pattern": "^[Hh][Oo][Ss][Tt]$",
+                    "err": "cannot contain 'Host' header"
                   },
                   {
-                    "err": "cannot contain 'Content-Length' header",
-                    "pattern": "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Ll][Ee][nn][Gg][Tt][Hh]$"
+                    "pattern": "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Ll][Ee][nn][Gg][Tt][Hh]$",
+                    "err": "cannot contain 'Content-Length' header"
                   },
                   {
-                    "err": "cannot contain 'Content-Type' header",
-                    "pattern": "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Tt][Yy][Pp][Ee]$"
+                    "pattern": "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Tt][Yy][Pp][Ee]$",
+                    "err": "cannot contain 'Content-Type' header"
                   }
-                ],
-                "type": "string"
-              },
-              "values": {
-                "referenceable": true,
-                "type": "string"
+                ]
               }
             }
           },
           {
             "queue": {
-              "required": true,
               "fields": [
                 {
                   "max_batch_size": {
+                    "default": 1,
+                    "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_coalescing_delay": {
+                    "default": 1,
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
                     "between": [
                       0,
                       3600
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_entries": {
+                    "default": 10000,
+                    "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 10000
+                    ]
                   }
                 },
                 {
                   "max_bytes": {
-                    "type": "number"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
                   "max_retry_time": {
                     "default": 60,
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
                     "type": "number"
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "type": "number"
+                    "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "type": "number"
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "custom_fields_by_lua": {
               "type": "map",
-              "keys": {
+              "description": "Lua code as a key-value map",
+              "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "values": {
+              "keys": {
                 "type": "string",
                 "len_min": 1
               }
             }
           }
         ],
+        "type": "record",
         "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/ip-restriction/3.4.x.json
+++ b/schemas/ip-restriction/3.4.x.json
@@ -2,60 +2,92 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
-          "grpc",
-          "grpcs",
           "http",
-          "https"
+          "https",
+          "tcp",
+          "tls",
+          "grpc",
+          "grpcs"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
-            "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+            "https",
+            "tcp",
+            "tls",
+            "tls_passthrough",
+            "udp",
+            "ws",
+            "wss"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "allow": {
+              "description": "List of IPs or CIDR ranges to allow. One of `config.allow` or `config.deny` must be specified.",
+              "type": "array",
               "elements": {
-                "type": "string"
-              },
-              "type": "array"
+                "type": "string",
+                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16."
+              }
             }
           },
           {
             "deny": {
+              "description": "List of IPs or CIDR ranges to deny. One of `config.allow` or `config.deny` must be specified.",
+              "type": "array",
               "elements": {
-                "type": "string"
-              },
-              "type": "array"
+                "type": "string",
+                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16."
+              }
             }
           },
           {
             "status": {
+              "description": "The HTTP status of the requests that will be rejected by the plugin.",
               "type": "number",
               "required": false
             }
           },
           {
             "message": {
+              "description": "The message to send as a response body to rejected requests.",
               "type": "string",
               "required": false
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.allow",
+        "config.deny"
+      ]
     }
   ]
 }

--- a/schemas/jq/3.4.x.json
+++ b/schemas/jq/3.4.x.json
@@ -2,41 +2,33 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "at_least_one_of": [
-              "request_jq_program",
-              "response_jq_program"
-            ]
-          }
-        ],
         "fields": [
           {
             "request_jq_program": {
-              "required": false,
-              "type": "string"
+              "type": "string",
+              "required": false
             }
           },
           {
@@ -45,62 +37,62 @@
 
               ],
               "required": false,
+              "type": "record",
               "fields": [
                 {
                   "compact_output": {
-                    "required": true,
+                    "default": true,
                     "type": "boolean",
-                    "default": true
+                    "required": true
                   }
                 },
                 {
                   "raw_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "join_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "ascii_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "sort_keys": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 }
-              ],
-              "type": "record"
+              ]
             }
           },
           {
             "request_if_media_type": {
-              "elements": {
-                "type": "string"
-              },
               "default": [
                 "application/json"
               ],
               "required": false,
-              "type": "array"
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "response_jq_program": {
-              "required": false,
-              "type": "string"
+              "type": "string",
+              "required": false
             }
           },
           {
@@ -109,77 +101,89 @@
 
               ],
               "required": false,
+              "type": "record",
               "fields": [
                 {
                   "compact_output": {
-                    "required": true,
+                    "default": true,
                     "type": "boolean",
-                    "default": true
+                    "required": true
                   }
                 },
                 {
                   "raw_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "join_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "ascii_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "sort_keys": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 }
-              ],
-              "type": "record"
+              ]
             }
           },
           {
             "response_if_media_type": {
-              "elements": {
-                "type": "string"
-              },
               "default": [
                 "application/json"
               ],
               "required": false,
-              "type": "array"
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "response_if_status_code": {
-              "elements": {
-                "between": [
-                  100,
-                  599
-                ],
-                "type": "integer"
-              },
               "default": [
                 200
               ],
               "required": false,
-              "type": "array"
+              "type": "array",
+              "elements": {
+                "type": "integer",
+                "between": [
+                  100,
+                  599
+                ]
+              }
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "at_least_one_of": [
+              "request_jq_program",
+              "response_jq_program"
+            ]
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/jwe-decrypt/3.4.x.json
+++ b/schemas/jwe-decrypt/3.4.x.json
@@ -2,53 +2,65 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "lookup_header_name": {
-              "required": true,
               "default": "Authorization",
-              "type": "string"
+              "description": "The name of the header to look for the JWE token.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "forward_header_name": {
-              "required": true,
               "default": "Authorization",
-              "type": "string"
+              "description": "The name of the header that is used to set the decrypted value.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "key_sets": {
               "required": true,
+              "description": "Denote the name or names of all Key Sets that should be inspected when trying to find a suitable key to decrypt the JWE token.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -57,13 +69,18 @@
           },
           {
             "strict": {
-              "type": "boolean",
-              "default": true
+              "default": true,
+              "description": "Defines how the plugin behaves in cases where no token was found in the request. When using `strict` mode, the request requires a token to be present and subsequently raise an error if none could be found.",
+              "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/jwt-signer/3.4.x.json
+++ b/schemas/jwt-signer/3.4.x.json
@@ -2,38 +2,50 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
         "required": true,
+        "type": "record",
         "fields": [
           {
             "realm": {
+              "description": "When authentication or authorization fails, or there is an unexpected error, the plugin sends an `WWW-Authenticate` header with the `realm` attribute value.",
               "type": "string",
               "required": false
             }
@@ -41,33 +53,38 @@
           {
             "enable_hs_signatures": {
               "default": false,
-              "required": false,
-              "type": "boolean"
+              "description": "Tokens signed with HMAC algorithms such as `HS256`, `HS384`, or `HS512` are not accepted by default. If you need to accept such tokens for verification, enable this setting.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "enable_instrumentation": {
               "default": false,
-              "required": false,
-              "type": "boolean"
+              "description": "Writes log entries with some added information using `ngx.CRIT` (CRITICAL) level.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "access_token_issuer": {
               "default": "kong",
-              "required": false,
-              "type": "string"
+              "description": "The `iss` claim of a signed or re-signed access token is set to this value. Original `iss` claim of the incoming token (possibly introspected) is stored in `original_iss` claim of the newly signed access token.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_keyset": {
               "default": "kong",
-              "required": false,
-              "type": "string"
+              "description": "The name of the keyset containing signing keys.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_jwks_uri": {
+              "description": "Specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the access token.",
               "type": "string",
               "required": false
             }
@@ -75,20 +92,23 @@
           {
             "access_token_request_header": {
               "default": "Authorization",
-              "required": false,
-              "type": "string"
+              "description": "This parameter tells the name of the header where to look for the access token.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_leeway": {
               "default": 0,
-              "required": false,
-              "type": "number"
+              "description": "Adjusts clock skew between the token issuer and Kong. The value is added to the token's `exp` claim before checking token expiry against Kong servers' current time in seconds. You can disable access token `expiry` verification altogether with `config.verify_access_token_expiry`.",
+              "type": "number",
+              "required": false
             }
           },
           {
             "access_token_scopes_required": {
               "required": false,
+              "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.access_token_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -97,19 +117,21 @@
           },
           {
             "access_token_scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
+              "required": false,
               "default": [
                 "scope"
               ],
+              "description": "Specify the claim in an access token to verify against values of `config.access_token_scopes_required`.",
               "type": "array",
-              "required": false
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "access_token_consumer_claim": {
               "required": false,
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (for example, `sub` or `username`) in an access token to Kong consumer entity.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -118,50 +140,56 @@
           },
           {
             "access_token_consumer_by": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
+              "required": false,
               "default": [
                 "username",
                 "custom_id"
               ],
+              "description": "When the plugin tries to apply an access token to a Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of alues. Valid values are `id`, `username`, and `custom_id`.",
               "type": "array",
-              "required": false
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "username",
+                  "custom_id"
+                ]
+              }
             }
           },
           {
             "access_token_upstream_header": {
               "default": "Authorization:Bearer",
-              "required": false,
-              "type": "string"
+              "description": "Removes the `config.access_token_request_header` from the request after reading its value. With `config.access_token_upstream_header`, you can specify the upstream header where the plugin adds the Kong signed token. If you don't specify a value, such as use `null` or `\"\"` (empty string), the plugin does not even try to sign or re-sign the token.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_upstream_leeway": {
               "default": 0,
-              "required": false,
-              "type": "number"
+              "description": "If you want to add or subtract (using a negative value) expiry time (in seconds) of the original access token, you can specify a value that is added to the original access token's `exp` claim.",
+              "type": "number",
+              "required": false
             }
           },
           {
             "access_token_introspection_endpoint": {
+              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter.",
               "type": "string",
               "required": false
             }
           },
           {
             "access_token_introspection_authorization": {
+              "description": "If the introspection endpoint requires client authentication (client being the JWT Signer plugin), you can specify the `Authorization` header's value with this configuration parameter.",
               "type": "string",
               "required": false
             }
           },
           {
             "access_token_introspection_body_args": {
+              "description": "This parameter allows you to pass URL encoded request body arguments. For example: `resource=` or `a=1&b=&c`.",
               "type": "string",
               "required": false
             }
@@ -169,13 +197,15 @@
           {
             "access_token_introspection_hint": {
               "default": "access_token",
-              "required": false,
-              "type": "string"
+              "description": "If you need to give `hint` parameter when introspecting an access token, use this parameter to specify the value. By default, the plugin sends `hint=access_token`.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_introspection_jwt_claim": {
               "required": false,
+              "description": "If your introspection endpoint returns an access token in one of the keys (or claims) within the introspection results (`JSON`). If the key cannot be found, the plugin responds with `401 Unauthorized`. Also if the key is found but cannot be decoded as JWT, it also responds with `401 Unauthorized`.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -185,6 +215,7 @@
           {
             "access_token_introspection_scopes_required": {
               "required": false,
+              "description": "Specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.access_token_introspection_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -193,19 +224,21 @@
           },
           {
             "access_token_introspection_scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
+              "required": true,
               "default": [
                 "scope"
               ],
+              "description": "Specify the claim/property in access token introspection results (`JSON`) to be verified against values of `config.access_token_introspection_scopes_required`. This supports nested claims. For example, with Keycloak you could use `[ \"realm_access\", \"roles\" ]`, hich can be given as `realm_access,roles` (form post). If the claim is not found in access token introspection results, and you have specified `config.access_token_introspection_scopes_required`, the plugin responds with `403 Forbidden`.",
               "type": "array",
-              "required": true
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "access_token_introspection_consumer_claim": {
               "required": false,
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in access token introspection results to the Kong consumer entity.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -214,37 +247,43 @@
           },
           {
             "access_token_introspection_consumer_by": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
+              "required": false,
               "default": [
                 "username",
                 "custom_id"
               ],
+              "description": "When the plugin tries to do access token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values.",
               "type": "array",
-              "required": false
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "username",
+                  "custom_id"
+                ]
+              }
             }
           },
           {
             "access_token_introspection_leeway": {
               "default": 0,
-              "required": false,
-              "type": "number"
+              "description": "Adjusts clock skew between the token issuer introspection results and Kong. The value is added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time in seconds. You can disable access token introspection `expiry` verification altogether with `config.verify_access_token_introspection_expiry`.",
+              "type": "number",
+              "required": false
             }
           },
           {
             "access_token_introspection_timeout": {
+              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on access token introspection.",
               "type": "number",
               "required": false
             }
           },
           {
             "access_token_signing_algorithm": {
+              "required": true,
+              "default": "RS256",
+              "description": "When this plugin sets the upstream header as specified with `config.access_token_upstream_header`, re-signs the original access token using the private keys of the JWT Signer plugin. Specify the algorithm that is used to sign the token. The `config.access_token_issuer` specifies which `keyset` is used to sign the new token issued by Kong using the specified signing algorithm.",
               "type": "string",
               "one_of": [
                 "HS256",
@@ -259,96 +298,107 @@
                 "PS384",
                 "PS512",
                 "EdDSA"
-              ],
-              "default": "RS256",
-              "required": true
+              ]
             }
           },
           {
             "access_token_optional": {
               "default": false,
-              "required": false,
-              "type": "boolean"
+              "description": "If an access token is not provided or no `config.access_token_request_header` is specified, the plugin cannot verify the access token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Use this parameter to allow the request to proceed even when there is no token to check. If the token is provided, then this parameter has no effect",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_signature": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn access token signature verification off and on as needed.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_expiry": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn access token expiry verification off and on as needed.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_scopes": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn off and on the access token required scopes verification, specified with `config.access_token_scopes_required`.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_introspection_expiry": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn access token introspection expiry verification off and on as needed.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_introspection_scopes": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn off and on the access token introspection scopes verification, specified with `config.access_token_introspection_scopes_required`.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "cache_access_token_introspection": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Whether to cache access token introspection results.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "trust_access_token_introspection": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Use this parameter to enable and disable further checks on a payload before the new token is signed. If you set this to `true`, the expiry or scopes are not checked on a payload.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "enable_access_token_introspection": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "If you don't want to support opaque access tokens, change this configuration parameter to `false` to disable introspection.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "channel_token_issuer": {
               "default": "kong",
-              "required": false,
-              "type": "string"
+              "description": "The `iss` claim of the re-signed channel token is set to this value, which is `kong` by default. The original `iss` claim of the incoming token (possibly introspected) is stored in the `original_iss` claim of the newly signed channel token.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_keyset": {
               "default": "kong",
-              "required": false,
-              "type": "string"
+              "description": "The name of the keyset containing signing keys.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_jwks_uri": {
+              "description": "If you want to use `config.verify_channel_token_signature`, you must specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the channel token. If you don't specify a URI and you pass a JWT token to the plugin, then the plugin responds with `401 Unauthorized`.",
               "type": "string",
               "required": false
             }
           },
           {
             "channel_token_request_header": {
+              "description": "This parameter tells the name of the header where to look for the channel token. If you don't want to do anything with the channel token, then you can set this to `null` or `\"\"` (empty string).",
               "type": "string",
               "required": false
             }
@@ -356,13 +406,15 @@
           {
             "channel_token_leeway": {
               "default": 0,
-              "required": false,
-              "type": "number"
+              "description": "Adjusts clock skew between the token issuer and Kong. The value will be added to token's `exp` claim before checking token expiry against Kong servers current time in seconds. You can disable channel token `expiry` verification altogether with `config.verify_channel_token_expiry`.",
+              "type": "number",
+              "required": false
             }
           },
           {
             "channel_token_scopes_required": {
               "required": false,
+              "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.channel_token_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -371,19 +423,21 @@
           },
           {
             "channel_token_scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
+              "required": false,
               "default": [
                 "scope"
               ],
+              "description": "Specify the claim in a channel token to verify against values of `config.channel_token_scopes_required`. This supports nested claims.",
               "type": "array",
-              "required": false
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "channel_token_consumer_claim": {
               "required": false,
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter. Kong consumers have an `id`, a `username`, and a `custom_id`. If this parameter is enabled but the mapping fails, such as when there's a non-existent Kong consumer, the plugin responds with `403 Forbidden`.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -392,23 +446,25 @@
           },
           {
             "channel_token_consumer_by": {
+              "default": [
+                "username",
+                "custom_id"
+              ],
+              "description": "When the plugin tries to do channel token to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of valid values: `id`, `username`, and `custom_id`.",
               "type": "array",
               "elements": {
+                "type": "string",
                 "one_of": [
                   "id",
                   "username",
                   "custom_id"
-                ],
-                "type": "string"
-              },
-              "default": [
-                "username",
-                "custom_id"
-              ]
+                ]
+              }
             }
           },
           {
             "channel_token_upstream_header": {
+              "description": "This plugin removes the `config.channel_token_request_header` from the request after reading its value.",
               "type": "string",
               "required": false
             }
@@ -416,12 +472,14 @@
           {
             "channel_token_upstream_leeway": {
               "default": 0,
-              "required": false,
-              "type": "number"
+              "description": "If you want to add or perhaps subtract (using negative value) expiry time of the original channel token, you can specify a value that is added to the original channel token's `exp` claim.",
+              "type": "number",
+              "required": false
             }
           },
           {
             "channel_token_introspection_endpoint": {
+              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise, the plugin does not try introspection and returns `401 Unauthorized` instead.",
               "type": "string",
               "required": false
             }
@@ -429,6 +487,7 @@
           {
             "channel_token_introspection_authorization": {
               "required": false,
+              "description": "When using `opaque` channel tokens, and you want to turn on channel token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise the plugin will not try introspection, and instead returns `401 Unauthorized` when using opaque channel tokens.",
               "type": "string",
               "elements": {
                 "type": "string"
@@ -438,6 +497,7 @@
           {
             "channel_token_introspection_body_args": {
               "required": false,
+              "description": "If you need to pass additional body arguments to introspection endpoint when the plugin introspects the opaque channel token, you can use this config parameter to specify them. You should URL encode the value. For example: `resource=` or `a=1&b=&c`.",
               "type": "string",
               "elements": {
                 "type": "string"
@@ -447,6 +507,7 @@
           {
             "channel_token_introspection_hint": {
               "required": false,
+              "description": "If you need to give `hint` parameter when introspecting a channel token, you can use this parameter to specify the value of such parameter. By default, a `hint` isn't sent with channel token introspection.",
               "type": "string",
               "elements": {
                 "type": "string"
@@ -456,6 +517,7 @@
           {
             "channel_token_introspection_jwt_claim": {
               "required": false,
+              "description": "If your introspection endpoint returns a channel token in one of the keys (or claims) in the introspection results (`JSON`), the plugin can use that value instead of the introspection results when doing expiry verification and signing of the new token issued by Kong.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -465,6 +527,7 @@
           {
             "channel_token_introspection_scopes_required": {
               "required": false,
+              "description": "Use this parameter to specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.channel_token_introspection_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -473,19 +536,21 @@
           },
           {
             "channel_token_introspection_scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
+              "required": false,
               "default": [
                 "scope"
               ],
+              "description": "Use this parameter to specify the claim/property in channel token introspection results (`JSON`) to be verified against values of `config.channel_token_introspection_scopes_required`. This supports nested claims.",
               "type": "array",
-              "required": false
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "channel_token_introspection_consumer_claim": {
               "required": false,
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in channel token introspection results to Kong consumer entity",
               "type": "array",
               "elements": {
                 "type": "string"
@@ -494,37 +559,43 @@
           },
           {
             "channel_token_introspection_consumer_by": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
+              "required": false,
               "default": [
                 "username",
                 "custom_id"
               ],
+              "description": "When the plugin tries to do channel token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values. Valid values are `id`, `username` and `custom_id`.",
               "type": "array",
-              "required": false
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "username",
+                  "custom_id"
+                ]
+              }
             }
           },
           {
             "channel_token_introspection_leeway": {
               "default": 0,
-              "required": false,
-              "type": "number"
+              "description": "You can use this parameter to adjust clock skew between the token issuer introspection results and Kong. The value will be added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time (in seconds). You can disable channel token introspection `expiry` verification altogether with `config.verify_channel_token_introspection_expiry`.",
+              "type": "number",
+              "required": false
             }
           },
           {
             "channel_token_introspection_timeout": {
+              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on channel token introspection.",
               "type": "number",
               "required": false
             }
           },
           {
             "channel_token_signing_algorithm": {
+              "required": true,
+              "default": "RS256",
+              "description": "When this plugin sets the upstream header as specified with `config.channel_token_upstream_header`, it also re-signs the original channel token using private keys of this plugin. Specify the algorithm that is used to sign the token.",
               "type": "string",
               "one_of": [
                 "HS256",
@@ -539,72 +610,78 @@
                 "PS384",
                 "PS512",
                 "EdDSA"
-              ],
-              "default": "RS256",
-              "required": true
+              ]
             }
           },
           {
             "channel_token_optional": {
               "default": false,
-              "required": false,
-              "type": "boolean"
+              "description": "If a channel token is not provided or no `config.channel_token_request_header` is specified, the plugin cannot verify the channel token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Enable this parameter to allow the request to proceed even when there is no channel token to check. If the channel token is provided, then this parameter has no effect",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_signature": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn on/off the channel token signature verification.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_expiry": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_scopes": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn on/off the channel token required scopes verification specified with `config.channel_token_scopes_required`.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_introspection_expiry": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn on/off the channel token introspection expiry verification.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_introspection_scopes": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Quickly turn on/off the channel token introspection scopes verification specified with `config.channel_token_introspection_scopes_required`.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "cache_channel_token_introspection": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Whether to cache channel token introspection results.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "trust_channel_token_introspection": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "Providing an opaque channel token for plugin introspection, and verifying expiry and scopes on introspection results may make further payload checks unnecessary before the plugin signs a new token. This also applies when using a JWT token with introspection JSON as per config.channel_token_introspection_jwt_claim. Use this parameter to manage additional payload checks before signing a new token. With true (default), payload's expiry or scopes aren't checked.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "enable_channel_token_introspection": {
               "default": true,
-              "required": false,
-              "type": "boolean"
+              "description": "If you don't want to support opaque channel tokens, disable introspection by changing this configuration parameter to `false`.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
@@ -612,14 +689,15 @@
               "values": {
                 "type": "string"
               },
+              "required": false,
               "default": [
 
               ],
+              "description": "Add customized claims if they are not present yet.",
+              "type": "map",
               "keys": {
                 "type": "string"
-              },
-              "required": false,
-              "type": "map"
+              }
             }
           },
           {
@@ -627,19 +705,22 @@
               "values": {
                 "type": "string"
               },
+              "required": false,
               "default": [
 
               ],
+              "description": "Set customized claims. If a claim is already present, it will be overwritten.",
+              "type": "map",
               "keys": {
                 "type": "string"
-              },
-              "required": false,
-              "type": "map"
+              }
             }
           }
-        ],
-        "type": "record"
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/jwt/3.4.x.json
+++ b/schemas/jwt/3.4.x.json
@@ -2,118 +2,151 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "uri_param_names": {
+              "default": [
+                "jwt"
+              ],
+              "description": "A list of querystring parameters that Kong will inspect to retrieve JWTs.",
               "type": "set",
               "elements": {
                 "type": "string"
-              },
-              "default": [
-                "jwt"
-              ]
+              }
             }
           },
           {
             "cookie_names": {
+              "default": [
+
+              ],
+              "description": "A list of cookie names that Kong will inspect to retrieve JWTs.",
               "type": "set",
               "elements": {
                 "type": "string"
-              },
-              "default": [
-
-              ]
+              }
             }
           },
           {
             "key_claim_name": {
               "default": "iss",
+              "description": "The name of the claim in which the key identifying the secret must be passed. The plugin will attempt to read this claim from the JWT payload and the header, in that order.",
               "type": "string"
             }
           },
           {
             "secret_is_base64": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "If true, the plugin assumes the credential’s secret to be base64 encoded. You will need to create a base64-encoded secret for your Consumer, and sign your JWT with the original secret.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "claims_to_verify": {
+              "description": "A list of registered claims (according to RFC 7519) that Kong can verify as well. Accepted values: one of exp or nbf.",
+              "type": "set",
               "elements": {
+                "type": "string",
                 "one_of": [
                   "exp",
                   "nbf"
-                ],
-                "type": "string"
-              },
-              "type": "set"
+                ]
+              }
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
             }
           },
           {
             "run_on_preflight": {
               "default": true,
-              "required": true,
-              "type": "boolean"
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "maximum_expiration": {
+              "default": 0,
+              "description": "A value between 0 and 31536000 (365 days) limiting the lifetime of the JWT to maximum_expiration seconds in the future.",
+              "type": "number",
               "between": [
                 0,
                 31536000
-              ],
-              "type": "number",
-              "default": 0
+              ]
             }
           },
           {
             "header_names": {
+              "default": [
+                "authorization"
+              ],
+              "description": "A list of HTTP header names that Kong will inspect to retrieve JWTs.",
               "type": "set",
               "elements": {
                 "type": "string"
-              },
-              "default": [
-                "authorization"
-              ]
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "conditional": {
+        "if_field": "config.maximum_expiration",
+        "then_field": "config.claims_to_verify",
+        "if_match": {
+          "gt": 0
+        },
+        "then_match": {
+          "contains": "exp"
+        }
       }
     }
   ]

--- a/schemas/kafka-log/3.4.x.json
+++ b/schemas/kafka-log/3.4.x.json
@@ -10,7 +10,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -18,32 +21,31 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "custom_entity_check": {
-              "field_sources": [
-                "authentication"
-              ]
-            }
-          }
-        ],
         "fields": [
           {
             "bootstrap_servers": {
+              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format.",
+              "type": "set",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "host": {
+                      "description": "A string representing a host name, such as example.com.",
                       "type": "string",
                       "required": true
                     }
@@ -54,121 +56,131 @@
                         0,
                         65535
                       ],
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
                       "type": "integer",
                       "required": true
                     }
                   }
-                ],
-                "type": "record"
-              },
-              "type": "set"
+                ]
+              }
             }
           },
           {
             "topic": {
-              "required": true,
-              "type": "string"
+              "description": "The Kafka topic to publish to.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "timeout": {
               "default": 10000,
+              "description": "Socket timeout in milliseconds.",
               "type": "integer"
             }
           },
           {
             "keepalive": {
-              "default": 60000,
-              "type": "integer"
+              "type": "integer",
+              "default": 60000
             }
           },
           {
             "keepalive_enabled": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "authentication": {
-              "required": true,
               "fields": [
                 {
                   "strategy": {
-                    "required": false,
                     "type": "string",
+                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`.",
                     "one_of": [
                       "sasl"
-                    ]
+                    ],
+                    "required": false
                   }
                 },
                 {
                   "mechanism": {
-                    "required": false,
                     "type": "string",
+                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN` or `SCRAM-SHA-256`.",
                     "one_of": [
                       "PLAIN",
                       "SCRAM-SHA-256",
                       "SCRAM-SHA-512"
-                    ]
+                    ],
+                    "required": false
                   }
                 },
                 {
                   "tokenauth": {
-                    "required": false,
-                    "type": "boolean"
+                    "description": "Enable this to indicate `DelegationToken` authentication",
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
                   "user": {
-                    "type": "string",
                     "encrypted": true,
-                    "referenceable": true,
-                    "required": false
+                    "required": false,
+                    "description": "Username for SASL authentication.",
+                    "type": "string",
+                    "referenceable": true
                   }
                 },
                 {
                   "password": {
-                    "type": "string",
                     "encrypted": true,
-                    "referenceable": true,
-                    "required": false
+                    "required": false,
+                    "description": "Password for SASL authentication.",
+                    "type": "string",
+                    "referenceable": true
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "security": {
-              "required": true,
               "fields": [
                 {
                   "certificate_id": {
                     "uuid": true,
+                    "description": "UUID of certificate entity for mTLS authentication.",
                     "type": "string",
                     "required": false
                   }
                 },
                 {
                   "ssl": {
-                    "required": false,
-                    "type": "boolean"
+                    "description": "Enables TLS.",
+                    "type": "boolean",
+                    "required": false
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "cluster_name": {
-              "required": false,
               "auto": true,
-              "type": "string"
+              "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "producer_request_acks": {
               "default": 1,
+              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set).",
               "type": "integer",
               "one_of": [
                 -1,
@@ -180,54 +192,89 @@
           {
             "producer_request_timeout": {
               "default": 2000,
+              "description": "Time to wait for a Produce response in milliseconds",
               "type": "integer"
             }
           },
           {
             "producer_request_limits_messages_per_request": {
               "default": 200,
+              "description": "Maximum number of messages to include into a single Produce request.",
               "type": "integer"
             }
           },
           {
             "producer_request_limits_bytes_per_request": {
               "default": 1048576,
+              "description": "Maximum size of a Produce request in bytes.",
               "type": "integer"
             }
           },
           {
             "producer_request_retries_max_attempts": {
               "default": 10,
+              "description": "Maximum number of retry attempts per single Produce request.",
               "type": "integer"
             }
           },
           {
             "producer_request_retries_backoff_timeout": {
               "default": 100,
+              "description": "Backoff interval between retry attempts in milliseconds.",
               "type": "integer"
             }
           },
           {
             "producer_async": {
               "default": true,
+              "description": "Flag to enable asynchronous mode.",
               "type": "boolean"
             }
           },
           {
             "producer_async_flush_timeout": {
               "default": 1000,
+              "description": "Maximum time interval in milliseconds between buffer flushes in asynchronous mode.",
               "type": "integer"
             }
           },
           {
             "producer_async_buffering_limits_messages_in_memory": {
               "default": 50000,
+              "description": "Maximum number of messages that can be buffered in memory in asynchronous mode.",
               "type": "integer"
+            }
+          },
+          {
+            "custom_fields_by_lua": {
+              "type": "map",
+              "description": "Lua code as a key-value map",
+              "values": {
+                "len_min": 1,
+                "type": "string"
+              },
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              }
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "custom_entity_check": {
+              "field_sources": [
+                "authentication"
+              ]
+            }
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/kafka-upstream/3.4.x.json
+++ b/schemas/kafka-upstream/3.4.x.json
@@ -2,28 +2,278 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "bootstrap_servers": {
+              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format.",
+              "type": "set",
+              "elements": {
+                "type": "record",
+                "fields": [
+                  {
+                    "host": {
+                      "description": "A string representing a host name, such as example.com.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  {
+                    "port": {
+                      "between": [
+                        0,
+                        65535
+                      ],
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "type": "integer",
+                      "required": true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "topic": {
+              "description": "The Kafka topic to publish to.",
+              "type": "string",
+              "required": true
+            }
+          },
+          {
+            "timeout": {
+              "default": 10000,
+              "description": "Socket timeout in milliseconds.",
+              "type": "integer"
+            }
+          },
+          {
+            "keepalive": {
+              "default": 60000,
+              "description": "Keepalive timeout in milliseconds.",
+              "type": "integer"
+            }
+          },
+          {
+            "keepalive_enabled": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "authentication": {
+              "fields": [
+                {
+                  "strategy": {
+                    "type": "string",
+                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`.",
+                    "one_of": [
+                      "sasl"
+                    ],
+                    "required": false
+                  }
+                },
+                {
+                  "mechanism": {
+                    "type": "string",
+                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.",
+                    "one_of": [
+                      "PLAIN",
+                      "SCRAM-SHA-256",
+                      "SCRAM-SHA-512"
+                    ],
+                    "required": false
+                  }
+                },
+                {
+                  "tokenauth": {
+                    "description": "Enable this to indicate `DelegationToken` authentication.",
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "user": {
+                    "encrypted": true,
+                    "referenceable": true,
+                    "description": "Username for SASL authentication.",
+                    "type": "string",
+                    "required": false
+                  }
+                },
+                {
+                  "password": {
+                    "encrypted": true,
+                    "referenceable": true,
+                    "description": "Password for SASL authentication.",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              ],
+              "type": "record",
+              "required": true
+            }
+          },
+          {
+            "security": {
+              "fields": [
+                {
+                  "certificate_id": {
+                    "uuid": true,
+                    "description": "UUID of certificate entity for mTLS authentication.",
+                    "type": "string",
+                    "required": false
+                  }
+                },
+                {
+                  "ssl": {
+                    "description": "Enables TLS.",
+                    "type": "boolean",
+                    "required": false
+                  }
+                }
+              ],
+              "type": "record",
+              "required": true
+            }
+          },
+          {
+            "forward_method": {
+              "default": false,
+              "description": "Include the request method in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
+              "type": "boolean"
+            }
+          },
+          {
+            "forward_uri": {
+              "default": false,
+              "description": "Include the request URI and URI arguments (as in, query arguments) in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
+              "type": "boolean"
+            }
+          },
+          {
+            "forward_headers": {
+              "default": false,
+              "description": "Include the request headers in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
+              "type": "boolean"
+            }
+          },
+          {
+            "forward_body": {
+              "default": true,
+              "description": "Include the request body in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
+              "type": "boolean"
+            }
+          },
+          {
+            "cluster_name": {
+              "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster.",
+              "auto": true,
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "producer_request_acks": {
+              "default": 1,
+              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set).",
+              "type": "integer",
+              "one_of": [
+                -1,
+                0,
+                1
+              ]
+            }
+          },
+          {
+            "producer_request_timeout": {
+              "default": 2000,
+              "description": "Time to wait for a Produce response in milliseconds.",
+              "type": "integer"
+            }
+          },
+          {
+            "producer_request_limits_messages_per_request": {
+              "default": 200,
+              "description": "Maximum number of messages to include into a single producer request.",
+              "type": "integer"
+            }
+          },
+          {
+            "producer_request_limits_bytes_per_request": {
+              "default": 1048576,
+              "description": "Maximum size of a Produce request in bytes.",
+              "type": "integer"
+            }
+          },
+          {
+            "producer_request_retries_max_attempts": {
+              "default": 10,
+              "description": "Maximum number of retry attempts per single Produce request.",
+              "type": "integer"
+            }
+          },
+          {
+            "producer_request_retries_backoff_timeout": {
+              "default": 100,
+              "description": "Backoff interval between retry attempts in milliseconds.",
+              "type": "integer"
+            }
+          },
+          {
+            "producer_async": {
+              "default": true,
+              "description": "Flag to enable asynchronous mode.",
+              "type": "boolean"
+            }
+          },
+          {
+            "producer_async_flush_timeout": {
+              "default": 1000,
+              "description": "Maximum time interval in milliseconds between buffer flushes in asynchronous mode.",
+              "type": "integer"
+            }
+          },
+          {
+            "producer_async_buffering_limits_messages_in_memory": {
+              "default": 50000,
+              "description": "Maximum number of messages that can be buffered in memory in asynchronous mode.",
+              "type": "integer"
+            }
+          }
+        ],
         "required": true,
+        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -42,222 +292,11 @@
               ]
             }
           }
-        ],
-        "fields": [
-          {
-            "bootstrap_servers": {
-              "elements": {
-                "fields": [
-                  {
-                    "host": {
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  {
-                    "port": {
-                      "between": [
-                        0,
-                        65535
-                      ],
-                      "type": "integer",
-                      "required": true
-                    }
-                  }
-                ],
-                "type": "record"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "topic": {
-              "type": "string",
-              "required": true
-            }
-          },
-          {
-            "timeout": {
-              "type": "integer",
-              "default": 10000
-            }
-          },
-          {
-            "keepalive": {
-              "type": "integer",
-              "default": 60000
-            }
-          },
-          {
-            "keepalive_enabled": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "authentication": {
-              "required": true,
-              "fields": [
-                {
-                  "strategy": {
-                    "required": false,
-                    "type": "string",
-                    "one_of": [
-                      "sasl"
-                    ]
-                  }
-                },
-                {
-                  "mechanism": {
-                    "required": false,
-                    "type": "string",
-                    "one_of": [
-                      "PLAIN",
-                      "SCRAM-SHA-256",
-                      "SCRAM-SHA-512"
-                    ]
-                  }
-                },
-                {
-                  "tokenauth": {
-                    "type": "boolean",
-                    "required": false
-                  }
-                },
-                {
-                  "user": {
-                    "referenceable": true,
-                    "type": "string",
-                    "encrypted": true,
-                    "required": false
-                  }
-                },
-                {
-                  "password": {
-                    "referenceable": true,
-                    "type": "string",
-                    "encrypted": true,
-                    "required": false
-                  }
-                }
-              ],
-              "type": "record"
-            }
-          },
-          {
-            "security": {
-              "required": true,
-              "fields": [
-                {
-                  "certificate_id": {
-                    "uuid": true,
-                    "type": "string",
-                    "required": false
-                  }
-                },
-                {
-                  "ssl": {
-                    "type": "boolean",
-                    "required": false
-                  }
-                }
-              ],
-              "type": "record"
-            }
-          },
-          {
-            "forward_method": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "forward_uri": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "forward_headers": {
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "forward_body": {
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "cluster_name": {
-              "required": false,
-              "auto": true,
-              "type": "string"
-            }
-          },
-          {
-            "producer_request_acks": {
-              "default": 1,
-              "type": "integer",
-              "one_of": [
-                -1,
-                0,
-                1
-              ]
-            }
-          },
-          {
-            "producer_request_timeout": {
-              "type": "integer",
-              "default": 2000
-            }
-          },
-          {
-            "producer_request_limits_messages_per_request": {
-              "type": "integer",
-              "default": 200
-            }
-          },
-          {
-            "producer_request_limits_bytes_per_request": {
-              "type": "integer",
-              "default": 1048576
-            }
-          },
-          {
-            "producer_request_retries_max_attempts": {
-              "type": "integer",
-              "default": 10
-            }
-          },
-          {
-            "producer_request_retries_backoff_timeout": {
-              "type": "integer",
-              "default": 100
-            }
-          },
-          {
-            "producer_async": {
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "producer_async_flush_timeout": {
-              "type": "integer",
-              "default": 1000
-            }
-          },
-          {
-            "producer_async_buffering_limits_messages_in_memory": {
-              "type": "integer",
-              "default": 50000
-            }
-          }
-        ],
-        "type": "record"
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/key-auth-enc/3.4.x.json
+++ b/schemas/key-auth-enc/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -17,7 +18,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,67 +29,83 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "key_names": {
-              "elements": {
-                "type": "string"
-              },
+              "required": true,
               "default": [
                 "apikey"
               ],
-              "required": true,
-              "type": "array"
+              "description": "Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name.  Key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "hide_credentials": {
               "default": false,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request (i.e., the header, query string, or request body containing the key) before proxying it.",
               "type": "boolean"
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "key_in_header": {
               "default": true,
+              "description": "If enabled (default), the plugin reads the request header and tries to find the key in it.",
               "type": "boolean"
             }
           },
           {
             "key_in_query": {
               "default": true,
+              "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it.",
               "type": "boolean"
             }
           },
           {
             "key_in_body": {
               "default": false,
+              "description": "If enabled, the plugin reads the request body (if said request has one and its MIME type is supported) and tries to find the key in it. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
               "type": "boolean"
             }
           },
           {
             "run_on_preflight": {
               "default": true,
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed.",
               "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/key-auth/3.4.x.json
+++ b/schemas/key-auth/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -17,7 +18,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,72 +29,88 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "key_names": {
-              "elements": {
-                "type": "string"
-              },
+              "required": true,
               "default": [
                 "apikey"
               ],
-              "required": true,
-              "type": "array"
+              "description": "Describes an array of parameter names where the plugin will look for a key. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "hide_credentials": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`."
             }
           },
           {
             "key_in_header": {
-              "type": "boolean",
               "default": true,
+              "description": "If enabled (default), the plugin reads the request header and tries to find the key in it.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "key_in_query": {
-              "type": "boolean",
               "default": true,
+              "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "key_in_body": {
-              "type": "boolean",
               "default": false,
+              "description": "If enabled, the plugin reads the request body. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "run_on_preflight": {
-              "type": "boolean",
               "default": true,
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed.",
+              "type": "boolean",
               "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/konnect-application-auth/3.4.x.json
+++ b/schemas/konnect-application-auth/3.4.x.json
@@ -2,79 +2,97 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "route": {
-        "eq": null,
         "reference": "routes",
-        "type": "foreign"
+        "description": "A reference to the 'routes' table with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-
-        ],
         "fields": [
           {
             "key_names": {
-              "elements": {
-                "type": "string"
-              },
+              "required": true,
               "default": [
                 "apikey"
               ],
-              "required": true,
-              "type": "array"
+              "description": "The names of the headers containing the API key. You can specify multiple header names.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "auth_type": {
+              "required": true,
               "default": "openid-connect",
+              "description": "The type of authentication to be performed. Possible values are: 'openid-connect', 'key-auth'.",
+              "type": "string",
               "one_of": [
                 "openid-connect",
                 "key-auth"
-              ],
-              "type": "string",
-              "required": true
+              ]
             }
           },
           {
             "scope": {
-              "required": true,
               "unique": true,
-              "type": "string"
+              "description": "The unique scope identifier for the plugin configuration.",
+              "type": "string",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/ldap-auth-advanced/3.4.x.json
+++ b/schemas/ldap-auth-advanced/3.4.x.json
@@ -10,7 +10,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -18,26 +21,32 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "ldap_host": {
+              "description": "Host on which the LDAP server is running.",
               "type": "string",
               "required": true
             }
@@ -45,18 +54,21 @@
           {
             "ldap_password": {
               "encrypted": true,
-              "referenceable": true,
-              "type": "string"
+              "description": "The password to the LDAP server.",
+              "type": "string",
+              "referenceable": true
             }
           },
           {
             "ldap_port": {
-              "type": "number",
-              "default": 389
+              "default": 389,
+              "description": "TCP port where the LDAP server is listening. 389 is the default port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is configured, you must use port 636.",
+              "type": "number"
             }
           },
           {
             "bind_dn": {
+              "description": "The DN to bind to. Used to perform LDAP search of user. This `bind_dn` should have permissions to search for the user being authenticated.",
               "type": "string",
               "referenceable": true
             }
@@ -64,32 +76,37 @@
           {
             "ldaps": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "start_tls": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "verify_ldap_host": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "base_dn": {
+              "description": "Base DN as the starting point for the search; e.g., 'dc=example,dc=com'.",
               "type": "string",
               "required": true
             }
           },
           {
             "attribute": {
+              "description": "Attribute to be used to search the user; e.g., \"cn\".",
               "type": "string",
               "required": true
             }
@@ -97,99 +114,122 @@
           {
             "cache_ttl": {
               "default": 60,
-              "required": true,
-              "type": "number"
+              "description": "Cache expiry time in seconds.",
+              "type": "number",
+              "required": true
             }
           },
           {
             "hide_credentials": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
+              "type": "boolean"
             }
           },
           {
             "timeout": {
-              "type": "number",
-              "default": 10000
+              "default": 10000,
+              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server.",
+              "type": "number"
             }
           },
           {
             "keepalive": {
-              "type": "number",
-              "default": 60000
+              "default": 60000,
+              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.",
+              "type": "number"
             }
           },
           {
             "anonymous": {
-              "len_min": 0,
+              "default": "",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
               "type": "string",
-              "default": ""
+              "len_min": 0
             }
           },
           {
             "header_type": {
-              "type": "string",
-              "default": "ldap"
+              "default": "ldap",
+              "description": "An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to \"basic\", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `'ldap'` and `'basic'`.",
+              "type": "string"
             }
           },
           {
             "consumer_optional": {
               "default": false,
-              "required": false,
-              "type": "boolean"
-            }
-          },
-          {
-            "consumer_by": {
-              "elements": {
-                "one_of": [
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
-              "default": [
-                "username",
-                "custom_id"
-              ],
-              "type": "array",
+              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user.",
+              "type": "boolean",
               "required": false
             }
           },
           {
+            "consumer_by": {
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
+              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "username",
+                  "custom_id"
+                ]
+              }
+            }
+          },
+          {
             "group_base_dn": {
-              "type": "string"
+              "type": "string",
+              "description": "Sets a distinguished name (DN) for the entry where LDAP searches for groups begin. This field is case-insensitive.',dc=com'."
             }
           },
           {
             "group_name_attribute": {
-              "type": "string"
+              "type": "string",
+              "description": "Sets the attribute holding the name of a group, typically called `name` (in Active Directory) or `cn` (in OpenLDAP). This field is case-insensitive."
             }
           },
           {
             "group_member_attribute": {
-              "type": "string",
-              "default": "memberOf"
+              "default": "memberOf",
+              "description": "Sets the attribute holding the members of the LDAP group. This field is case-sensitive.",
+              "type": "string"
             }
           },
           {
             "log_search_results": {
               "default": false,
-              "required": false,
-              "type": "boolean"
+              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment.",
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "groups_required": {
-              "type": "array",
               "required": false,
+              "description": "The groups required to be present in the LDAP search result for successful authorization. This config parameter works in both **AND** / **OR** cases. - When `[\"group1 group2\"]` are in the same array indices, both `group1` AND `group2` need to be present in the LDAP search result. - When `[\"group1\", \"group2\"]` are in different array indices, either `group1` OR `group2` need to be present in the LDAP search result.",
+              "type": "array",
               "elements": {
                 "type": "string"
               }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config"
+        ]
       }
     }
   ]

--- a/schemas/ldap-auth/3.4.x.json
+++ b/schemas/ldap-auth/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -17,7 +18,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,122 +29,143 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "conditional": {
-              "then_err": "'ldaps' and 'start_tls' cannot be enabled simultaneously",
-              "if_match": {
-                "eq": true
-              },
-              "then_field": "start_tls",
-              "if_field": "ldaps",
-              "then_match": {
-                "eq": false
-              }
-            }
-          }
-        ],
         "fields": [
           {
             "ldap_host": {
+              "description": "A string representing a host name, such as example.com.",
               "type": "string",
               "required": true
             }
           },
           {
             "ldap_port": {
+              "required": true,
+              "default": 389,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "required": true,
-              "default": 389
+              ]
             }
           },
           {
             "ldaps": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "start_tls": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "verify_ldap_host": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "base_dn": {
-              "required": true,
-              "type": "string"
+              "description": "Base DN as the starting point for the search; e.g., dc=example,dc=com",
+              "type": "string",
+              "required": true
             }
           },
           {
             "attribute": {
-              "required": true,
-              "type": "string"
+              "description": "Attribute to be used to search the user; e.g. cn",
+              "type": "string",
+              "required": true
             }
           },
           {
             "cache_ttl": {
               "default": 60,
-              "required": true,
-              "type": "number"
+              "description": "Cache expiry time in seconds.",
+              "type": "number",
+              "required": true
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "timeout": {
               "default": 10000,
+              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server.",
               "type": "number"
             }
           },
           {
             "keepalive": {
               "default": 60000,
+              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.",
               "type": "number"
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`."
             }
           },
           {
             "header_type": {
               "default": "ldap",
+              "description": "An optional string to use as part of the Authorization header",
               "type": "string"
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "conditional": {
+              "then_field": "start_tls",
+              "then_err": "'ldaps' and 'start_tls' cannot be enabled simultaneously",
+              "then_match": {
+                "eq": false
+              },
+              "if_match": {
+                "eq": true
+              },
+              "if_field": "ldaps"
+            }
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/loggly/3.4.x.json
+++ b/schemas/loggly/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,47 +25,53 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "host": {
-              "type": "string",
-              "default": "logs-01.loggly.com"
+              "default": "logs-01.loggly.com",
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "port": {
+              "default": 514,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "type": "integer",
-              "default": 514
+              ]
             }
           },
           {
             "key": {
-              "type": "string",
               "required": true,
               "encrypted": true,
+              "type": "string",
               "referenceable": true
             }
           },
           {
             "tags": {
-              "type": "set",
               "default": [
                 "kong"
               ],
+              "type": "set",
               "elements": {
                 "type": "string"
               }
@@ -68,8 +79,8 @@
           },
           {
             "log_level": {
-              "type": "string",
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -84,8 +95,8 @@
           },
           {
             "successful_severity": {
-              "type": "string",
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -100,8 +111,8 @@
           },
           {
             "client_errors_severity": {
-              "type": "string",
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -116,8 +127,8 @@
           },
           {
             "server_errors_severity": {
-              "type": "string",
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -139,19 +150,24 @@
           {
             "custom_fields_by_lua": {
               "type": "map",
-              "keys": {
+              "description": "Lua code as a key-value map",
+              "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "values": {
+              "keys": {
                 "type": "string",
                 "len_min": 1
               }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/mocking/3.4.x.json
+++ b/schemas/mocking/3.4.x.json
@@ -2,83 +2,108 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "api_specification_filename": {
+              "description": "The path and name of the specification file loaded into Kong Gateway's database. You cannot use this option for DB-less or hybrid mode.",
               "type": "string",
               "required": false
             }
           },
           {
             "api_specification": {
-              "required": false,
-              "type": "string"
+              "description": "The contents of the specification file. You must use this option for hybrid or DB-less mode. You can include the full specification as part of the configuration. In Kong Manager, you can copy and paste the contents of the spec directly into the `Config.Api Specification` text field.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "random_delay": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Enables a random delay in the mocked response. Introduces delays to simulate real-time response times by APIs.",
+              "type": "boolean"
             }
           },
           {
             "max_delay_time": {
-              "type": "number",
-              "default": 1
+              "default": 1,
+              "description": "The maximum value in seconds of delay time. Set this value when `random_delay` is enabled and you want to adjust the default. The value must be greater than the `min_delay_time`.",
+              "type": "number"
             }
           },
           {
             "min_delay_time": {
-              "type": "number",
-              "default": 0.001
+              "default": 0.001,
+              "description": "The minimum value in seconds of delay time. Set this value when `random_delay` is enabled and you want to adjust the default. The value must be less than the `max_delay_time`.",
+              "type": "number"
             }
           },
           {
             "random_examples": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Randomly selects one example and returns it. This parameter requires the spec to have multiple examples configured.",
+              "type": "boolean"
             }
           },
           {
             "included_status_codes": {
+              "description": "A global list of the HTTP status codes that can only be selected and returned.",
+              "type": "array",
               "elements": {
                 "type": "integer"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "random_status_code": {
-              "required": true,
               "default": false,
-              "type": "boolean"
+              "description": "Determines whether to randomly select an HTTP status code from the responses of the corresponding API method. The default value is `false`, which means the minimum HTTP status code is always selected and returned.",
+              "type": "boolean",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.api_specification_filename",
+        "config.api_specification"
+      ]
     }
   ]
 }

--- a/schemas/mtls-auth/3.4.x.json
+++ b/schemas/mtls-auth/3.4.x.json
@@ -2,35 +2,185 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "anonymous": {
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
+            }
+          },
+          {
+            "consumer_by": {
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
+              "description": "Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array), then auto-matching is disabled.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "username",
+                  "custom_id"
+                ]
+              }
+            }
+          },
+          {
+            "ca_certificates": {
+              "required": true,
+              "description": "List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`).",
+              "type": "array",
+              "elements": {
+                "uuid": true,
+                "type": "string"
+              }
+            }
+          },
+          {
+            "cache_ttl": {
+              "default": 60,
+              "description": "Cache expiry time in seconds.",
+              "type": "number",
+              "required": true
+            }
+          },
+          {
+            "skip_consumer_lookup": {
+              "default": false,
+              "description": "Skip consumer lookup once certificate is trusted against the configured CA list.",
+              "type": "boolean",
+              "required": true
+            }
+          },
+          {
+            "allow_partial_chain": {
+              "default": false,
+              "description": "Allow certificate verification with only an intermediate certificate. When this is enabled, you don't need to upload the full chain to Kong Certificates.",
+              "type": "boolean",
+              "required": true
+            }
+          },
+          {
+            "authenticated_group_by": {
+              "required": false,
+              "default": "CN",
+              "description": "Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API. To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users.",
+              "type": "string",
+              "one_of": [
+                "CN",
+                "DN"
+              ]
+            }
+          },
+          {
+            "revocation_check_mode": {
+              "required": false,
+              "default": "IGNORE_CA_ERROR",
+              "description": "Controls client certificate revocation check behavior. If set to `SKIP`, no revocation check is performed. If set to `IGNORE_CA_ERROR`, the plugin respects the revocation status when either OCSP or CRL URL is set, and doesn't fail on network issues. If set to `STRICT`, the plugin only treats the certificate as valid when it's able to verify the revocation status.",
+              "type": "string",
+              "one_of": [
+                "SKIP",
+                "IGNORE_CA_ERROR",
+                "STRICT"
+              ]
+            }
+          },
+          {
+            "http_timeout": {
+              "default": 30000,
+              "description": "HTTP timeout threshold in milliseconds when communicating with the OCSP server or downloading CRL.",
+              "type": "number"
+            }
+          },
+          {
+            "cert_cache_ttl": {
+              "default": 60000,
+              "description": "The length of time in milliseconds between refreshes of the revocation check status cache.",
+              "type": "number"
+            }
+          },
+          {
+            "send_ca_dn": {
+              "default": false,
+              "description": "Sends the distinguished names (DN) of the configured CA list in the TLS handshake message.",
+              "type": "boolean"
+            }
+          },
+          {
+            "http_proxy_host": {
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
+            }
+          },
+          {
+            "http_proxy_port": {
+              "between": [
+                0,
+                65535
+              ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer"
+            }
+          },
+          {
+            "https_proxy_host": {
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
+            }
+          },
+          {
+            "https_proxy_port": {
+              "between": [
+                0,
+                65535
+              ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer"
+            }
+          }
+        ],
         "required": true,
+        "type": "record",
         "entity_checks": [
           {
             "mutually_required": [
@@ -44,133 +194,11 @@
               "https_proxy_port"
             ]
           }
-        ],
-        "fields": [
-          {
-            "anonymous": {
-              "type": "string"
-            }
-          },
-          {
-            "consumer_by": {
-              "elements": {
-                "one_of": [
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
-              "default": [
-                "username",
-                "custom_id"
-              ],
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "ca_certificates": {
-              "required": true,
-              "type": "array",
-              "elements": {
-                "uuid": true,
-                "type": "string"
-              }
-            }
-          },
-          {
-            "cache_ttl": {
-              "type": "number",
-              "required": true,
-              "default": 60
-            }
-          },
-          {
-            "skip_consumer_lookup": {
-              "type": "boolean",
-              "required": true,
-              "default": false
-            }
-          },
-          {
-            "allow_partial_chain": {
-              "type": "boolean",
-              "required": true,
-              "default": false
-            }
-          },
-          {
-            "authenticated_group_by": {
-              "default": "CN",
-              "one_of": [
-                "CN",
-                "DN"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "revocation_check_mode": {
-              "default": "IGNORE_CA_ERROR",
-              "one_of": [
-                "SKIP",
-                "IGNORE_CA_ERROR",
-                "STRICT"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "http_timeout": {
-              "default": 30000,
-              "type": "number"
-            }
-          },
-          {
-            "cert_cache_ttl": {
-              "default": 60000,
-              "type": "number"
-            }
-          },
-          {
-            "send_ca_dn": {
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          {
-            "http_proxy_host": {
-              "type": "string"
-            }
-          },
-          {
-            "http_proxy_port": {
-              "between": [
-                0,
-                65535
-              ],
-              "type": "integer"
-            }
-          },
-          {
-            "https_proxy_host": {
-              "type": "string"
-            }
-          },
-          {
-            "https_proxy_port": {
-              "between": [
-                0,
-                65535
-              ],
-              "type": "integer"
-            }
-          }
-        ],
-        "type": "record"
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/oas-validation/3.4.x.json
+++ b/schemas/oas-validation/3.4.x.json
@@ -2,115 +2,139 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "api_spec": {
+              "description": "The API specification defined using either Swagger or the OpenAPI. This can be either a JSON or YAML based file. If using a YAML file, the spec needs to be URL encoded to preserve the YAML format.",
               "type": "string",
               "required": true
             }
           },
           {
             "verbose_response": {
-              "required": false,
+              "default": false,
+              "description": "If set to true, returns a detailed error message for invalid requests & responses. This is useful while testing.",
               "type": "boolean",
-              "default": false
+              "required": false
             }
           },
           {
             "validate_request_body": {
-              "required": false,
+              "default": true,
+              "description": "If set to true, validates the request body content against the API specification.",
               "type": "boolean",
-              "default": true
+              "required": false
             }
           },
           {
             "notify_only_request_validation_failure": {
-              "required": false,
+              "default": false,
+              "description": "If set to true, notifications via event hooks are enabled, but request based validation failures don't affect the request flow.",
               "type": "boolean",
-              "default": false
+              "required": false
             }
           },
           {
             "validate_request_header_params": {
-              "required": false,
+              "default": true,
+              "description": "If set to true, validates HTTP header parameters against the API specification.",
               "type": "boolean",
-              "default": true
+              "required": false
             }
           },
           {
             "validate_request_query_params": {
-              "required": false,
+              "default": true,
+              "description": "If set to true, validates query parameters against the API specification.",
               "type": "boolean",
-              "default": true
+              "required": false
             }
           },
           {
             "validate_request_uri_params": {
-              "required": false,
+              "default": true,
+              "description": "If set to true, validates URI parameters in the request against the API specification.",
               "type": "boolean",
-              "default": true
+              "required": false
             }
           },
           {
             "validate_response_body": {
-              "required": false,
+              "default": false,
+              "description": "If set to true, validates the response from the upstream services against the API specification. If validation fails, it results in an `HTTP 406 Not Acceptable` status code.",
               "type": "boolean",
-              "default": false
+              "required": false
             }
           },
           {
             "notify_only_response_body_validation_failure": {
-              "required": false,
+              "default": false,
+              "description": "If set to true, notifications via event hooks are enabled, but response validation failures don't affect the response flow.",
               "type": "boolean",
-              "default": false
+              "required": false
             }
           },
           {
             "query_parameter_check": {
-              "required": true,
+              "default": false,
+              "description": "If set to true, checks if query parameters in the request exist in the API specification.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           },
           {
             "header_parameter_check": {
-              "required": true,
+              "default": false,
+              "description": "If set to true, checks if HTTP header parameters in the request exist in the API specification.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           },
           {
             "allowed_header_parameters": {
-              "required": false,
+              "default": "Host,Content-Type,User-Agent,Accept,Content-Length",
+              "description": "List of header parameters in the request that will be ignored when performing HTTP header validation. These are additional headers added to an API request beyond those defined in the API specification.  For example, you might include the HTTP header `User-Agent`, which lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent.",
               "type": "string",
-              "default": "Host,Content-Type,User-Agent,Accept,Content-Length"
+              "required": false
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/oauth2-introspection/3.4.x.json
+++ b/schemas/oauth2-introspection/3.4.x.json
@@ -2,106 +2,126 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "introspection_url": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
               "type": "string",
               "required": true
             }
           },
           {
             "ttl": {
-              "type": "number",
-              "default": 30
+              "default": 30,
+              "description": "The TTL in seconds for the introspection response. Set to 0 to disable the expiration.",
+              "type": "number"
             }
           },
           {
             "token_type_hint": {
-              "type": "string"
+              "type": "string",
+              "description": "The `token_type_hint` value to associate to introspection requests."
             }
           },
           {
             "authorization_value": {
+              "description": "The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`).",
               "type": "string",
               "required": true
             }
           },
           {
             "timeout": {
-              "type": "integer",
-              "default": 10000
+              "default": 10000,
+              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
+              "type": "integer"
             }
           },
           {
             "keepalive": {
-              "type": "integer",
-              "default": 60000
+              "default": 60000,
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
+              "type": "integer"
             }
           },
           {
             "introspect_request": {
-              "required": true,
               "default": false,
-              "type": "boolean"
+              "description": "A boolean indicating whether to forward information about the current downstream request to the introspect endpoint. If true, headers `X-Request-Path` and `X-Request-Http-Method` will be inserted into the introspect request.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "hide_credentials": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request.",
+              "type": "boolean"
             }
           },
           {
             "run_on_preflight": {
-              "type": "boolean",
-              "default": true
+              "default": true,
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed.",
+              "type": "boolean"
             }
           },
           {
             "anonymous": {
               "len_min": 0,
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
               "type": "string",
               "default": ""
             }
           },
           {
             "consumer_by": {
+              "required": true,
               "default": "username",
+              "description": "A string indicating whether to associate OAuth2 `username` or `client_id` with the consumer's username. OAuth2 `username` is mapped to a consumer's `username` field, while an OAuth2 `client_id` maps to a consumer's `custom_id`.",
+              "type": "string",
               "one_of": [
                 "username",
                 "client_id"
-              ],
-              "type": "string",
-              "required": true
+              ]
             }
           },
           {
@@ -109,31 +129,37 @@
               "values": {
                 "type": "string"
               },
+              "required": true,
               "default": [
 
               ],
+              "description": "A list of custom headers to be added in the introspection request.",
+              "type": "map",
               "keys": {
                 "type": "string"
-              },
-              "required": true,
-              "type": "map"
+              }
             }
           },
           {
             "custom_claims_forward": {
-              "elements": {
-                "type": "string"
-              },
+              "required": true,
               "default": [
 
               ],
+              "description": "A list of custom claims to be forwarded from the introspection response to the upstream request. Claims are forwarded in headers with prefix `X-Credential-{claim-name}`.",
               "type": "set",
-              "required": true
+              "elements": {
+                "type": "string"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/oauth2/3.4.x.json
+++ b/schemas/oauth2/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -17,7 +18,10 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -25,24 +29,28 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "type": "record",
         "entity_checks": [
           {
             "conditional": {
+              "if_field": "mandatory_scope",
+              "then_field": "scopes",
               "if_match": {
                 "eq": true
               },
-              "then_field": "scopes",
-              "if_field": "mandatory_scope",
               "then_match": {
                 "required": true
               }
@@ -52,135 +60,155 @@
         "fields": [
           {
             "scopes": {
+              "description": "Describes an array of scope names that will be available to the end user. If `mandatory_scope` is set to `true`, then `scopes` are required.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "mandatory_scope": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value telling the plugin to require at least one `scope` to be authorized by the end user.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "provision_key": {
-              "unique": true,
               "encrypted": true,
               "required": true,
-              "auto": true,
-              "type": "string"
+              "unique": true,
+              "description": "The unique key the plugin has generated when it has been added to the Service.",
+              "type": "string",
+              "auto": true
             }
           },
           {
             "token_expiration": {
-              "type": "number",
               "default": 7200,
+              "description": "An optional integer value telling the plugin how many seconds a token should last, after which the client will need to refresh the token. Set to `0` to disable the expiration.",
+              "type": "number",
               "required": true
             }
           },
           {
             "enable_authorization_code": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value to enable the three-legged Authorization Code flow (RFC 6742 Section 4.1).",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "enable_implicit_grant": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value to enable the Implicit Grant flow which allows to provision a token as a result of the authorization process (RFC 6742 Section 4.2).",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "enable_client_credentials": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value to enable the Client Credentials Grant flow (RFC 6742 Section 4.4).",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "enable_password_grant": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value to enable the Resource Owner Password Credentials Grant flow (RFC 6742 Section 4.3).",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "hide_credentials": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "accept_http_if_already_terminated": {
-              "type": "boolean",
               "default": false,
+              "description": "Accepts HTTPs requests that have already been terminated by a proxy or load balancer.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
             }
           },
           {
             "global_credentials": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value that allows using the same OAuth credentials generated by the plugin with any other service whose OAuth 2.0 plugin configuration also has `config.global_credentials=true`.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "auth_header_name": {
               "default": "authorization",
+              "description": "The name of the header that is supposed to carry the access token.",
               "type": "string"
             }
           },
           {
             "refresh_token_ttl": {
+              "required": true,
+              "default": 1209600,
+              "description": "Time-to-live value for data",
               "type": "number",
               "between": [
                 0,
                 100000000
-              ],
-              "default": 1209600,
-              "required": true
+              ]
             }
           },
           {
             "reuse_refresh_token": {
-              "type": "boolean",
               "default": false,
+              "description": "An optional boolean value that indicates whether an OAuth refresh token is reused when refreshing an access token.",
+              "type": "boolean",
               "required": true
             }
           },
           {
             "persistent_refresh_token": {
-              "type": "boolean",
               "default": false,
+              "type": "boolean",
               "required": true
             }
           },
           {
             "pkce": {
               "required": false,
+              "default": "lax",
+              "description": "Specifies a mode of how the Proof Key for Code Exchange (PKCE) should be handled by the plugin.",
+              "type": "string",
               "one_of": [
                 "none",
                 "lax",
                 "strict"
-              ],
-              "default": "lax",
-              "type": "string"
+              ]
             }
           }
         ],
+        "type": "record",
         "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/opa/3.4.x.json
+++ b/schemas/opa/3.4.x.json
@@ -2,40 +2,50 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "opa_protocol": {
-              "type": "string",
               "default": "http",
+              "description": "The protocol to use when talking to Open Policy Agent (OPA) server. Allowed protocols are `http` and `https`.",
+              "type": "string",
               "one_of": [
                 "http",
                 "https"
@@ -44,51 +54,57 @@
           },
           {
             "opa_host": {
+              "default": "localhost",
+              "description": "A string representing a host name, such as example.com.",
               "type": "string",
-              "required": true,
-              "default": "localhost"
+              "required": true
             }
           },
           {
             "opa_port": {
+              "required": true,
+              "default": 8181,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "default": 8181,
-              "required": true
+              ]
             }
           },
           {
             "opa_path": {
               "match_none": [
                 {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
+                  "pattern": "//",
+                  "err": "must not have empty segments"
                 }
               ],
-              "type": "string",
+              "required": true,
               "starts_with": "/",
-              "required": true
+              "type": "string",
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "include_service_in_opa_input": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to true, the Kong Gateway Service object in use for the current request is included as input to OPA.",
+              "type": "boolean"
             }
           },
           {
             "include_route_in_opa_input": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to true, the Kong Gateway Route object in use for the current request is included as input to OPA.",
+              "type": "boolean"
             }
           },
           {
             "include_consumer_in_opa_input": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to true, the Kong Gateway Consumer object in use for the current request (if any) is included as input to OPA.",
+              "type": "boolean"
             }
           },
           {
@@ -99,26 +115,33 @@
           },
           {
             "include_parsed_json_body_in_opa_input": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be JSON decoded and the decoded struct is included as input to OPA.",
+              "type": "boolean"
             }
           },
           {
             "include_uri_captures_in_opa_input": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to true, the regex capture groups captured on the Kong Gateway Route's path field in the current request (if any) are included as input to OPA.",
+              "type": "boolean"
             }
           },
           {
             "ssl_verify": {
+              "default": true,
+              "description": "If set to true, the OPA certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate.",
               "type": "boolean",
-              "required": true,
-              "default": true
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/openid-connect/3.4.x.json
+++ b/schemas/openid-connect/3.4.x.json
@@ -2,34 +2,2303 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "issuer": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": true
+            }
+          },
+          {
+            "discovery_headers_names": {
+              "required": false,
+              "description": "Extra header names passed to the discovery endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "discovery_headers_values": {
+              "required": false,
+              "description": "Extra header values passed to the discovery endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "extra_jwks_uris": {
+              "required": false,
+              "description": "JWKS URIs whose public keys are trusted (in addition to the keys found with the discovery).",
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "rediscovery_lifetime": {
+              "default": 30,
+              "description": "Specifies how long (in seconds) the plugin waits between discovery attempts. Discovery is still triggered on an as-needed basis.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "auth_methods": {
+              "required": false,
+              "default": [
+                "password",
+                "client_credentials",
+                "authorization_code",
+                "bearer",
+                "introspection",
+                "userinfo",
+                "kong_oauth2",
+                "refresh_token",
+                "session"
+              ],
+              "description": "Types of credentials/grants to enable.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "bearer",
+                  "introspection",
+                  "userinfo",
+                  "kong_oauth2",
+                  "refresh_token",
+                  "session"
+                ]
+              }
+            }
+          },
+          {
+            "client_id": {
+              "encrypted": true,
+              "required": false,
+              "description": "The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "referenceable": true
+              }
+            }
+          },
+          {
+            "client_secret": {
+              "encrypted": true,
+              "required": false,
+              "description": "The client secret.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "referenceable": true
+              }
+            }
+          },
+          {
+            "client_auth": {
+              "required": false,
+              "description": "The authentication method used by the client (plugin) when calling the endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "client_secret_basic",
+                  "client_secret_post",
+                  "client_secret_jwt",
+                  "private_key_jwt",
+                  "none"
+                ]
+              }
+            }
+          },
+          {
+            "client_jwk": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "required": false,
+                "type": "record",
+                "fields": [
+                  {
+                    "issuer": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "kty": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "use": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "key_ops": {
+                      "required": false,
+                      "type": "array",
+                      "elements": {
+                        "type": "string",
+                        "required": false
+                      }
+                    }
+                  },
+                  {
+                    "alg": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "kid": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "x5u": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "x5c": {
+                      "required": false,
+                      "type": "array",
+                      "elements": {
+                        "type": "string",
+                        "required": false
+                      }
+                    }
+                  },
+                  {
+                    "x5t": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "x5t#S256": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "k": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "x": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "y": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "crv": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "n": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "e": {
+                      "type": "string",
+                      "required": false
+                    }
+                  },
+                  {
+                    "d": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "p": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "q": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "dp": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "dq": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "qi": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "oth": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "r": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  },
+                  {
+                    "t": {
+                      "required": false,
+                      "referenceable": true,
+                      "type": "string",
+                      "encrypted": true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "client_alg": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "HS256",
+                  "HS384",
+                  "HS512",
+                  "RS256",
+                  "RS384",
+                  "RS512",
+                  "ES256",
+                  "ES384",
+                  "ES512",
+                  "PS256",
+                  "PS384",
+                  "PS512",
+                  "EdDSA"
+                ]
+              }
+            }
+          },
+          {
+            "client_arg": {
+              "default": "client_id",
+              "description": "The client to use for this request (the selection is made with a request parameter with the same name).",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "redirect_uri": {
+              "required": false,
+              "description": "The redirect URI passed to the authorization and token endpoints.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "login_redirect_uri": {
+              "required": false,
+              "description": "Where to redirect the client when `login_action` is set to `redirect`.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "logout_redirect_uri": {
+              "required": false,
+              "description": "Where to redirect the client after the logout.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "forbidden_redirect_uri": {
+              "required": false,
+              "description": "Where to redirect the client on forbidden requests.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "forbidden_error_message": {
+              "default": "Forbidden",
+              "description": "The error message for the forbidden requests (when not using the redirection).",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "forbidden_destroy_session": {
+              "default": true,
+              "description": "Destroy any active session for the forbidden requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "unauthorized_redirect_uri": {
+              "required": false,
+              "description": "Where to redirect the client on unauthorized requests.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "unauthorized_error_message": {
+              "default": "Unauthorized",
+              "description": "The error message for the unauthorized requests (when not using the redirection).",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "unexpected_redirect_uri": {
+              "required": false,
+              "description": "Where to redirect the client when unexpected errors happen with the requests.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              }
+            }
+          },
+          {
+            "response_mode": {
+              "required": false,
+              "default": "query",
+              "description": "The response mode passed to the authorization endpoint: - `query`: Instructs the identity provider to pass parameters in query string - `form_post`: Instructs the identity provider to pass parameters in request body - `fragment`: Instructs the identity provider to pass parameters in uri fragment (rarely useful as the plugin itself cannot read it)",
+              "type": "string",
+              "one_of": [
+                "query",
+                "form_post",
+                "fragment"
+              ]
+            }
+          },
+          {
+            "response_type": {
+              "required": false,
+              "default": [
+                "code"
+              ],
+              "description": "The response type passed to the authorization endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "scopes": {
+              "required": false,
+              "default": [
+                "openid"
+              ],
+              "description": "The scopes passed to the authorization and token endpoints.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "audience": {
+              "required": false,
+              "description": "The audience passed to the authorization endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "issuers_allowed": {
+              "required": false,
+              "description": "The issuers allowed to be present in the tokens (`iss` claim).",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "scopes_required": {
+              "required": false,
+              "description": "The scopes (`scopes_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "scopes_claim": {
+              "required": false,
+              "default": [
+                "scope"
+              ],
+              "description": "The claim that contains the scopes.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "audience_required": {
+              "required": false,
+              "description": "The audiences (`audience_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "audience_claim": {
+              "required": false,
+              "default": [
+                "aud"
+              ],
+              "description": "The claim that contains the audience.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "groups_required": {
+              "required": false,
+              "description": "The groups (`groups_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "groups_claim": {
+              "required": false,
+              "default": [
+                "groups"
+              ],
+              "description": "The claim that contains the groups.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "roles_required": {
+              "required": false,
+              "description": "The roles (`roles_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "roles_claim": {
+              "required": false,
+              "default": [
+                "roles"
+              ],
+              "description": "The claim that contains the roles.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "domains": {
+              "required": false,
+              "description": "The allowed values for the `hd` claim.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "max_age": {
+              "description": "The maximum age (in seconds) compared to the `auth_time` claim.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "authenticated_groups_claim": {
+              "required": false,
+              "description": "The claim that contains authenticated groups. This setting can be used together with ACL plugin, but it also enables IdP managed groups with other applications and integrations.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "authorization_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "authorization_query_args_names": {
+              "required": false,
+              "description": "Extra query argument names passed to the authorization endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "authorization_query_args_values": {
+              "required": false,
+              "description": "Extra query argument values passed to the authorization endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "authorization_query_args_client": {
+              "required": false,
+              "description": "Extra query arguments passed from the client to the authorization endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "authorization_rolling_timeout": {
+              "default": 600,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "authorization_cookie_name": {
+              "default": "authorization",
+              "description": "The authorization cookie name.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "authorization_cookie_path": {
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "default": "/",
+              "starts_with": "/",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "authorization_cookie_domain": {
+              "description": "The authorization cookie Domain flag.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "authorization_cookie_same_site": {
+              "required": false,
+              "default": "Default",
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ]
+            }
+          },
+          {
+            "authorization_cookie_http_only": {
+              "default": true,
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "authorization_cookie_secure": {
+              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "preserve_query_args": {
+              "default": false,
+              "description": "With this parameter, you can preserve request query arguments even when doing authorization code flow.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "token_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "token_endpoint_auth_method": {
+              "type": "string",
+              "description": "The token endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
+              "one_of": [
+                "client_secret_basic",
+                "client_secret_post",
+                "client_secret_jwt",
+                "private_key_jwt",
+                "none"
+              ],
+              "required": false
+            }
+          },
+          {
+            "token_headers_names": {
+              "required": false,
+              "description": "Extra header names passed to the token endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_headers_values": {
+              "required": false,
+              "description": "Extra header values passed to the token endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_headers_client": {
+              "required": false,
+              "description": "Extra headers passed from the client to the token endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_headers_replay": {
+              "required": false,
+              "description": "The names of token endpoint response headers to forward to the downstream client.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_headers_prefix": {
+              "description": "Add a prefix to the token endpoint response headers before forwarding them to the downstream client.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "token_headers_grants": {
+              "required": false,
+              "description": "Enable the sending of the token endpoint response headers only with certain grants: - `password`: with OAuth password grant - `client_credentials`: with OAuth client credentials grant - `authorization_code`: with authorization code flow - `refresh_token` with refresh token grant",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "refresh_token"
+                ]
+              }
+            }
+          },
+          {
+            "token_post_args_names": {
+              "required": false,
+              "description": "Extra post argument names passed to the token endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_post_args_values": {
+              "required": false,
+              "description": "Extra post argument values passed to the token endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_post_args_client": {
+              "required": false,
+              "description": "Pass extra arguments from the client to the OpenID-Connect plugin. If arguments exist, the client can pass them using: - Request Body - Query parameters  This parameter can be used with `scope` values, like this:  `config.token_post_args_client=scope`  In this case, the token would take the `scope` value from the query parameter or from the request body and send it to the token endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspection_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "introspection_endpoint_auth_method": {
+              "type": "string",
+              "description": "The introspection endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
+              "one_of": [
+                "client_secret_basic",
+                "client_secret_post",
+                "client_secret_jwt",
+                "private_key_jwt",
+                "none"
+              ],
+              "required": false
+            }
+          },
+          {
+            "introspection_hint": {
+              "default": "access_token",
+              "description": "Introspection hint parameter value passed to the introspection endpoint.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "introspection_check_active": {
+              "default": true,
+              "description": "Check that the introspection response has an `active` claim with a value of `true`.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "introspection_accept": {
+              "required": false,
+              "default": "application/json",
+              "description": "The value of `Accept` header for introspection requests: - `application/json`: introspection response as JSON - `application/token-introspection+jwt`: introspection response as JWT (from the current IETF draft document) - `application/jwt`: introspection response as JWT (from the obsolete IETF draft document)",
+              "type": "string",
+              "one_of": [
+                "application/json",
+                "application/token-introspection+jwt",
+                "application/jwt"
+              ]
+            }
+          },
+          {
+            "introspection_headers_names": {
+              "required": false,
+              "description": "Extra header names passed to the introspection endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspection_headers_values": {
+              "required": false,
+              "description": "Extra header values passed to the introspection endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspection_headers_client": {
+              "required": false,
+              "description": "Extra headers passed from the client to the introspection endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspection_post_args_names": {
+              "required": false,
+              "description": "Extra post argument names passed to the introspection endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspection_post_args_values": {
+              "required": false,
+              "description": "Extra post argument values passed to the introspection endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspection_post_args_client": {
+              "required": false,
+              "description": "Extra post arguments passed from the client to the introspection endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "introspect_jwt_tokens": {
+              "default": false,
+              "description": "Specifies whether to introspect the JWT access tokens (can be used to check for revocations).",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "revocation_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "revocation_endpoint_auth_method": {
+              "type": "string",
+              "description": "The revocation endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
+              "one_of": [
+                "client_secret_basic",
+                "client_secret_post",
+                "client_secret_jwt",
+                "private_key_jwt",
+                "none"
+              ],
+              "required": false
+            }
+          },
+          {
+            "end_session_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "userinfo_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "userinfo_accept": {
+              "required": false,
+              "default": "application/json",
+              "description": "The value of `Accept` header for user info requests: - `application/json`: user info response as JSON - `application/jwt`: user info response as JWT (from the obsolete IETF draft document)",
+              "type": "string",
+              "one_of": [
+                "application/json",
+                "application/jwt"
+              ]
+            }
+          },
+          {
+            "userinfo_headers_names": {
+              "required": false,
+              "description": "Extra header names passed to the user info endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "userinfo_headers_values": {
+              "required": false,
+              "description": "Extra header values passed to the user info endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "userinfo_headers_client": {
+              "required": false,
+              "description": "Extra headers passed from the client to the user info endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "userinfo_query_args_names": {
+              "required": false,
+              "description": "Extra query argument names passed to the user info endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "userinfo_query_args_values": {
+              "required": false,
+              "description": "Extra query argument values passed to the user info endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "userinfo_query_args_client": {
+              "required": false,
+              "description": "Extra query arguments passed from the client to the user info endpoint.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "token_exchange_endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_secret": {
+              "required": false,
+              "referenceable": true,
+              "description": "The session secret.",
+              "type": "string",
+              "encrypted": true
+            }
+          },
+          {
+            "session_audience": {
+              "default": "default",
+              "description": "The session audience, which is the intended target application. For example `\"my-application\"`.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_name": {
+              "default": "session",
+              "description": "The session cookie name.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_remember": {
+              "default": false,
+              "description": "Enables or disables persistent sessions.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_remember_cookie_name": {
+              "default": "remember",
+              "description": "Persistent session cookie name. Use with the `remember` configuration parameter.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_remember_rolling_timeout": {
+              "default": 604800,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_remember_absolute_timeout": {
+              "default": 2592000,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_idling_timeout": {
+              "default": 900,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_rolling_timeout": {
+              "default": 3600,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_absolute_timeout": {
+              "default": 86400,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_path": {
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "default": "/",
+              "starts_with": "/",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_domain": {
+              "description": "The session cookie Domain flag.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_same_site": {
+              "required": false,
+              "default": "Lax",
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ]
+            }
+          },
+          {
+            "session_cookie_http_only": {
+              "default": true,
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_secure": {
+              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_request_headers": {
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              }
+            }
+          },
+          {
+            "session_response_headers": {
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              }
+            }
+          },
+          {
+            "session_storage": {
+              "required": false,
+              "default": "cookie",
+              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie (the session cannot be invalidated or revoked without changing session secret, but is stateless, and doesn't require a database) - `memcache`: stores session data in memcached - `redis`: stores session data in Redis",
+              "type": "string",
+              "one_of": [
+                "cookie",
+                "memcache",
+                "memcached",
+                "redis"
+              ]
+            }
+          },
+          {
+            "session_store_metadata": {
+              "default": false,
+              "description": "Configures whether or not session metadata should be stored. This metadata includes information about the active sessions for a specific audience belonging to a specific subject.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_enforce_same_subject": {
+              "default": false,
+              "description": "When set to `true`, audiences are forced to share the same subject.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_hash_subject": {
+              "default": false,
+              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_hash_storage_key": {
+              "default": false,
+              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_prefix": {
+              "description": "The memcached session key prefix.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_socket": {
+              "description": "The memcached unix socket path.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_host": {
+              "default": "127.0.0.1",
+              "description": "The memcached host.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_port": {
+              "required": false,
+              "default": 11211,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ]
+            }
+          },
+          {
+            "session_redis_prefix": {
+              "description": "The Redis session key prefix.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_socket": {
+              "description": "The Redis unix socket path.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_host": {
+              "default": "127.0.0.1",
+              "description": "The Redis host",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_port": {
+              "required": false,
+              "default": 6379,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ]
+            }
+          },
+          {
+            "session_redis_username": {
+              "required": false,
+              "description": "Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired. If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
+              "type": "string",
+              "referenceable": true
+            }
+          },
+          {
+            "session_redis_password": {
+              "required": false,
+              "referenceable": true,
+              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no AUTH commands are sent to Redis.",
+              "type": "string",
+              "encrypted": true
+            }
+          },
+          {
+            "session_redis_connect_timeout": {
+              "description": "Network IO timeout in milliseconds.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "session_redis_read_timeout": {
+              "description": "Network IO timeout in milliseconds.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "session_redis_send_timeout": {
+              "description": "Network IO timeout in milliseconds.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "session_redis_ssl": {
+              "default": false,
+              "description": "Use SSL/TLS for Redis connection.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_redis_ssl_verify": {
+              "default": false,
+              "description": "Verify identity provider server certificate.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_redis_server_name": {
+              "description": "The SNI used for connecting the Redis server.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_cluster_nodes": {
+              "required": false,
+              "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values.",
+              "type": "array",
+              "elements": {
+                "type": "record",
+                "fields": [
+                  {
+                    "ip": {
+                      "default": "127.0.0.1",
+                      "description": "A string representing a host name, such as example.com.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  {
+                    "port": {
+                      "default": 6379,
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "type": "integer",
+                      "between": [
+                        0,
+                        65535
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "session_redis_cluster_max_redirections": {
+              "description": "The Redis cluster maximum redirects.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "reverify": {
+              "default": false,
+              "description": "Specifies whether to always verify tokens stored in the session.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "jwt_session_claim": {
+              "default": "sid",
+              "description": "The claim to match against the JWT session cookie.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "jwt_session_cookie": {
+              "description": "The name of the JWT session cookie.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "bearer_token_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the bearer token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body - `cookie`: search the HTTP request cookies specified with `config.bearer_token_cookie_name`",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "cookie",
+                  "query",
+                  "body"
+                ]
+              }
+            }
+          },
+          {
+            "bearer_token_cookie_name": {
+              "description": "The name of the cookie in which the bearer token is passed.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "client_credentials_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the client credentials: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search from the HTTP request body",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              }
+            }
+          },
+          {
+            "password_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the username and password: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              }
+            }
+          },
+          {
+            "id_token_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the id token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              }
+            }
+          },
+          {
+            "id_token_param_name": {
+              "description": "The name of the parameter used to pass the id token.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "refresh_token_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the refresh token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              }
+            }
+          },
+          {
+            "refresh_token_param_name": {
+              "description": "The name of the parameter used to pass the refresh token.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "refresh_tokens": {
+              "default": true,
+              "description": "Specifies whether the plugin should try to refresh (soon to be) expired access tokens if the plugin has a `refresh_token` available.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "upstream_headers_claims": {
+              "required": false,
+              "description": "The upstream header claims.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "upstream_headers_names": {
+              "required": false,
+              "description": "The upstream header names for the claim values.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "upstream_access_token_header": {
+              "default": "authorization:bearer",
+              "description": "The upstream access token header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_access_token_jwk_header": {
+              "description": "The upstream access token JWK header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_id_token_header": {
+              "description": "The upstream id token header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_id_token_jwk_header": {
+              "description": "The upstream id token JWK header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_refresh_token_header": {
+              "description": "The upstream refresh token header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_user_info_header": {
+              "description": "The upstream user info header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_user_info_jwt_header": {
+              "description": "The upstream user info JWT header (in case the user info returns a JWT response).",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_introspection_header": {
+              "description": "The upstream introspection header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_introspection_jwt_header": {
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "upstream_session_id_header": {
+              "description": "The upstream session id header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_headers_claims": {
+              "required": false,
+              "description": "The downstream header claims.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "downstream_headers_names": {
+              "required": false,
+              "description": "The downstream header names for the claim values.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "downstream_access_token_header": {
+              "description": "The downstream access token header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_access_token_jwk_header": {
+              "description": "The downstream access token JWK header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_id_token_header": {
+              "description": "The downstream id token header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_id_token_jwk_header": {
+              "description": "The downstream id token JWK header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_refresh_token_header": {
+              "description": "The downstream refresh token header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_user_info_header": {
+              "description": "The downstream user info header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_user_info_jwt_header": {
+              "description": "The downstream user info JWT header (in case the user info returns a JWT response).",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_introspection_header": {
+              "description": "The downstream introspection header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_introspection_jwt_header": {
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "downstream_session_id_header": {
+              "description": "The downstream session id header.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "login_methods": {
+              "required": false,
+              "default": [
+                "authorization_code"
+              ],
+              "description": "Enable login functionality with specified grants.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "bearer",
+                  "introspection",
+                  "userinfo",
+                  "kong_oauth2",
+                  "refresh_token",
+                  "session"
+                ]
+              }
+            }
+          },
+          {
+            "login_action": {
+              "required": false,
+              "default": "upstream",
+              "description": "What to do after successful login: - `upstream`: proxy request to upstream service - `response`: terminate request with a response - `redirect`: redirect to a different location",
+              "type": "string",
+              "one_of": [
+                "upstream",
+                "response",
+                "redirect"
+              ]
+            }
+          },
+          {
+            "login_tokens": {
+              "required": false,
+              "default": [
+                "id_token"
+              ],
+              "description": "What tokens to include in `response` body or `redirect` query string or fragment: - `id_token`: include id token - `access_token`: include access token - `refresh_token`: include refresh token - `tokens`: include the full token endpoint response - `introspection`: include introspection response",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id_token",
+                  "access_token",
+                  "refresh_token",
+                  "tokens",
+                  "introspection"
+                ]
+              }
+            }
+          },
+          {
+            "login_redirect_mode": {
+              "required": false,
+              "default": "fragment",
+              "description": "Where to place `login_tokens` when using `redirect` `login_action`: - `query`: place tokens in query string - `fragment`: place tokens in url fragment (not readable by servers)",
+              "type": "string",
+              "one_of": [
+                "query",
+                "fragment"
+              ]
+            }
+          },
+          {
+            "logout_query_arg": {
+              "description": "The request query argument that activates the logout.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "logout_post_arg": {
+              "description": "The request body argument that activates the logout.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "logout_uri_suffix": {
+              "description": "The request URI suffix that activates the logout.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "logout_methods": {
+              "required": false,
+              "default": [
+                "POST",
+                "DELETE"
+              ],
+              "description": "The request methods that can activate the logout: - `POST`: HTTP POST method - `GET`: HTTP GET method - `DELETE`: HTTP DELETE method",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "POST",
+                  "GET",
+                  "DELETE"
+                ]
+              }
+            }
+          },
+          {
+            "logout_revoke": {
+              "default": false,
+              "description": "Revoke tokens as part of the logout.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "logout_revoke_access_token": {
+              "default": true,
+              "description": "Revoke the access token as part of the logout.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "logout_revoke_refresh_token": {
+              "default": true,
+              "description": "Revoke the refresh token as part of the logout.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "consumer_claim": {
+              "required": false,
+              "description": "The claim used for consumer mapping.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "consumer_by": {
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
+              "description": "Consumer fields used for mapping: - `id`: try to find the matching Consumer by `id` - `username`: try to find the matching Consumer by `username` - `custom_id`: try to find the matching Consumer by `custom_id`",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "username",
+                  "custom_id"
+                ]
+              }
+            }
+          },
+          {
+            "consumer_optional": {
+              "default": false,
+              "description": "Do not terminate the request if consumer mapping fails.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "credential_claim": {
+              "required": false,
+              "default": [
+                "sub"
+              ],
+              "description": "The claim used to derive virtual credentials (e.g. to be consumed by the rate-limiting plugin), in case the consumer mapping is not used.",
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "anonymous": {
+              "description": "An optional string (consumer UUID or username) value that functions as an “anonymous” consumer if authentication fails. If empty (default null), requests that fail authentication will return a `4xx` HTTP status code. This value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "run_on_preflight": {
+              "default": true,
+              "description": "Specifies whether to run this plugin on pre-flight (`OPTIONS`) requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "leeway": {
+              "default": 0,
+              "description": "Allow some leeway (in seconds) on the ttl / expiry verification.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "verify_parameters": {
+              "default": false,
+              "description": "Verify plugin configuration against discovery.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "verify_nonce": {
+              "default": true,
+              "description": "Verify nonce on authorization code flow.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "verify_claims": {
+              "default": true,
+              "description": "Verify tokens for standard claims.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "verify_signature": {
+              "default": true,
+              "description": "Verify signature of tokens.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "ignore_signature": {
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Skip the token signature verification on certain grants: - `password`: OAuth password grant - `client_credentials`: OAuth client credentials grant - `authorization_code`: authorization code flow - `refresh_token`: OAuth refresh token grant - `session`: session cookie authentication - `introspection`: OAuth introspection - `userinfo`: OpenID Connect user info endpoint authentication",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "refresh_token",
+                  "session",
+                  "introspection",
+                  "userinfo"
+                ]
+              }
+            }
+          },
+          {
+            "enable_hs_signatures": {
+              "default": false,
+              "description": "Enable shared secret, for example, HS256, signatures (when disabled they will not be accepted).",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "disable_session": {
+              "required": false,
+              "description": "Disable issuing the session cookie with the specified grants.",
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "bearer",
+                  "introspection",
+                  "userinfo",
+                  "kong_oauth2",
+                  "refresh_token",
+                  "session"
+                ]
+              }
+            }
+          },
+          {
+            "cache_ttl": {
+              "default": 3600,
+              "description": "The default cache ttl in seconds that is used in case the cached object does not specify the expiry.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "cache_ttl_max": {
+              "description": "The maximum cache ttl in seconds (enforced).",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "cache_ttl_min": {
+              "description": "The minimum cache ttl in seconds (enforced).",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "cache_ttl_neg": {
+              "description": "The negative cache ttl in seconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "cache_ttl_resurrect": {
+              "description": "The resurrection ttl in seconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "cache_tokens": {
+              "default": true,
+              "description": "Cache the token endpoint requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "cache_tokens_salt": {
+              "auto": true,
+              "description": "Salt used for generating the cache key that is used for caching the token endpoint requests.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "cache_introspection": {
+              "default": true,
+              "description": "Cache the introspection endpoint requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "cache_token_exchange": {
+              "default": true,
+              "description": "Cache the token exchange endpoint requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "cache_user_info": {
+              "default": true,
+              "description": "Cache the user info requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "search_user_info": {
+              "default": false,
+              "description": "Specify whether to use the user info endpoint to get additional claims for consumer mapping, credential mapping, authenticated groups, and upstream and downstream headers.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "hide_credentials": {
+              "default": false,
+              "description": "Remove the credentials used for authentication from the request. If multiple credentials are sent with the same request, the plugin will remove those that were used for successful authentication.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "http_version": {
+              "default": 1.1,
+              "description": "The HTTP version used for the requests by this plugin: - `1.1`: HTTP 1.1 (the default) - `1.0`: HTTP 1.0",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "http_proxy": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "http_proxy_authorization": {
+              "description": "The HTTP proxy authorization.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "https_proxy": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "https_proxy_authorization": {
+              "description": "The HTTPS proxy authorization.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "no_proxy": {
+              "description": "Do not use proxy with these hosts.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "keepalive": {
+              "default": true,
+              "description": "Use keepalive with the HTTP client.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "ssl_verify": {
+              "default": false,
+              "description": "Verify identity provider server certificate.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "timeout": {
+              "default": 10000,
+              "description": "Network IO timeout in milliseconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "display_errors": {
+              "default": false,
+              "description": "Display errors on failure responses.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "by_username_ignore_case": {
+              "default": false,
+              "description": "If `consumer_by` is set to `username`, specify whether `username` can match consumers case-insensitively.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "resolve_distributed_claims": {
+              "default": false,
+              "description": "Distributed claims are represented by the `_claim_names` and `_claim_sources` members of the JSON object containing the claims. If this parameter is set to `true`, the plugin explicitly resolves these distributed claims.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "expose_error_code": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "type": "record",
         "shorthand_fields": [
           {
             "authorization_cookie_lifetime": {
@@ -112,2049 +2381,11 @@
             }
           }
         ],
-        "type": "record",
-        "fields": [
-          {
-            "issuer": {
-              "type": "string",
-              "required": true
-            }
-          },
-          {
-            "discovery_headers_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "discovery_headers_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "extra_jwks_uris": {
-              "type": "set",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "rediscovery_lifetime": {
-              "required": false,
-              "type": "number",
-              "default": 30
-            }
-          },
-          {
-            "auth_methods": {
-              "default": [
-                "password",
-                "client_credentials",
-                "authorization_code",
-                "bearer",
-                "introspection",
-                "userinfo",
-                "kong_oauth2",
-                "refresh_token",
-                "session"
-              ],
-              "elements": {
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "bearer",
-                  "introspection",
-                  "userinfo",
-                  "kong_oauth2",
-                  "refresh_token",
-                  "session"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "client_id": {
-              "encrypted": true,
-              "elements": {
-                "type": "string",
-                "referenceable": true
-              },
-              "type": "array",
-              "required": false
-            }
-          },
-          {
-            "client_secret": {
-              "encrypted": true,
-              "elements": {
-                "type": "string",
-                "referenceable": true
-              },
-              "type": "array",
-              "required": false
-            }
-          },
-          {
-            "client_auth": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "one_of": [
-                  "client_secret_basic",
-                  "client_secret_post",
-                  "client_secret_jwt",
-                  "private_key_jwt",
-                  "none"
-                ],
-                "type": "string"
-              }
-            }
-          },
-          {
-            "client_jwk": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "required": false,
-                "fields": [
-                  {
-                    "issuer": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "kty": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "use": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "key_ops": {
-                      "required": false,
-                      "type": "array",
-                      "elements": {
-                        "type": "string",
-                        "required": false
-                      }
-                    }
-                  },
-                  {
-                    "alg": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "kid": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "x5u": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "x5c": {
-                      "required": false,
-                      "type": "array",
-                      "elements": {
-                        "type": "string",
-                        "required": false
-                      }
-                    }
-                  },
-                  {
-                    "x5t": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "x5t#S256": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "k": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "x": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "y": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "crv": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "n": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "e": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "d": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "p": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "q": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "dp": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "dq": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "qi": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "oth": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "r": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  },
-                  {
-                    "t": {
-                      "required": false,
-                      "type": "string",
-                      "encrypted": true,
-                      "referenceable": true
-                    }
-                  }
-                ],
-                "type": "record"
-              }
-            }
-          },
-          {
-            "client_alg": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "one_of": [
-                  "HS256",
-                  "HS384",
-                  "HS512",
-                  "RS256",
-                  "RS384",
-                  "RS512",
-                  "ES256",
-                  "ES384",
-                  "ES512",
-                  "PS256",
-                  "PS384",
-                  "PS512",
-                  "EdDSA"
-                ],
-                "type": "string"
-              }
-            }
-          },
-          {
-            "client_arg": {
-              "required": false,
-              "type": "string",
-              "default": "client_id"
-            }
-          },
-          {
-            "redirect_uri": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "login_redirect_uri": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "logout_redirect_uri": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "forbidden_redirect_uri": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "forbidden_error_message": {
-              "required": false,
-              "type": "string",
-              "default": "Forbidden"
-            }
-          },
-          {
-            "forbidden_destroy_session": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "unauthorized_redirect_uri": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "unauthorized_error_message": {
-              "required": false,
-              "type": "string",
-              "default": "Unauthorized"
-            }
-          },
-          {
-            "unexpected_redirect_uri": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "response_mode": {
-              "default": "query",
-              "one_of": [
-                "query",
-                "form_post",
-                "fragment"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "response_type": {
-              "default": [
-                "code"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "scopes": {
-              "default": [
-                "openid"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "audience": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "issuers_allowed": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "scopes_required": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "scopes_claim": {
-              "default": [
-                "scope"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "audience_required": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "audience_claim": {
-              "default": [
-                "aud"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "groups_required": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "groups_claim": {
-              "default": [
-                "groups"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "roles_required": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "roles_claim": {
-              "default": [
-                "roles"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "domains": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "max_age": {
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "authenticated_groups_claim": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_query_args_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_query_args_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_query_args_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_rolling_timeout": {
-              "required": false,
-              "type": "number",
-              "default": 600
-            }
-          },
-          {
-            "authorization_cookie_name": {
-              "required": false,
-              "type": "string",
-              "default": "authorization"
-            }
-          },
-          {
-            "authorization_cookie_path": {
-              "match_none": [
-                {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
-                }
-              ],
-              "starts_with": "/",
-              "default": "/",
-              "required": false,
-              "type": "string"
-            }
-          },
-          {
-            "authorization_cookie_domain": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_same_site": {
-              "default": "Default",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_http_only": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "authorization_cookie_secure": {
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "preserve_query_args": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "token_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "required": false,
-              "one_of": [
-                "client_secret_basic",
-                "client_secret_post",
-                "client_secret_jwt",
-                "private_key_jwt",
-                "none"
-              ]
-            }
-          },
-          {
-            "token_headers_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_replay": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_prefix": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "token_headers_grants": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "refresh_token"
-                ],
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_post_args_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_post_args_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_post_args_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "introspection_endpoint_auth_method": {
-              "type": "string",
-              "required": false,
-              "one_of": [
-                "client_secret_basic",
-                "client_secret_post",
-                "client_secret_jwt",
-                "private_key_jwt",
-                "none"
-              ]
-            }
-          },
-          {
-            "introspection_hint": {
-              "required": false,
-              "type": "string",
-              "default": "access_token"
-            }
-          },
-          {
-            "introspection_check_active": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "introspection_accept": {
-              "default": "application/json",
-              "one_of": [
-                "application/json",
-                "application/token-introspection+jwt",
-                "application/jwt"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "introspection_headers_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_headers_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_headers_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_post_args_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_post_args_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_post_args_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspect_jwt_tokens": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "revocation_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "revocation_endpoint_auth_method": {
-              "type": "string",
-              "required": false,
-              "one_of": [
-                "client_secret_basic",
-                "client_secret_post",
-                "client_secret_jwt",
-                "private_key_jwt",
-                "none"
-              ]
-            }
-          },
-          {
-            "end_session_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "userinfo_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "userinfo_accept": {
-              "default": "application/json",
-              "one_of": [
-                "application/json",
-                "application/jwt"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "userinfo_headers_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_headers_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_headers_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_query_args_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_query_args_values": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_query_args_client": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_exchange_endpoint": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_secret": {
-              "required": false,
-              "encrypted": true,
-              "referenceable": true,
-              "type": "string"
-            }
-          },
-          {
-            "session_audience": {
-              "required": false,
-              "type": "string",
-              "default": "default"
-            }
-          },
-          {
-            "session_cookie_name": {
-              "required": false,
-              "type": "string",
-              "default": "session"
-            }
-          },
-          {
-            "session_remember": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_remember_cookie_name": {
-              "required": false,
-              "type": "string",
-              "default": "remember"
-            }
-          },
-          {
-            "session_remember_rolling_timeout": {
-              "required": false,
-              "type": "number",
-              "default": 604800
-            }
-          },
-          {
-            "session_remember_absolute_timeout": {
-              "required": false,
-              "type": "number",
-              "default": 2592000
-            }
-          },
-          {
-            "session_idling_timeout": {
-              "required": false,
-              "type": "number",
-              "default": 900
-            }
-          },
-          {
-            "session_rolling_timeout": {
-              "required": false,
-              "type": "number",
-              "default": 3600
-            }
-          },
-          {
-            "session_absolute_timeout": {
-              "required": false,
-              "type": "number",
-              "default": 86400
-            }
-          },
-          {
-            "session_cookie_path": {
-              "match_none": [
-                {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
-                }
-              ],
-              "starts_with": "/",
-              "default": "/",
-              "required": false,
-              "type": "string"
-            }
-          },
-          {
-            "session_cookie_domain": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_same_site": {
-              "default": "Lax",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_http_only": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "session_cookie_secure": {
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_request_headers": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ],
-                "type": "string"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "session_response_headers": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ],
-                "type": "string"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "session_storage": {
-              "default": "cookie",
-              "one_of": [
-                "cookie",
-                "memcache",
-                "memcached",
-                "redis"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_store_metadata": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_enforce_same_subject": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_hash_subject": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_hash_storage_key": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_memcached_prefix": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_socket": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_host": {
-              "required": false,
-              "type": "string",
-              "default": "127.0.0.1"
-            }
-          },
-          {
-            "session_memcached_port": {
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ],
-              "required": false,
-              "default": 11211
-            }
-          },
-          {
-            "session_redis_prefix": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_socket": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_host": {
-              "required": false,
-              "type": "string",
-              "default": "127.0.0.1"
-            }
-          },
-          {
-            "session_redis_port": {
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ],
-              "required": false,
-              "default": 6379
-            }
-          },
-          {
-            "session_redis_username": {
-              "type": "string",
-              "referenceable": true,
-              "required": false
-            }
-          },
-          {
-            "session_redis_password": {
-              "required": false,
-              "encrypted": true,
-              "referenceable": true,
-              "type": "string"
-            }
-          },
-          {
-            "session_redis_connect_timeout": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_read_timeout": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_send_timeout": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_redis_ssl_verify": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "session_redis_server_name": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_cluster_nodes": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "fields": [
-                  {
-                    "ip": {
-                      "type": "string",
-                      "default": "127.0.0.1",
-                      "required": true
-                    }
-                  },
-                  {
-                    "port": {
-                      "between": [
-                        0,
-                        65535
-                      ],
-                      "type": "integer",
-                      "default": 6379
-                    }
-                  }
-                ],
-                "type": "record"
-              }
-            }
-          },
-          {
-            "session_redis_cluster_max_redirections": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "reverify": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "jwt_session_claim": {
-              "required": false,
-              "type": "string",
-              "default": "sid"
-            }
-          },
-          {
-            "jwt_session_cookie": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "bearer_token_param_type": {
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "elements": {
-                "one_of": [
-                  "header",
-                  "cookie",
-                  "query",
-                  "body"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "bearer_token_cookie_name": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "client_credentials_param_type": {
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "elements": {
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "password_param_type": {
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "elements": {
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "id_token_param_type": {
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "elements": {
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "id_token_param_name": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "refresh_token_param_type": {
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "elements": {
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "refresh_token_param_name": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "refresh_tokens": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "upstream_headers_claims": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "upstream_headers_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "upstream_access_token_header": {
-              "required": false,
-              "type": "string",
-              "default": "authorization:bearer"
-            }
-          },
-          {
-            "upstream_access_token_jwk_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_id_token_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_id_token_jwk_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_refresh_token_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_user_info_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_user_info_jwt_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_introspection_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_introspection_jwt_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_session_id_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_headers_claims": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "downstream_headers_names": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "downstream_access_token_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_access_token_jwk_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_id_token_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_id_token_jwk_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_refresh_token_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_user_info_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_user_info_jwt_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_introspection_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_introspection_jwt_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_session_id_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "login_methods": {
-              "default": [
-                "authorization_code"
-              ],
-              "elements": {
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "bearer",
-                  "introspection",
-                  "userinfo",
-                  "kong_oauth2",
-                  "refresh_token",
-                  "session"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "login_action": {
-              "default": "upstream",
-              "one_of": [
-                "upstream",
-                "response",
-                "redirect"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "login_tokens": {
-              "default": [
-                "id_token"
-              ],
-              "elements": {
-                "one_of": [
-                  "id_token",
-                  "access_token",
-                  "refresh_token",
-                  "tokens",
-                  "introspection"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "login_redirect_mode": {
-              "default": "fragment",
-              "one_of": [
-                "query",
-                "fragment"
-              ],
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_query_arg": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_post_arg": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_uri_suffix": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_methods": {
-              "default": [
-                "POST",
-                "DELETE"
-              ],
-              "elements": {
-                "one_of": [
-                  "POST",
-                  "GET",
-                  "DELETE"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "logout_revoke": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "logout_revoke_access_token": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "logout_revoke_refresh_token": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "consumer_claim": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "consumer_by": {
-              "default": [
-                "username",
-                "custom_id"
-              ],
-              "elements": {
-                "one_of": [
-                  "id",
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "consumer_optional": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "credential_claim": {
-              "default": [
-                "sub"
-              ],
-              "elements": {
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "anonymous": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "run_on_preflight": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "leeway": {
-              "required": false,
-              "type": "number",
-              "default": 0
-            }
-          },
-          {
-            "verify_parameters": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "verify_nonce": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "verify_claims": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "verify_signature": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "ignore_signature": {
-              "default": [
-
-              ],
-              "elements": {
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "refresh_token",
-                  "session",
-                  "introspection",
-                  "userinfo"
-                ],
-                "type": "string"
-              },
-              "required": false,
-              "type": "array"
-            }
-          },
-          {
-            "enable_hs_signatures": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "disable_session": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "bearer",
-                  "introspection",
-                  "userinfo",
-                  "kong_oauth2",
-                  "refresh_token",
-                  "session"
-                ],
-                "type": "string"
-              }
-            }
-          },
-          {
-            "cache_ttl": {
-              "required": false,
-              "type": "number",
-              "default": 3600
-            }
-          },
-          {
-            "cache_ttl_max": {
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_min": {
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_neg": {
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_resurrect": {
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_tokens": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "cache_tokens_salt": {
-              "type": "string",
-              "auto": true,
-              "required": false
-            }
-          },
-          {
-            "cache_introspection": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "cache_token_exchange": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "cache_user_info": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "search_user_info": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "hide_credentials": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "http_version": {
-              "default": 1.1,
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "http_proxy": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "http_proxy_authorization": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "https_proxy": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "https_proxy_authorization": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "no_proxy": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "keepalive": {
-              "required": false,
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "ssl_verify": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "timeout": {
-              "required": false,
-              "type": "number",
-              "default": 10000
-            }
-          },
-          {
-            "display_errors": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "by_username_ignore_case": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          },
-          {
-            "resolve_distributed_claims": {
-              "required": false,
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
         "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/opentelemetry/3.4.x.json
+++ b/schemas/opentelemetry/3.4.x.json
@@ -2,41 +2,40 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "custom_entity_check": {
-              "field_sources": [
-                "batch_span_count",
-                "batch_flush_delay"
-              ]
-            }
-          }
-        ],
         "fields": [
           {
             "endpoint": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
               "type": "string",
               "required": true
             }
@@ -44,17 +43,20 @@
           {
             "headers": {
               "type": "map",
-              "keys": {
-                "type": "string"
-              },
+              "description": "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend.",
               "values": {
                 "type": "string",
                 "referenceable": true
+              },
+              "keys": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
               }
             }
           },
           {
             "resource_attributes": {
+              "type": "map",
               "values": {
                 "type": "string",
                 "required": true
@@ -62,109 +64,128 @@
               "keys": {
                 "type": "string",
                 "required": true
-              },
-              "type": "map"
-            }
-          },
-          {
-            "batch_span_count": {
-              "type": "integer"
-            }
-          },
-          {
-            "batch_flush_delay": {
-              "type": "integer"
+              }
             }
           },
           {
             "queue": {
-              "required": true,
               "fields": [
                 {
                   "max_batch_size": {
+                    "default": 1,
+                    "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_coalescing_delay": {
+                    "default": 1,
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
                     "between": [
                       0,
                       3600
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_entries": {
+                    "default": 10000,
+                    "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 10000
+                    ]
                   }
                 },
                 {
                   "max_bytes": {
-                    "type": "number"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
                   "max_retry_time": {
                     "default": 60,
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
                     "type": "number"
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "type": "number"
+                    "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "type": "number"
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
+            }
+          },
+          {
+            "batch_span_count": {
+              "type": "integer",
+              "description": "The number of spans to be sent in a single batch."
+            }
+          },
+          {
+            "batch_flush_delay": {
+              "type": "integer",
+              "description": "The delay, in seconds, between two consecutive batches."
             }
           },
           {
             "connect_timeout": {
+              "default": 1000,
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
               "between": [
                 0,
                 2147483646
-              ],
-              "type": "integer",
-              "default": 1000
+              ]
             }
           },
           {
             "send_timeout": {
+              "default": 5000,
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
               "between": [
                 0,
                 2147483646
-              ],
-              "type": "integer",
-              "default": 5000
+              ]
             }
           },
           {
             "read_timeout": {
+              "default": 5000,
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
               "between": [
                 0,
                 2147483646
-              ],
-              "type": "integer",
-              "default": 5000
+              ]
             }
           },
           {
@@ -174,6 +195,7 @@
           },
           {
             "header_type": {
+              "default": "preserve",
               "type": "string",
               "one_of": [
                 "preserve",
@@ -182,15 +204,29 @@
                 "b3-single",
                 "w3c",
                 "jaeger",
-                "ot"
+                "ot",
+                "aws"
               ],
-              "required": false,
-              "default": "preserve"
+              "required": false
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "custom_entity_check": {
+              "field_sources": [
+                "batch_span_count",
+                "batch_flush_delay"
+              ]
+            }
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/post-function/3.4.x.json
+++ b/schemas/post-function/3.4.x.json
@@ -10,8 +10,10 @@
           "ws",
           "wss"
         ],
+        "required": false,
         "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -19,28 +21,32 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": false
+          ]
+        }
       }
     },
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -52,28 +58,24 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "certificate": {
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -81,12 +83,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -94,12 +96,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -107,12 +109,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -120,12 +122,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -133,12 +135,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -146,12 +148,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -159,12 +161,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -172,12 +174,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -185,17 +187,34 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.certificate",
+        "config.rewrite",
+        "config.access",
+        "config.header_filter",
+        "config.body_filter",
+        "config.log",
+        "config.ws_handshake",
+        "config.ws_upstream_frame",
+        "config.ws_client_frame",
+        "config.ws_close"
+      ]
     }
   ]
 }

--- a/schemas/pre-function/3.4.x.json
+++ b/schemas/pre-function/3.4.x.json
@@ -10,8 +10,10 @@
           "ws",
           "wss"
         ],
+        "required": false,
         "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -19,28 +21,32 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": false
+          ]
+        }
       }
     },
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -52,28 +58,24 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "certificate": {
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -81,12 +83,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -94,12 +96,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -107,12 +109,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -120,12 +122,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -133,12 +135,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -146,12 +148,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -159,12 +161,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -172,12 +174,12 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
@@ -185,17 +187,34 @@
               "default": [
 
               ],
+              "required": true,
+              "type": "array",
               "elements": {
                 "type": "string",
                 "required": false
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.certificate",
+        "config.rewrite",
+        "config.access",
+        "config.header_filter",
+        "config.body_filter",
+        "config.log",
+        "config.ws_handshake",
+        "config.ws_upstream_frame",
+        "config.ws_client_frame",
+        "config.ws_close"
+      ]
     }
   ]
 }

--- a/schemas/prometheus/3.4.x.json
+++ b/schemas/prometheus/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,50 +25,63 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "per_consumer": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "A boolean value that determines if per-consumer metrics should be collected. If enabled, the `kong_http_requests_total` and `kong_bandwidth_bytes` metrics fill in the consumer label when available.",
+              "type": "boolean"
             }
           },
           {
             "status_code_metrics": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `http_requests_total`, `stream_sessions_total` metrics will be exported.",
+              "type": "boolean"
             }
           },
           {
             "latency_metrics": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `kong_latency_ms`, `upstream_latency_ms` and `request_latency_ms` metrics will be exported.",
+              "type": "boolean"
             }
           },
           {
             "bandwidth_metrics": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `bandwidth_bytes` and `stream_sessions_total` metrics will be exported.",
+              "type": "boolean"
             }
           },
           {
             "upstream_health_metrics": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `upstream_target_health` metric will be exported.",
+              "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/proxy-cache-advanced/3.4.x.json
+++ b/schemas/proxy-cache-advanced/3.4.x.json
@@ -2,151 +2,335 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "response_code": {
               "len_min": 1,
+              "required": true,
               "default": [
                 200,
                 301,
                 404
               ],
+              "description": "Upstream response status code considered cacheable. The integers must be a value between 100 and 900.",
+              "type": "array",
               "elements": {
+                "type": "integer",
                 "between": [
                   100,
                   900
-                ],
-                "type": "integer"
-              },
-              "required": true,
-              "type": "array"
+                ]
+              }
             }
           },
           {
             "request_method": {
+              "required": true,
               "default": [
                 "GET",
                 "HEAD"
               ],
+              "description": "Downstream request methods considered cacheable. Available options: `HEAD`, `GET`, `POST`, `PATCH`, `PUT`.",
+              "type": "array",
               "elements": {
+                "type": "string",
                 "one_of": [
                   "HEAD",
                   "GET",
                   "POST",
                   "PATCH",
                   "PUT"
-                ],
-                "type": "string"
-              },
-              "required": true,
-              "type": "array"
+                ]
+              }
             }
           },
           {
             "content_type": {
+              "required": true,
               "default": [
                 "text/plain",
                 "application/json"
               ],
+              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "required": true,
-              "type": "array"
+              }
             }
           },
           {
             "cache_ttl": {
               "default": 300,
               "gt": 0,
-              "type": "integer"
+              "type": "integer",
+              "description": "TTL in seconds of cache entities."
             }
           },
           {
             "strategy": {
-              "required": true,
               "type": "string",
+              "description": "The backing data store in which to hold cache entities. Accepted values are: `memory` and `redis`.",
               "one_of": [
                 "memory",
                 "redis"
-              ]
+              ],
+              "required": true
             }
           },
           {
             "cache_control": {
-              "required": true,
+              "default": false,
+              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "type": "boolean",
-              "default": false
+              "required": true
             }
           },
           {
             "ignore_uri_case": {
-              "required": false,
+              "default": false,
+              "description": "Determines whether to treat URIs as case sensitive. By default, case sensitivity is enabled. If set to true, requests are cached while ignoring case sensitivity in the URI.",
               "type": "boolean",
-              "default": false
+              "required": false
             }
           },
           {
             "storage_ttl": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors."
             }
           },
           {
             "memory": {
-              "required": true,
               "fields": [
                 {
                   "dictionary_name": {
-                    "required": true,
                     "default": "kong_db_cache",
-                    "type": "string"
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
+                    "type": "string",
+                    "required": true
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "vary_query_params": {
+              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "vary_headers": {
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "redis": {
+              "fields": [
+                {
+                  "host": {
+                    "type": "string",
+                    "description": "A string representing a host name, such as example.com."
+                  }
+                },
+                {
+                  "port": {
+                    "between": [
+                      0,
+                      65535
+                    ],
+                    "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "timeout": {
+                    "default": 2000,
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer",
+                    "between": [
+                      0,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "connect_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "send_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "read_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "username": {
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "password": {
+                    "encrypted": true,
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "sentinel_username": {
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "sentinel_password": {
+                    "encrypted": true,
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "database": {
+                    "type": "integer",
+                    "default": 0
+                  }
+                },
+                {
+                  "keepalive_pool_size": {
+                    "default": 30,
+                    "type": "integer",
+                    "between": [
+                      1,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "keepalive_backlog": {
+                    "type": "integer",
+                    "between": [
+                      0,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "sentinel_master": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "sentinel_role": {
+                    "type": "string",
+                    "one_of": [
+                      "master",
+                      "slave",
+                      "any"
+                    ]
+                  }
+                },
+                {
+                  "sentinel_addresses": {
+                    "len_min": 1,
+                    "type": "array",
+                    "elements": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "cluster_addresses": {
+                    "len_min": 1,
+                    "type": "array",
+                    "elements": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "ssl": {
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "ssl_verify": {
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "server_name": {
+                    "description": "A string representing an SNI (server name indication) value for TLS.",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              ],
               "required": true,
+              "type": "record",
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -204,175 +388,28 @@
                     "read_timeout"
                   ]
                 }
-              ],
-              "fields": [
-                {
-                  "host": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "port": {
-                    "between": [
-                      0,
-                      65535
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer",
-                    "default": 2000
-                  }
-                },
-                {
-                  "connect_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "send_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "read_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "username": {
-                    "type": "string",
-                    "referenceable": true
-                  }
-                },
-                {
-                  "password": {
-                    "referenceable": true,
-                    "encrypted": true,
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_username": {
-                    "type": "string",
-                    "referenceable": true
-                  }
-                },
-                {
-                  "sentinel_password": {
-                    "referenceable": true,
-                    "encrypted": true,
-                    "type": "string"
-                  }
-                },
-                {
-                  "database": {
-                    "type": "integer",
-                    "default": 0
-                  }
-                },
-                {
-                  "keepalive_pool_size": {
-                    "between": [
-                      1,
-                      2147483646
-                    ],
-                    "default": 30,
-                    "type": "integer"
-                  }
-                },
-                {
-                  "keepalive_backlog": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "sentinel_master": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_role": {
-                    "one_of": [
-                      "master",
-                      "slave",
-                      "any"
-                    ],
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_addresses": {
-                    "len_min": 1,
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                },
-                {
-                  "cluster_addresses": {
-                    "len_min": 1,
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                },
-                {
-                  "ssl": {
-                    "default": false,
-                    "required": false,
-                    "type": "boolean"
-                  }
-                },
-                {
-                  "ssl_verify": {
-                    "default": false,
-                    "required": false,
-                    "type": "boolean"
-                  }
-                },
-                {
-                  "server_name": {
-                    "type": "string",
-                    "required": false
-                  }
-                }
-              ],
-              "type": "record"
+              ]
             }
           },
           {
             "bypass_on_err": {
               "default": false,
+              "description": "Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream.",
               "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config"
+        ]
       }
     }
   ]

--- a/schemas/proxy-cache/3.4.x.json
+++ b/schemas/proxy-cache/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,137 +25,153 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "response_code": {
               "len_min": 1,
+              "required": true,
               "default": [
                 200,
                 301,
                 404
               ],
+              "description": "Upstream response status code considered cacheable.",
+              "type": "array",
               "elements": {
+                "type": "integer",
                 "between": [
                   100,
                   900
-                ],
-                "type": "integer"
-              },
-              "required": true,
-              "type": "array"
+                ]
+              }
             }
           },
           {
             "request_method": {
+              "required": true,
               "default": [
                 "GET",
                 "HEAD"
               ],
+              "description": "Downstream request methods considered cacheable.",
+              "type": "array",
               "elements": {
+                "type": "string",
                 "one_of": [
                   "HEAD",
                   "GET",
                   "POST",
                   "PATCH",
                   "PUT"
-                ],
-                "type": "string"
-              },
-              "type": "array",
-              "required": true
+                ]
+              }
             }
           },
           {
             "content_type": {
+              "required": true,
               "default": [
                 "text/plain",
                 "application/json"
               ],
+              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "required": true
+              }
             }
           },
           {
             "cache_ttl": {
               "default": 300,
-              "gt": 0,
-              "type": "integer"
+              "description": "TTL, in seconds, of cache entities.",
+              "type": "integer",
+              "gt": 0
             }
           },
           {
             "strategy": {
               "type": "string",
-              "required": true,
+              "description": "The backing data store in which to hold cache entities.",
               "one_of": [
                 "memory"
-              ]
+              ],
+              "required": true
             }
           },
           {
             "cache_control": {
+              "default": false,
+              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "ignore_uri_case": {
+              "default": false,
               "type": "boolean",
-              "required": false,
-              "default": false
+              "required": false
             }
           },
           {
             "storage_ttl": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors."
             }
           },
           {
             "memory": {
-              "required": true,
               "fields": [
                 {
                   "dictionary_name": {
-                    "required": true,
+                    "default": "kong_db_cache",
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
                     "type": "string",
-                    "default": "kong_db_cache"
+                    "required": true
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "vary_query_params": {
+              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "vary_headers": {
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config"
+        ]
       }
     }
   ]

--- a/schemas/rate-limiting-advanced/3.4.x.json
+++ b/schemas/rate-limiting-advanced/3.4.x.json
@@ -2,31 +2,34 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "identifier": {
+              "required": true,
+              "default": "consumer",
+              "description": "The type of identifier used to generate the rate limit key. Defines the scope used to increment the rate limiting counters. Can be `ip`, `credential`, `consumer`, `service`, `header`, or `path`.",
               "type": "string",
               "one_of": [
                 "ip",
@@ -35,14 +38,13 @@
                 "service",
                 "header",
                 "path"
-              ],
-              "default": "consumer",
-              "required": true
+              ]
             }
           },
           {
             "window_size": {
               "required": true,
+              "description": "One or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.",
               "type": "array",
               "elements": {
                 "type": "number"
@@ -52,6 +54,7 @@
           {
             "window_type": {
               "default": "sliding",
+              "description": "Sets the time window type to either `sliding` (default) or `fixed`. Sliding windows apply the rate limiting logic while taking into account previous hit rates (from the window that immediately precedes the current) using a dynamic weight. Fixed windows consist of buckets that are statically assigned to a definitive time range, each request is mapped to only one fixed window based on its timestamp and will affect only that window's counters.",
               "type": "string",
               "one_of": [
                 "fixed",
@@ -62,6 +65,7 @@
           {
             "limit": {
               "required": true,
+              "description": "One or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.",
               "type": "array",
               "elements": {
                 "type": "number"
@@ -70,67 +74,240 @@
           },
           {
             "sync_rate": {
-              "type": "number"
+              "type": "number",
+              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 will sync the counters in the specified number of seconds. The minimum allowed interval is 0.02 seconds (20ms)."
             }
           },
           {
             "namespace": {
-              "required": true,
               "auto": true,
-              "type": "string"
+              "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "strategy": {
+              "required": true,
+              "default": "local",
+              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits. Available values are: `local` and `cluster`.",
               "type": "string",
               "one_of": [
                 "cluster",
                 "redis",
                 "local"
-              ],
-              "default": "local",
-              "required": true
+              ]
             }
           },
           {
             "dictionary_name": {
-              "required": true,
               "default": "kong_rate_limiting_counters",
-              "type": "string"
+              "description": "The shared dictionary where counters are stored. When the plugin is configured to synchronize counter data externally (that is `config.strategy` is `cluster` or `redis` and `config.sync_rate` isn't `-1`), this dictionary serves as a buffer to populate counters in the data store on each synchronization cycle.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "hide_client_headers": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Optionally hide informative response headers that would otherwise provide information about the current status of limits and counters.",
+              "type": "boolean"
             }
           },
           {
             "retry_after_jitter_max": {
-              "type": "number",
-              "default": 0
+              "default": 0,
+              "description": "The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.",
+              "type": "number"
             }
           },
           {
             "header_name": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           },
           {
             "path": {
+              "starts_with": "/",
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "type": "string",
               "match_none": [
                 {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
+                  "pattern": "//",
+                  "err": "must not have empty segments"
                 }
-              ],
-              "starts_with": "/",
-              "type": "string"
+              ]
             }
           },
           {
             "redis": {
+              "fields": [
+                {
+                  "host": {
+                    "type": "string",
+                    "description": "A string representing a host name, such as example.com."
+                  }
+                },
+                {
+                  "port": {
+                    "between": [
+                      0,
+                      65535
+                    ],
+                    "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "timeout": {
+                    "default": 2000,
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer",
+                    "between": [
+                      0,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "connect_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "send_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "read_timeout": {
+                    "between": [
+                      0,
+                      2147483646
+                    ],
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+                    "type": "integer"
+                  }
+                },
+                {
+                  "username": {
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "password": {
+                    "encrypted": true,
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "sentinel_username": {
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "sentinel_password": {
+                    "encrypted": true,
+                    "type": "string",
+                    "referenceable": true
+                  }
+                },
+                {
+                  "database": {
+                    "type": "integer",
+                    "default": 0
+                  }
+                },
+                {
+                  "keepalive_pool_size": {
+                    "default": 30,
+                    "type": "integer",
+                    "between": [
+                      1,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "keepalive_backlog": {
+                    "type": "integer",
+                    "between": [
+                      0,
+                      2147483646
+                    ]
+                  }
+                },
+                {
+                  "sentinel_master": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "sentinel_role": {
+                    "type": "string",
+                    "one_of": [
+                      "master",
+                      "slave",
+                      "any"
+                    ]
+                  }
+                },
+                {
+                  "sentinel_addresses": {
+                    "len_min": 1,
+                    "type": "array",
+                    "elements": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "cluster_addresses": {
+                    "len_min": 1,
+                    "type": "array",
+                    "elements": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "ssl": {
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "ssl_verify": {
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
+                  }
+                },
+                {
+                  "server_name": {
+                    "description": "A string representing an SNI (server name indication) value for TLS.",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              ],
               "required": true,
+              "type": "record",
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -188,202 +365,59 @@
                     "read_timeout"
                   ]
                 }
-              ],
-              "fields": [
-                {
-                  "host": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "port": {
-                    "between": [
-                      0,
-                      65535
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer",
-                    "default": 2000
-                  }
-                },
-                {
-                  "connect_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "send_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "read_timeout": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "username": {
-                    "type": "string",
-                    "referenceable": true
-                  }
-                },
-                {
-                  "password": {
-                    "referenceable": true,
-                    "encrypted": true,
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_username": {
-                    "type": "string",
-                    "referenceable": true
-                  }
-                },
-                {
-                  "sentinel_password": {
-                    "referenceable": true,
-                    "encrypted": true,
-                    "type": "string"
-                  }
-                },
-                {
-                  "database": {
-                    "type": "integer",
-                    "default": 0
-                  }
-                },
-                {
-                  "keepalive_pool_size": {
-                    "between": [
-                      1,
-                      2147483646
-                    ],
-                    "default": 30,
-                    "type": "integer"
-                  }
-                },
-                {
-                  "keepalive_backlog": {
-                    "between": [
-                      0,
-                      2147483646
-                    ],
-                    "type": "integer"
-                  }
-                },
-                {
-                  "sentinel_master": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_role": {
-                    "one_of": [
-                      "master",
-                      "slave",
-                      "any"
-                    ],
-                    "type": "string"
-                  }
-                },
-                {
-                  "sentinel_addresses": {
-                    "len_min": 1,
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                },
-                {
-                  "cluster_addresses": {
-                    "len_min": 1,
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                },
-                {
-                  "ssl": {
-                    "default": false,
-                    "required": false,
-                    "type": "boolean"
-                  }
-                },
-                {
-                  "ssl_verify": {
-                    "default": false,
-                    "required": false,
-                    "type": "boolean"
-                  }
-                },
-                {
-                  "server_name": {
-                    "type": "string",
-                    "required": false
-                  }
-                }
-              ],
-              "type": "record"
+              ]
             }
           },
           {
             "enforce_consumer_groups": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`. Flipping `enforce_consumer_groups` from `true` to `false` disables the group override, but does not clear the list of consumer groups. You can then flip `enforce_consumer_groups` to `true` to re-enforce the groups.",
+              "type": "boolean"
             }
           },
           {
             "consumer_groups": {
+              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`. Flipping `enforce_consumer_groups` from `true` to `false` disables the group override, but does not clear the list of consumer groups. You can then flip `enforce_consumer_groups` to `true` to re-enforce the groups.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "disable_penalty": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "If set to `true`, this doesn't count denied requests (status = `429`). If set to `false`, all requests, including denied ones, are counted. This parameter only affects the `sliding` window_type.",
+              "type": "boolean"
             }
           },
           {
             "error_code": {
+              "default": 429,
+              "description": "Set a custom error code to return when the rate limit is exceeded.",
               "type": "number",
-              "gt": 0,
-              "default": 429
+              "gt": 0
             }
           },
           {
             "error_message": {
-              "type": "string",
-              "default": "API rate limit exceeded"
+              "default": "API rate limit exceeded",
+              "description": "Set a custom error message to return when the rate limit is exceeded.",
+              "type": "string"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config"
+        ]
       }
     }
   ]

--- a/schemas/rate-limiting/3.4.x.json
+++ b/schemas/rate-limiting/3.4.x.json
@@ -2,68 +2,83 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "second": {
               "gt": 0,
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per second."
             }
           },
           {
             "minute": {
               "gt": 0,
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per minute."
             }
           },
           {
             "hour": {
               "gt": 0,
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per hour."
             }
           },
           {
             "day": {
               "gt": 0,
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per day."
             }
           },
           {
             "month": {
               "gt": 0,
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per month."
             }
           },
           {
             "year": {
               "gt": 0,
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per year."
             }
           },
           {
             "limit_by": {
               "default": "consumer",
+              "description": "The entity that is used when aggregating the limits.",
               "type": "string",
               "one_of": [
                 "consumer",
@@ -77,64 +92,72 @@
           },
           {
             "header_name": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           },
           {
             "path": {
+              "starts_with": "/",
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "type": "string",
               "match_none": [
                 {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
+                  "pattern": "//",
+                  "err": "must not have empty segments"
                 }
-              ],
-              "starts_with": "/",
-              "type": "string"
+              ]
             }
           },
           {
             "policy": {
+              "default": "local",
+              "len_min": 0,
+              "description": "The rate-limiting policies to use for retrieving and incrementing the limits.",
               "one_of": [
                 "local",
                 "cluster",
                 "redis"
               ],
-              "len_min": 0,
-              "type": "string",
-              "default": "local"
+              "type": "string"
             }
           },
           {
             "fault_tolerant": {
               "default": true,
-              "required": true,
-              "type": "boolean"
+              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party data store. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the data store is working again. If `false`, then the clients will see `500` errors.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "redis_host": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "redis_port": {
+              "default": 6379,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "type": "integer",
-              "default": 6379
+              ]
             }
           },
           {
             "redis_password": {
               "len_min": 0,
+              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
               "type": "string",
               "referenceable": true
             }
           },
           {
             "redis_username": {
+              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.",
               "type": "string",
               "referenceable": true
             }
@@ -142,56 +165,145 @@
           {
             "redis_ssl": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "redis_ssl_verify": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "redis_server_name": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an SNI (server name indication) value for TLS."
             }
           },
           {
             "redis_timeout": {
-              "type": "number",
-              "default": 2000
+              "default": 2000,
+              "description": "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.",
+              "type": "number"
             }
           },
           {
             "redis_database": {
-              "type": "integer",
-              "default": 0
+              "default": 0,
+              "description": "When using the `redis` policy, this property specifies the Redis database to use.",
+              "type": "integer"
             }
           },
           {
             "hide_client_headers": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Optionally hide informative response headers.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "error_code": {
-              "type": "number",
+              "default": 429,
               "gt": 0,
-              "default": 429
+              "type": "number",
+              "description": "Set a custom error code to return when the rate limit is exceeded."
             }
           },
           {
             "error_message": {
-              "type": "string",
-              "default": "API rate limit exceeded"
+              "default": "API rate limit exceeded",
+              "description": "Set a custom error message to return when the rate limit is exceeded.",
+              "type": "string"
+            }
+          },
+          {
+            "sync_rate": {
+              "default": -1,
+              "description": "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior.",
+              "type": "number",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.second",
+        "config.minute",
+        "config.hour",
+        "config.day",
+        "config.month",
+        "config.year"
+      ]
+    },
+    {
+      "conditional": {
+        "if_field": "config.policy",
+        "then_field": "config.redis_host",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.policy",
+        "then_field": "config.redis_port",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.limit_by",
+        "then_field": "config.header_name",
+        "if_match": {
+          "eq": "header"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.limit_by",
+        "then_field": "config.path",
+        "if_match": {
+          "eq": "path"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.policy",
+        "then_field": "config.redis_timeout",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_match": {
+          "required": true
+        }
       }
     }
   ]

--- a/schemas/request-size-limiting/3.4.x.json
+++ b/schemas/request-size-limiting/3.4.x.json
@@ -2,57 +2,64 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "allowed_payload_size": {
               "default": 128,
+              "description": "Allowed request payload size in megabytes. Default is `128` megabytes (128000000 bytes).",
               "type": "integer"
             }
           },
           {
             "size_unit": {
+              "required": true,
               "default": "megabytes",
+              "description": "Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is not available in versions prior to Kong Gateway 1.3 and Kong Gateway (OSS) 2.0.",
+              "type": "string",
               "one_of": [
                 "megabytes",
                 "kilobytes",
                 "bytes"
-              ],
-              "required": true,
-              "type": "string"
+              ]
             }
           },
           {
             "require_content_length": {
               "default": false,
+              "description": "Set to `true` to ensure a valid `Content-Length` header exists before reading the request body.",
               "type": "boolean",
               "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/request-termination/3.4.x.json
+++ b/schemas/request-termination/3.4.x.json
@@ -2,70 +2,88 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "status_code": {
+              "required": true,
+              "default": 503,
+              "description": "The response code to send. Must be an integer between 100 and 599.",
               "type": "integer",
               "between": [
                 100,
                 599
-              ],
-              "default": 503,
-              "required": true
+              ]
             }
           },
           {
             "message": {
-              "type": "string"
+              "type": "string",
+              "description": "The message to send, if using the default response generator."
             }
           },
           {
             "content_type": {
-              "type": "string"
+              "type": "string",
+              "description": "Content type of the raw response configured with `config.body`."
             }
           },
           {
             "body": {
-              "type": "string"
+              "type": "string",
+              "description": "The raw response body to send. This is mutually exclusive with the `config.message` field."
             }
           },
           {
             "echo": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "When set, the plugin will echo a copy of the request back to the client. The main usecase for this is debugging. It can be combined with `trigger` in order to debug requests on live systems without disturbing real traffic.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "trigger": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/request-transformer-advanced/3.4.x.json
+++ b/schemas/request-transformer-advanced/3.4.x.json
@@ -2,45 +2,45 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "http_method": {
-              "match": "^%u+$",
-              "type": "string"
+              "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
+              "type": "string",
+              "match": "^%u+$"
             }
           },
           {
             "remove": {
-              "required": true,
               "fields": [
                 {
                   "body": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -48,10 +48,10 @@
                 },
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -59,77 +59,77 @@
                 },
                 {
                   "querystring": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
               "fields": [
                 {
                   "body": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "referenceable": true,
-                      "type": "string"
+                      "type": "string",
+                      "referenceable": true
                     }
                   }
                 },
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "referenceable": true,
-                      "type": "string"
+                      "type": "string",
+                      "referenceable": true
                     }
                   }
                 },
                 {
                   "querystring": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "referenceable": true,
-                      "type": "string"
+                      "type": "string",
+                      "referenceable": true
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "referenceable": true,
-                      "type": "string"
-                    },
-                    "type": "array"
+                      "type": "string",
+                      "referenceable": true
+                    }
                   }
                 },
                 {
@@ -137,11 +137,11 @@
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "referenceable": true,
-                      "type": "string"
-                    },
-                    "type": "array"
+                      "type": "string",
+                      "referenceable": true
+                    }
                   }
                 },
                 {
@@ -149,15 +149,19 @@
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "referenceable": true,
-                      "type": "string"
-                    },
-                    "type": "array"
+                      "type": "string",
+                      "referenceable": true
+                    }
                   }
                 },
                 {
                   "json_types": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "one_of": [
@@ -165,11 +169,7 @@
                         "number",
                         "string"
                       ]
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
@@ -178,154 +178,160 @@
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
               "fields": [
                 {
                   "body": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "referenceable": true
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "headers": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "referenceable": true
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "querystring": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "referenceable": true
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "json_types": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
               "fields": [
                 {
                   "body": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "referenceable": true
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "headers": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "referenceable": true
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "querystring": {
+                    "default": [
+
+                    ],
+                    "type": "array",
                     "elements": {
                       "type": "string",
                       "referenceable": true
-                    },
-                    "type": "array",
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "json_types": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
+                      ]
+                    }
+                  }
+                }
+              ],
+              "type": "record",
+              "required": true
+            }
+          },
+          {
+            "allow": {
+              "fields": [
+                {
+                  "body": {
+                    "type": "set",
+                    "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
-            }
-          },
-          {
-            "allow": {
-              "required": true,
-              "fields": [
-                {
-                  "body": {
-                    "elements": {
-                      "type": "string"
-                    },
-                    "type": "set"
-                  }
-                }
-              ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "dots_in_keys": {
               "default": true,
+              "description": "Specify whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects.  See [Arrays and nested objects](#arrays-and-nested-objects).",
               "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/request-transformer/3.4.x.json
+++ b/schemas/request-transformer/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,37 +25,33 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "http_method": {
-              "match": "^%u+$",
-              "type": "string"
+              "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
+              "type": "string",
+              "match": "^%u+$"
             }
           },
           {
             "remove": {
-              "required": true,
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 },
                 {
@@ -58,11 +59,11 @@
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 },
                 {
@@ -70,31 +71,31 @@
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 },
                 {
@@ -102,12 +103,12 @@
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
+                    "required": true,
                     "type": "array",
-                    "required": true
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 },
                 {
@@ -115,28 +116,28 @@
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
               "fields": [
                 {
                   "body": {
-                    "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -144,24 +145,24 @@
                 },
                 {
                   "headers": {
-                    "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "querystring": {
-                    "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -173,23 +174,23 @@
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 },
                 {
@@ -197,12 +198,12 @@
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
+                    "required": true,
                     "type": "array",
-                    "required": true
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 },
                 {
@@ -210,31 +211,31 @@
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 },
                 {
@@ -242,12 +243,12 @@
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
+                    "required": true,
                     "type": "array",
-                    "required": true
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 },
                 {
@@ -255,20 +256,25 @@
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "array",
-                    "required": true
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/request-validator/3.4.x.json
+++ b/schemas/request-validator/3.4.x.json
@@ -2,49 +2,51 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "at_least_one_of": [
-              "body_schema",
-              "parameter_schema"
-            ]
-          }
-        ],
         "fields": [
           {
             "body_schema": {
-              "required": false,
-              "type": "string"
+              "description": "The request body schema specification. One of `body_schema` or `parameter_schema` must be specified.",
+              "type": "string",
+              "required": false
             }
           },
           {
             "allowed_content_types": {
-              "type": "set",
               "default": [
                 "application/json"
               ],
+              "description": "List of allowed content types. The value can be configured with the `charset` parameter. For example, `application/json; charset=UTF-8`.",
+              "type": "set",
               "elements": {
                 "type": "string",
                 "required": true
@@ -53,20 +55,72 @@
           },
           {
             "version": {
+              "required": true,
+              "default": "kong",
+              "description": "Which validator to use. Supported values are `kong` (default) for using Kong's own schema validator, or `draft4` for using a JSON Schema Draft 4-compliant validator.",
               "one_of": [
                 "kong",
                 "draft4"
               ],
-              "default": "kong",
-              "type": "string",
-              "required": true
+              "type": "string"
             }
           },
           {
             "parameter_schema": {
-              "type": "array",
               "required": false,
+              "description": "Array of parameter validator specification. One of `body_schema` or `parameter_schema` must be specified.",
+              "type": "array",
               "elements": {
+                "fields": [
+                  {
+                    "in": {
+                      "type": "string",
+                      "one_of": [
+                        "query",
+                        "header",
+                        "path"
+                      ],
+                      "required": true
+                    }
+                  },
+                  {
+                    "name": {
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  {
+                    "required": {
+                      "type": "boolean",
+                      "required": true
+                    }
+                  },
+                  {
+                    "style": {
+                      "type": "string",
+                      "one_of": [
+                        "label",
+                        "form",
+                        "matrix",
+                        "simple",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                      ]
+                    }
+                  },
+                  {
+                    "explode": {
+                      "type": "boolean"
+                    }
+                  },
+                  {
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "type": "record",
                 "entity_checks": [
                   {
                     "mutually_required": [
@@ -83,69 +137,38 @@
                       ]
                     }
                   }
-                ],
-                "fields": [
-                  {
-                    "in": {
-                      "required": true,
-                      "type": "string",
-                      "one_of": [
-                        "query",
-                        "header",
-                        "path"
-                      ]
-                    }
-                  },
-                  {
-                    "name": {
-                      "required": true,
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "required": {
-                      "required": true,
-                      "type": "boolean"
-                    }
-                  },
-                  {
-                    "style": {
-                      "one_of": [
-                        "label",
-                        "form",
-                        "matrix",
-                        "simple",
-                        "spaceDelimited",
-                        "pipeDelimited",
-                        "deepObject"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  {
-                    "explode": {
-                      "type": "boolean"
-                    }
-                  },
-                  {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                ],
-                "type": "record"
+                ]
               }
             }
           },
           {
             "verbose_response": {
+              "default": false,
+              "description": "If enabled, the plugin returns more verbose and detailed validation errors.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "at_least_one_of": [
+              "body_schema",
+              "parameter_schema"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "custom_entity_check": {
+        "field_sources": [
+          "config"
+        ]
       }
     }
   ]

--- a/schemas/response-ratelimiting/3.4.x.json
+++ b/schemas/response-ratelimiting/3.4.x.json
@@ -2,38 +2,48 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "header_name": {
-              "type": "string",
-              "default": "x-kong-limit"
+              "default": "x-kong-limit",
+              "description": "The name of the response header used to increment the counters.",
+              "type": "string"
             }
           },
           {
             "limit_by": {
               "default": "consumer",
+              "description": "The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.",
               "type": "string",
               "one_of": [
                 "consumer",
@@ -45,6 +55,7 @@
           {
             "policy": {
               "default": "local",
+              "description": "The rate-limiting policies to use for retrieving and incrementing the limits.",
               "type": "string",
               "one_of": [
                 "local",
@@ -55,91 +66,138 @@
           },
           {
             "fault_tolerant": {
+              "default": true,
+              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors.",
               "type": "boolean",
-              "required": true,
-              "default": true
+              "required": true
             }
           },
           {
             "redis_host": {
-              "type": "string"
+              "type": "string",
+              "description": "When using the `redis` policy, this property specifies the address to the Redis server."
             }
           },
           {
             "redis_port": {
+              "default": 6379,
+              "description": "When using the `redis` policy, this property specifies the port of the Redis server.",
+              "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "type": "integer",
-              "default": 6379
+              ]
             }
           },
           {
             "redis_password": {
               "len_min": 0,
+              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
               "type": "string",
               "referenceable": true
             }
           },
           {
             "redis_username": {
+              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.\nThis requires Redis v6.0.0+. The username **cannot** be set to `default`.",
               "type": "string",
               "referenceable": true
             }
           },
           {
             "redis_ssl": {
+              "default": false,
+              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "redis_ssl_verify": {
+              "default": false,
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "redis_server_name": {
-              "type": "string"
+              "type": "string",
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI)."
             }
           },
           {
             "redis_timeout": {
-              "type": "number",
-              "default": 2000
+              "default": 2000,
+              "description": "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.",
+              "type": "number"
             }
           },
           {
             "redis_database": {
-              "type": "number",
-              "default": 0
+              "default": 0,
+              "description": "When using the `redis` policy, this property specifies Redis database to use.",
+              "type": "number"
             }
           },
           {
             "block_on_first_violation": {
+              "default": false,
+              "description": "A boolean value that determines if the requests should be blocked as soon as one limit is being exceeded. This will block requests that are supposed to consume other limits too.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "hide_client_headers": {
+              "default": false,
+              "description": "Optionally hide informative response headers.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "limits": {
-              "len_min": 1,
-              "keys": {
-                "type": "string"
-              },
               "values": {
+                "required": true,
+                "fields": [
+                  {
+                    "second": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  },
+                  {
+                    "minute": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  },
+                  {
+                    "hour": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  },
+                  {
+                    "day": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  },
+                  {
+                    "month": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  },
+                  {
+                    "year": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  }
+                ],
                 "type": "record",
                 "entity_checks": [
                   {
@@ -152,53 +210,58 @@
                       "year"
                     ]
                   }
-                ],
-                "fields": [
-                  {
-                    "second": {
-                      "gt": 0,
-                      "type": "number"
-                    }
-                  },
-                  {
-                    "minute": {
-                      "gt": 0,
-                      "type": "number"
-                    }
-                  },
-                  {
-                    "hour": {
-                      "gt": 0,
-                      "type": "number"
-                    }
-                  },
-                  {
-                    "day": {
-                      "gt": 0,
-                      "type": "number"
-                    }
-                  },
-                  {
-                    "month": {
-                      "gt": 0,
-                      "type": "number"
-                    }
-                  },
-                  {
-                    "year": {
-                      "gt": 0,
-                      "type": "number"
-                    }
-                  }
-                ],
-                "required": true
+                ]
               },
               "required": true,
-              "type": "map"
+              "len_min": 1,
+              "description": "A map that defines rate limits for the plugin.",
+              "type": "map",
+              "keys": {
+                "type": "string"
+              }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "conditional": {
+        "if_field": "config.policy",
+        "then_field": "config.redis_host",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.policy",
+        "then_field": "config.redis_port",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
+        "if_field": "config.policy",
+        "then_field": "config.redis_timeout",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_match": {
+          "required": true
+        }
       }
     }
   ]

--- a/schemas/response-transformer-advanced/3.4.x.json
+++ b/schemas/response-transformer-advanced/3.4.x.json
@@ -2,39 +2,38 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "remove": {
-              "required": true,
               "fields": [
                 {
                   "json": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -42,10 +41,10 @@
                 },
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -53,65 +52,66 @@
                 },
                 {
                   "if_status": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
               "fields": [
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "if_status": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
               "fields": [
                 {
                   "body": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "String with which to replace the entire response body."
                   }
                 },
                 {
                   "json": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -119,26 +119,26 @@
                 },
                 {
                   "json_types": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   }
                 },
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -146,29 +146,29 @@
                 },
                 {
                   "if_status": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
               "fields": [
                 {
                   "json": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -176,26 +176,26 @@
                 },
                 {
                   "json_types": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   }
                 },
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -203,29 +203,29 @@
                 },
                 {
                   "if_status": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
               "fields": [
                 {
                   "json": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -233,26 +233,26 @@
                 },
                 {
                   "json_types": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   }
                 },
                 {
                   "headers": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -260,45 +260,45 @@
                 },
                 {
                   "if_status": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "allow": {
-              "required": true,
               "fields": [
                 {
                   "json": {
+                    "type": "set",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "set"
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "transform": {
-              "required": true,
               "fields": [
                 {
                   "functions": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -306,10 +306,10 @@
                 },
                 {
                   "if_status": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -317,28 +317,34 @@
                 },
                 {
                   "json": {
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "dots_in_keys": {
               "default": true,
+              "description": "Whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects..",
               "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/response-transformer/3.4.x.json
+++ b/schemas/response-transformer/3.4.x.json
@@ -2,43 +2,42 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "remove": {
-              "required": true,
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "required": true,
-                    "type": "array"
+                    }
                   }
                 },
                 {
@@ -46,70 +45,71 @@
                     "default": [
 
                     ],
+                    "required": true,
+                    "type": "array",
                     "elements": {
                       "type": "string"
-                    },
-                    "required": true,
-                    "type": "array"
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
               "fields": [
                 {
                   "headers": {
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 },
                 {
                   "json_types": {
+                    "required": true,
                     "default": [
 
                     ],
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
-                    },
-                    "required": true,
-                    "type": "array"
+                      ]
+                    }
                   }
                 },
                 {
@@ -117,50 +117,51 @@
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 },
                 {
                   "json_types": {
+                    "required": true,
                     "default": [
 
                     ],
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
-                    },
-                    "required": true,
-                    "type": "array"
+                      ]
+                    }
                   }
                 },
                 {
@@ -168,50 +169,51 @@
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 },
                 {
                   "json_types": {
+                    "required": true,
                     "default": [
 
                     ],
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
+                    "type": "array",
                     "elements": {
+                      "type": "string",
                       "one_of": [
                         "boolean",
                         "number",
                         "string"
-                      ],
-                      "type": "string"
-                    },
-                    "required": true,
-                    "type": "array"
+                      ]
+                    }
                   }
                 },
                 {
@@ -219,21 +221,26 @@
                     "default": [
 
                     ],
-                    "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
-                    },
                     "required": true,
-                    "type": "array"
+                    "type": "array",
+                    "elements": {
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
+                    }
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/route-by-header/3.4.x.json
+++ b/schemas/route-by-header/3.4.x.json
@@ -2,36 +2,46 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "rules": {
-              "type": "array",
               "default": [
 
               ],
+              "description": "Route by header rules.",
+              "type": "array",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "upstream_name": {
@@ -41,25 +51,28 @@
                   },
                   {
                     "condition": {
-                      "len_min": 1,
-                      "keys": {
-                        "type": "string"
-                      },
                       "values": {
                         "type": "string"
                       },
                       "required": true,
-                      "type": "map"
+                      "len_min": 1,
+                      "type": "map",
+                      "keys": {
+                        "type": "string"
+                      }
                     }
                   }
-                ],
-                "type": "record"
+                ]
               }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/route-transformer-advanced/3.4.x.json
+++ b/schemas/route-transformer-advanced/3.4.x.json
@@ -2,37 +2,36 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "at_least_one_of": [
-              "path",
-              "port",
-              "host"
-            ]
-          }
-        ],
         "fields": [
           {
             "path": {
@@ -51,13 +50,26 @@
           },
           {
             "escape_path": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "at_least_one_of": [
+              "path",
+              "port",
+              "host"
+            ]
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/saml/3.4.x.json
+++ b/schemas/saml/3.4.x.json
@@ -2,34 +2,572 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "assertion_consumer_path": {
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "required": true,
+              "starts_with": "/",
+              "type": "string",
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
+            }
+          },
+          {
+            "idp_sso_url": {
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string",
+              "required": true
+            }
+          },
+          {
+            "idp_certificate": {
+              "encrypted": true,
+              "referenceable": true,
+              "description": "The public certificate provided by the IdP. This is used to validate responses from the IdP.  Only include the contents of the certificate. Do not include the header (`BEGIN CERTIFICATE`) and footer (`END CERTIFICATE`) lines.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "response_encryption_key": {
+              "encrypted": true,
+              "referenceable": true,
+              "description": "The private encryption key required to decrypt encrypted assertions.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "request_signing_key": {
+              "encrypted": true,
+              "referenceable": true,
+              "description": "The private key for signing requests.  If this parameter is set, requests sent to the IdP are signed.  The `request_signing_certificate` parameter must be set as well.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "request_signing_certificate": {
+              "encrypted": true,
+              "referenceable": true,
+              "description": "The certificate for signing requests.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "request_signature_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "description": "The signature algorithm for signing Authn requests. Options available are: - `SHA256` - `SHA384` - `SHA512`",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA384",
+                "SHA512"
+              ]
+            }
+          },
+          {
+            "request_digest_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "description": "The digest algorithm for Authn requests: - `SHA256` - `SHA1`",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA1"
+              ]
+            }
+          },
+          {
+            "response_signature_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "description": "The algorithm for validating signatures in SAML responses. Options available are: - `SHA256` - `SHA384` - `SHA512`",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA384",
+                "SHA512"
+              ]
+            }
+          },
+          {
+            "response_digest_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "description": "The algorithm for verifying digest in SAML responses: - `SHA256` - `SHA1`",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA1"
+              ]
+            }
+          },
+          {
+            "issuer": {
+              "description": "The unique identifier of the IdP application. Formatted as a URL containing information about the IdP so the SP can validate that the SAML assertions it receives are issued from the correct IdP.",
+              "type": "string",
+              "required": true
+            }
+          },
+          {
+            "nameid_format": {
+              "required": false,
+              "default": "EmailAddress",
+              "description": "The requested `NameId` format. Options available are: - `Unspecified` - `EmailAddress` - `Persistent` - `Transient`",
+              "type": "string",
+              "one_of": [
+                "Unspecified",
+                "EmailAddress",
+                "Persistent",
+                "Transient"
+              ]
+            }
+          },
+          {
+            "validate_assertion_signature": {
+              "default": true,
+              "description": "Enable signature validation for SAML responses.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "anonymous": {
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer. If not set, a Kong Consumer must exist for the SAML IdP user credentials, mapping the username format to the Kong Consumer username.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_secret": {
+              "referenceable": true,
+              "required": true,
+              "description": "The session secret. This must be a random string of 32 characters from the base64 alphabet (letters, numbers, `/`, `_` and `+`). It is used as the secret key for encrypting session data as well as state information that is sent to the IdP in the authentication exchange.",
+              "encrypted": true,
+              "len_min": 32,
+              "len_max": 32,
+              "type": "string",
+              "match": "^[0-9a-zA-Z/_+]+$"
+            }
+          },
+          {
+            "session_audience": {
+              "default": "default",
+              "description": "The session audience, for example \"my-application\"",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_name": {
+              "default": "session",
+              "description": "The session cookie name.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_remember": {
+              "default": false,
+              "description": "Enables or disables persistent sessions",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_remember_cookie_name": {
+              "default": "remember",
+              "description": "Persistent session cookie name",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_remember_rolling_timeout": {
+              "default": 604800,
+              "description": "Persistent session rolling timeout in seconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_remember_absolute_timeout": {
+              "default": 2592000,
+              "description": "Persistent session absolute timeout in seconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_idling_timeout": {
+              "default": 900,
+              "description": "The session cookie idle time in seconds.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_rolling_timeout": {
+              "default": 3600,
+              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_absolute_timeout": {
+              "default": 86400,
+              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
+              "type": "number",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_path": {
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "default": "/",
+              "starts_with": "/",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_domain": {
+              "description": "The session cookie domain flag.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_same_site": {
+              "required": false,
+              "default": "Lax",
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ]
+            }
+          },
+          {
+            "session_cookie_http_only": {
+              "default": true,
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_cookie_secure": {
+              "description": "The cookie is only sent to the server when a request is made with the https:scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_request_headers": {
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              }
+            }
+          },
+          {
+            "session_response_headers": {
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              }
+            }
+          },
+          {
+            "session_storage": {
+              "required": false,
+              "default": "cookie",
+              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie. The session cannot be invalidated or revoked without changing the session secret, but is stateless, and doesn't require a database. - `memcached`: stores session data in memcached - `redis`: stores session data in Redis",
+              "type": "string",
+              "one_of": [
+                "cookie",
+                "memcache",
+                "memcached",
+                "redis"
+              ]
+            }
+          },
+          {
+            "session_store_metadata": {
+              "default": false,
+              "description": "Configures whether or not session metadata should be stored. This includes information about the active sessions for the `specific_audience` belonging to a specific subject.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_enforce_same_subject": {
+              "default": false,
+              "description": "When set to `true`, audiences are forced to share the same subject.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_hash_subject": {
+              "default": false,
+              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_hash_storage_key": {
+              "default": false,
+              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_prefix": {
+              "description": "The memcached session key prefix.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_socket": {
+              "description": "The memcached unix socket path.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_host": {
+              "default": "127.0.0.1",
+              "description": "The memcached host.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_memcached_port": {
+              "required": false,
+              "default": 11211,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ]
+            }
+          },
+          {
+            "session_redis_prefix": {
+              "description": "The Redis session key prefix.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_socket": {
+              "description": "The Redis unix socket path.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_host": {
+              "default": "127.0.0.1",
+              "description": "The Redis host IP.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_port": {
+              "required": false,
+              "default": 6379,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ]
+            }
+          },
+          {
+            "session_redis_username": {
+              "referenceable": true,
+              "description": "Redis username if the `redis` session storage is defined and ACL authentication is desired.If undefined, ACL authentication will not be performed.  This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_password": {
+              "encrypted": true,
+              "referenceable": true,
+              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no auth commands are sent to Redis. This value is pulled from",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_connect_timeout": {
+              "description": "The Redis connection timeout in milliseconds.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "session_redis_read_timeout": {
+              "description": "The Redis read timeout in milliseconds.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "session_redis_send_timeout": {
+              "description": "The Redis send timeout in milliseconds.",
+              "type": "integer",
+              "required": false
+            }
+          },
+          {
+            "session_redis_ssl": {
+              "default": false,
+              "description": "Use SSL/TLS for the Redis connection.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_redis_ssl_verify": {
+              "default": false,
+              "description": "Verify the Redis server certificate.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
+            "session_redis_server_name": {
+              "description": "The SNI used for connecting to the Redis server.",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "session_redis_cluster_nodes": {
+              "required": false,
+              "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values.",
+              "type": "array",
+              "elements": {
+                "type": "record",
+                "fields": [
+                  {
+                    "ip": {
+                      "default": "127.0.0.1",
+                      "description": "A string representing a host name, such as example.com.",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  {
+                    "port": {
+                      "default": 6379,
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "type": "integer",
+                      "between": [
+                        0,
+                        65535
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "session_redis_cluster_max_redirections": {
+              "description": "The Redis cluster maximum redirects.",
+              "type": "integer",
+              "required": false
+            }
+          }
+        ],
+        "type": "record",
         "shorthand_fields": [
           {
             "session_cookie_lifetime": {
@@ -102,482 +640,11 @@
             }
           }
         ],
-        "type": "record",
-        "fields": [
-          {
-            "assertion_consumer_path": {
-              "match_none": [
-                {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
-                }
-              ],
-              "type": "string",
-              "starts_with": "/",
-              "required": true
-            }
-          },
-          {
-            "idp_sso_url": {
-              "type": "string",
-              "required": true
-            }
-          },
-          {
-            "idp_certificate": {
-              "required": false,
-              "encrypted": true,
-              "type": "string",
-              "referenceable": true
-            }
-          },
-          {
-            "response_encryption_key": {
-              "required": false,
-              "encrypted": true,
-              "type": "string",
-              "referenceable": true
-            }
-          },
-          {
-            "request_signing_key": {
-              "required": false,
-              "encrypted": true,
-              "type": "string",
-              "referenceable": true
-            }
-          },
-          {
-            "request_signing_certificate": {
-              "required": false,
-              "encrypted": true,
-              "type": "string",
-              "referenceable": true
-            }
-          },
-          {
-            "request_signature_algorithm": {
-              "required": false,
-              "one_of": [
-                "SHA256",
-                "SHA384",
-                "SHA512"
-              ],
-              "type": "string",
-              "default": "SHA256"
-            }
-          },
-          {
-            "request_digest_algorithm": {
-              "required": false,
-              "one_of": [
-                "SHA256",
-                "SHA1"
-              ],
-              "type": "string",
-              "default": "SHA256"
-            }
-          },
-          {
-            "response_signature_algorithm": {
-              "required": false,
-              "one_of": [
-                "SHA256",
-                "SHA384",
-                "SHA512"
-              ],
-              "type": "string",
-              "default": "SHA256"
-            }
-          },
-          {
-            "response_digest_algorithm": {
-              "required": false,
-              "one_of": [
-                "SHA256",
-                "SHA1"
-              ],
-              "type": "string",
-              "default": "SHA256"
-            }
-          },
-          {
-            "issuer": {
-              "required": true,
-              "type": "string"
-            }
-          },
-          {
-            "nameid_format": {
-              "required": false,
-              "one_of": [
-                "Unspecified",
-                "EmailAddress",
-                "Persistent",
-                "Transient"
-              ],
-              "type": "string",
-              "default": "EmailAddress"
-            }
-          },
-          {
-            "validate_assertion_signature": {
-              "default": true,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "anonymous": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_secret": {
-              "match": "^[0-9a-zA-Z/_+]+$",
-              "len_min": 32,
-              "len_max": 32,
-              "required": true,
-              "referenceable": true,
-              "encrypted": true,
-              "type": "string"
-            }
-          },
-          {
-            "session_audience": {
-              "default": "default",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_name": {
-              "default": "session",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_remember": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_remember_cookie_name": {
-              "default": "remember",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_remember_rolling_timeout": {
-              "default": 604800,
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_remember_absolute_timeout": {
-              "default": 2592000,
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_idling_timeout": {
-              "default": 900,
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_rolling_timeout": {
-              "default": 3600,
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_absolute_timeout": {
-              "default": 86400,
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_path": {
-              "match_none": [
-                {
-                  "err": "must not have empty segments",
-                  "pattern": "//"
-                }
-              ],
-              "starts_with": "/",
-              "default": "/",
-              "required": false,
-              "type": "string"
-            }
-          },
-          {
-            "session_cookie_domain": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_same_site": {
-              "required": false,
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ],
-              "type": "string",
-              "default": "Lax"
-            }
-          },
-          {
-            "session_cookie_http_only": {
-              "default": true,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_secure": {
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_request_headers": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ],
-                "type": "string"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "session_response_headers": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ],
-                "type": "string"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "session_storage": {
-              "required": false,
-              "one_of": [
-                "cookie",
-                "memcache",
-                "memcached",
-                "redis"
-              ],
-              "type": "string",
-              "default": "cookie"
-            }
-          },
-          {
-            "session_store_metadata": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_enforce_same_subject": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_hash_subject": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_hash_storage_key": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_prefix": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_socket": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_host": {
-              "default": "127.0.0.1",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_port": {
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ],
-              "required": false,
-              "default": 11211
-            }
-          },
-          {
-            "session_redis_prefix": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_socket": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_host": {
-              "default": "127.0.0.1",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_port": {
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ],
-              "required": false,
-              "default": 6379
-            }
-          },
-          {
-            "session_redis_username": {
-              "referenceable": true,
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_password": {
-              "required": false,
-              "encrypted": true,
-              "type": "string",
-              "referenceable": true
-            }
-          },
-          {
-            "session_redis_connect_timeout": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_read_timeout": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_send_timeout": {
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl_verify": {
-              "default": false,
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_redis_server_name": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_cluster_nodes": {
-              "type": "array",
-              "required": false,
-              "elements": {
-                "fields": [
-                  {
-                    "ip": {
-                      "type": "string",
-                      "default": "127.0.0.1",
-                      "required": true
-                    }
-                  },
-                  {
-                    "port": {
-                      "between": [
-                        0,
-                        65535
-                      ],
-                      "type": "integer",
-                      "default": 6379
-                    }
-                  }
-                ],
-                "type": "record"
-              }
-            }
-          },
-          {
-            "session_redis_cluster_max_redirections": {
-              "type": "integer",
-              "required": false
-            }
-          }
-        ],
         "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/session/3.4.x.json
+++ b/schemas/session/3.4.x.json
@@ -2,20 +2,26 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -27,15 +33,222 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "secret": {
+              "referenceable": true,
+              "required": false,
+              "default": "as6rhTxJRUuWhaZKo58zQN1ZdWZSxGzYdKDnvRIEUSUp",
+              "description": "The secret that is used in keyed HMAC generation.",
+              "type": "string",
+              "encrypted": true
+            }
+          },
+          {
+            "storage": {
+              "default": "cookie",
+              "description": "Determines where the session data is stored. `kong`: Stores encrypted session data into Kong's current database strategy; the cookie will not contain any session data. `cookie`: Stores encrypted session data within the cookie itself.",
+              "type": "string",
+              "one_of": [
+                "cookie",
+                "kong"
+              ]
+            }
+          },
+          {
+            "audience": {
+              "default": "default",
+              "description": "The session audience, which is the intended target application. For example `\"my-application\"`.",
+              "type": "string"
+            }
+          },
+          {
+            "idling_timeout": {
+              "default": 900,
+              "description": "The session cookie idle time, in seconds.",
+              "type": "number"
+            }
+          },
+          {
+            "rolling_timeout": {
+              "default": 3600,
+              "description": "The session cookie rolling timeout, in seconds. Specifies how long the session can be used until it needs to be renewed.",
+              "type": "number"
+            }
+          },
+          {
+            "absolute_timeout": {
+              "default": 86400,
+              "description": "The session cookie absolute timeout, in seconds. Specifies how long the session can be used until it is no longer valid.",
+              "type": "number"
+            }
+          },
+          {
+            "stale_ttl": {
+              "default": 10,
+              "description": "The duration, in seconds, after which an old cookie is discarded, starting from the moment when the session becomes outdated and is replaced by a new one.",
+              "type": "number"
+            }
+          },
+          {
+            "cookie_name": {
+              "default": "session",
+              "description": "The name of the cookie.",
+              "type": "string"
+            }
+          },
+          {
+            "cookie_path": {
+              "default": "/",
+              "description": "The resource in the host where the cookie is available.",
+              "type": "string"
+            }
+          },
+          {
+            "cookie_domain": {
+              "type": "string",
+              "description": "The domain with which the cookie is intended to be exchanged."
+            }
+          },
+          {
+            "cookie_same_site": {
+              "default": "Strict",
+              "description": "Determines whether and how a cookie may be sent with cross-site requests.",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ]
+            }
+          },
+          {
+            "cookie_http_only": {
+              "default": true,
+              "description": "Applies the `HttpOnly` tag so that the cookie is sent only to a server.",
+              "type": "boolean"
+            }
+          },
+          {
+            "cookie_secure": {
+              "default": true,
+              "description": "Applies the Secure directive so that the cookie may be sent to the server only with an encrypted request over the HTTPS protocol.",
+              "type": "boolean"
+            }
+          },
+          {
+            "remember": {
+              "default": false,
+              "description": "Enables or disables persistent sessions.",
+              "type": "boolean"
+            }
+          },
+          {
+            "remember_cookie_name": {
+              "default": "remember",
+              "description": "Persistent session cookie name. Use with the `remember` configuration parameter.",
+              "type": "string"
+            }
+          },
+          {
+            "remember_rolling_timeout": {
+              "default": 604800,
+              "description": "The persistent session rolling timeout window, in seconds.",
+              "type": "number"
+            }
+          },
+          {
+            "remember_absolute_timeout": {
+              "default": 2592000,
+              "description": "The persistent session absolute timeout limit, in seconds.",
+              "type": "number"
+            }
+          },
+          {
+            "response_headers": {
+              "description": "List of information to include, as headers, in the response to the downstream.",
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              }
+            }
+          },
+          {
+            "request_headers": {
+              "description": "List of information to include, as headers, in the response to the downstream.",
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              }
+            }
+          },
+          {
+            "logout_methods": {
+              "default": [
+                "POST",
+                "DELETE"
+              ],
+              "description": "A set of HTTP methods that the plugin will respond to.",
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "GET",
+                  "POST",
+                  "DELETE"
+                ]
+              }
+            }
+          },
+          {
+            "logout_query_arg": {
+              "default": "session_logout",
+              "description": "The query argument passed to logout requests.",
+              "type": "string"
+            }
+          },
+          {
+            "logout_post_arg": {
+              "default": "session_logout",
+              "description": "The POST argument passed to logout requests. Do not change this property.",
+              "type": "string"
+            }
+          }
+        ],
+        "type": "record",
         "shorthand_fields": [
           {
             "cookie_lifetime": {
@@ -73,188 +286,11 @@
             }
           }
         ],
-        "required": true,
-        "fields": [
-          {
-            "secret": {
-              "required": false,
-              "type": "string",
-              "default": "x8iNgCZK6ujBch4SJzrfXTvxciHURzefZYUqZ0PDyIwr",
-              "encrypted": true,
-              "referenceable": true
-            }
-          },
-          {
-            "storage": {
-              "type": "string",
-              "default": "cookie",
-              "one_of": [
-                "cookie",
-                "kong"
-              ]
-            }
-          },
-          {
-            "audience": {
-              "default": "default",
-              "type": "string"
-            }
-          },
-          {
-            "idling_timeout": {
-              "default": 900,
-              "type": "number"
-            }
-          },
-          {
-            "rolling_timeout": {
-              "default": 3600,
-              "type": "number"
-            }
-          },
-          {
-            "absolute_timeout": {
-              "default": 86400,
-              "type": "number"
-            }
-          },
-          {
-            "stale_ttl": {
-              "default": 10,
-              "type": "number"
-            }
-          },
-          {
-            "cookie_name": {
-              "default": "session",
-              "type": "string"
-            }
-          },
-          {
-            "cookie_path": {
-              "default": "/",
-              "type": "string"
-            }
-          },
-          {
-            "cookie_domain": {
-              "type": "string"
-            }
-          },
-          {
-            "cookie_same_site": {
-              "type": "string",
-              "default": "Strict",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ]
-            }
-          },
-          {
-            "cookie_http_only": {
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          {
-            "cookie_secure": {
-              "default": true,
-              "type": "boolean"
-            }
-          },
-          {
-            "remember": {
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          {
-            "remember_cookie_name": {
-              "default": "remember",
-              "type": "string"
-            }
-          },
-          {
-            "remember_rolling_timeout": {
-              "default": 604800,
-              "type": "number"
-            }
-          },
-          {
-            "remember_absolute_timeout": {
-              "default": 2592000,
-              "type": "number"
-            }
-          },
-          {
-            "response_headers": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ],
-                "type": "string"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "request_headers": {
-              "elements": {
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ],
-                "type": "string"
-              },
-              "type": "set"
-            }
-          },
-          {
-            "logout_methods": {
-              "type": "set",
-              "elements": {
-                "one_of": [
-                  "GET",
-                  "POST",
-                  "DELETE"
-                ],
-                "type": "string"
-              },
-              "default": [
-                "POST",
-                "DELETE"
-              ]
-            }
-          },
-          {
-            "logout_query_arg": {
-              "default": "session_logout",
-              "type": "string"
-            }
-          },
-          {
-            "logout_post_arg": {
-              "default": "session_logout",
-              "type": "string"
-            }
-          }
-        ],
-        "type": "record"
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/statsd-advanced/3.4.x.json
+++ b/schemas/statsd-advanced/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,185 +25,126 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "host": {
-              "type": "string",
-              "default": "localhost"
+              "default": "localhost",
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "port": {
+              "default": 8125,
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "type": "integer",
-              "default": 8125
+              ]
             }
           },
           {
             "prefix": {
-              "type": "string",
-              "default": "kong"
+              "default": "kong",
+              "description": "String to prefix to each metric's name.",
+              "type": "string"
             }
           },
           {
             "metrics": {
-              "type": "array",
               "default": [
                 {
-                  "stat_type": "counter",
                   "name": "request_count",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "stat_type": "counter"
                 },
                 {
-                  "name": "latency",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "latency"
                 },
                 {
-                  "name": "request_size",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "request_size"
                 },
                 {
-                  "stat_type": "counter",
                   "name": "status_count",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "stat_type": "counter"
                 },
                 {
-                  "name": "response_size",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "response_size"
                 },
                 {
-                  "name": "unique_users",
-                  "stat_type": "set"
-                },
-                {
-                  "stat_type": "counter",
-                  "name": "request_per_user",
-                  "sample_rate": 1
-                },
-                {
-                  "name": "upstream_latency",
-                  "stat_type": "timer"
-                },
-                {
-                  "name": "kong_latency",
-                  "stat_type": "timer"
+                  "stat_type": "set",
+                  "name": "unique_users"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "status_count_per_user",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "request_per_user"
+                },
+                {
+                  "stat_type": "timer",
+                  "name": "upstream_latency"
+                },
+                {
+                  "stat_type": "timer",
+                  "name": "kong_latency"
                 },
                 {
                   "stat_type": "counter",
+                  "sample_rate": 1,
+                  "name": "status_count_per_user"
+                },
+                {
                   "name": "status_count_per_workspace",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "stat_type": "counter"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "status_count_per_user_per_route",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "status_count_per_user_per_route"
                 },
                 {
-                  "stat_type": "gauge",
                   "name": "shdict_usage",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "stat_type": "gauge"
                 },
                 {
-                  "stat_type": "counter",
                   "name": "cache_datastore_hits_total",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "name": "cache_datastore_misses_total",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "stat_type": "counter"
                 }
               ],
+              "description": "List of Metrics to be logged.",
+              "type": "array",
               "elements": {
-                "entity_checks": [
-                  {
-                    "conditional": {
-                      "if_match": {
-                        "one_of": [
-                          "unique_users"
-                        ]
-                      },
-                      "then_field": "stat_type",
-                      "if_field": "name",
-                      "then_match": {
-                        "eq": "set"
-                      }
-                    }
-                  },
-                  {
-                    "conditional": {
-                      "if_match": {
-                        "one_of": [
-                          "request_count",
-                          "status_count",
-                          "request_per_user",
-                          "status_count_per_user",
-                          "status_count_per_workspace",
-                          "status_count_per_user_per_route",
-                          "cache_datastore_hits_total",
-                          "cache_datastore_misses_total"
-                        ]
-                      },
-                      "then_field": "stat_type",
-                      "if_field": "name",
-                      "then_match": {
-                        "eq": "counter"
-                      }
-                    }
-                  },
-                  {
-                    "conditional": {
-                      "if_match": {
-                        "one_of": [
-                          "shdict_usage"
-                        ]
-                      },
-                      "then_field": "stat_type",
-                      "if_field": "name",
-                      "then_match": {
-                        "eq": "gauge"
-                      }
-                    }
-                  },
-                  {
-                    "conditional": {
-                      "if_match": {
-                        "one_of": [
-                          "counter",
-                          "gauge"
-                        ]
-                      },
-                      "then_field": "sample_rate",
-                      "if_field": "stat_type",
-                      "then_match": {
-                        "required": true
-                      }
-                    }
-                  }
-                ],
                 "fields": [
                   {
                     "name": {
                       "type": "string",
-                      "required": true,
                       "one_of": [
                         "kong_latency",
                         "latency",
@@ -215,13 +161,13 @@
                         "shdict_usage",
                         "cache_datastore_hits_total",
                         "cache_datastore_misses_total"
-                      ]
+                      ],
+                      "required": true
                     }
                   },
                   {
                     "stat_type": {
                       "type": "string",
-                      "required": true,
                       "one_of": [
                         "counter",
                         "gauge",
@@ -229,181 +175,274 @@
                         "meter",
                         "set",
                         "timer"
-                      ]
+                      ],
+                      "required": true
                     }
                   },
                   {
                     "sample_rate": {
-                      "gt": 0,
-                      "type": "number"
+                      "type": "number",
+                      "gt": 0
                     }
                   },
                   {
                     "consumer_identifier": {
+                      "type": "string",
                       "one_of": [
                         "consumer_id",
                         "custom_id",
                         "username"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   },
                   {
                     "service_identifier": {
+                      "type": "string",
                       "one_of": [
                         "service_id",
                         "service_name",
                         "service_host",
                         "service_name_or_host"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   },
                   {
                     "workspace_identifier": {
+                      "type": "string",
                       "one_of": [
                         "workspace_id",
                         "workspace_name"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   }
                 ],
-                "type": "record"
+                "type": "record",
+                "entity_checks": [
+                  {
+                    "conditional": {
+                      "if_field": "name",
+                      "then_field": "stat_type",
+                      "if_match": {
+                        "one_of": [
+                          "unique_users"
+                        ]
+                      },
+                      "then_match": {
+                        "eq": "set"
+                      }
+                    }
+                  },
+                  {
+                    "conditional": {
+                      "if_field": "name",
+                      "then_field": "stat_type",
+                      "if_match": {
+                        "one_of": [
+                          "request_count",
+                          "status_count",
+                          "request_per_user",
+                          "status_count_per_user",
+                          "status_count_per_workspace",
+                          "status_count_per_user_per_route",
+                          "cache_datastore_hits_total",
+                          "cache_datastore_misses_total"
+                        ]
+                      },
+                      "then_match": {
+                        "eq": "counter"
+                      }
+                    }
+                  },
+                  {
+                    "conditional": {
+                      "if_field": "name",
+                      "then_field": "stat_type",
+                      "if_match": {
+                        "one_of": [
+                          "shdict_usage"
+                        ]
+                      },
+                      "then_match": {
+                        "eq": "gauge"
+                      }
+                    }
+                  },
+                  {
+                    "conditional": {
+                      "if_field": "stat_type",
+                      "then_field": "sample_rate",
+                      "if_match": {
+                        "one_of": [
+                          "counter",
+                          "gauge"
+                        ]
+                      },
+                      "then_match": {
+                        "required": true
+                      }
+                    }
+                  }
+                ]
               }
             }
           },
           {
             "allow_status_codes": {
+              "description": "List of status code ranges that are allowed to be logged in metrics.",
+              "type": "array",
               "elements": {
-                "match": "^[0-9]+-[0-9]+$",
-                "type": "string"
-              },
-              "type": "array"
+                "type": "string",
+                "match": "^[0-9]+-[0-9]+$"
+              }
             }
           },
           {
             "udp_packet_size": {
+              "default": 0,
+              "description": "Combine UDP packet up to the size configured. If zero (0), don't combine the UDP packet. Must be a number between 0 and 65507 (inclusive).",
+              "type": "number",
               "between": [
                 0,
                 65507
-              ],
-              "type": "number",
-              "default": 0
+              ]
             }
           },
           {
             "use_tcp": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Use TCP instead of UDP.",
+              "type": "boolean"
             }
           },
           {
             "hostname_in_prefix": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Include the `hostname` in the `prefix` for each metric name.",
+              "type": "boolean"
             }
           },
           {
             "consumer_identifier_default": {
               "required": true,
+              "default": "custom_id",
+              "description": "The default consumer identifier for metrics. This will take effect when a metric's consumer identifier is omitted. Allowed values are `custom_id`, `consumer_id`, `username`.",
+              "type": "string",
               "one_of": [
                 "consumer_id",
                 "custom_id",
                 "username"
-              ],
-              "default": "custom_id",
-              "type": "string"
+              ]
             }
           },
           {
             "service_identifier_default": {
               "required": true,
+              "default": "service_name_or_host",
+              "description": "The default service identifier for metrics. This will take effect when a metric's service identifier is omitted. Allowed values are `service_name_or_host`, `service_id`, `service_name`, `service_host`.",
+              "type": "string",
               "one_of": [
                 "service_id",
                 "service_name",
                 "service_host",
                 "service_name_or_host"
-              ],
-              "default": "service_name_or_host",
-              "type": "string"
+              ]
             }
           },
           {
             "workspace_identifier_default": {
               "required": true,
+              "default": "workspace_id",
+              "description": "The default workspace identifier for metrics. This will take effect when a metric's workspace identifier is omitted. Allowed values are `workspace_id`, `workspace_name`.   ",
+              "type": "string",
               "one_of": [
                 "workspace_id",
                 "workspace_name"
-              ],
-              "default": "workspace_id",
-              "type": "string"
+              ]
             }
           },
           {
             "queue": {
-              "required": true,
               "fields": [
                 {
                   "max_batch_size": {
+                    "default": 1,
+                    "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_coalescing_delay": {
+                    "default": 1,
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
                     "between": [
                       0,
                       3600
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_entries": {
+                    "default": 10000,
+                    "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 10000
+                    ]
                   }
                 },
                 {
                   "max_bytes": {
-                    "type": "number"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
                   "max_retry_time": {
                     "default": 60,
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
                     "type": "number"
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "type": "number"
+                    "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "type": "number"
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/statsd/3.4.x.json
+++ b/schemas/statsd/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,149 +25,134 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "custom_entity_check": {
-              "field_sources": [
-                "retry_count",
-                "queue_size",
-                "flush_timeout"
-              ]
-            }
-          }
-        ],
         "fields": [
           {
             "host": {
-              "type": "string",
-              "default": "localhost"
+              "default": "localhost",
+              "description": "The IP address or hostname of StatsD server to send data to.",
+              "type": "string"
             }
           },
           {
             "port": {
+              "default": 8125,
+              "description": "The port of StatsD server to send data to.",
+              "type": "integer",
               "between": [
                 0,
                 65535
-              ],
-              "type": "integer",
-              "default": 8125
+              ]
             }
           },
           {
             "prefix": {
               "default": "kong",
+              "description": "String to prefix to each metric's name.",
               "type": "string"
             }
           },
           {
             "metrics": {
-              "type": "array",
               "default": [
                 {
                   "stat_type": "counter",
-                  "name": "request_count",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "request_count"
                 },
                 {
-                  "name": "latency",
-                  "stat_type": "timer"
-                },
-                {
-                  "stat_type": "counter",
-                  "name": "request_size",
-                  "sample_rate": 1
+                  "stat_type": "timer",
+                  "name": "latency"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "status_count",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "request_size"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "response_size",
-                  "sample_rate": 1
-                },
-                {
-                  "name": "unique_users",
-                  "stat_type": "set"
+                  "sample_rate": 1,
+                  "name": "status_count"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "request_per_user",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "response_size"
                 },
                 {
-                  "name": "upstream_latency",
-                  "stat_type": "timer"
-                },
-                {
-                  "name": "kong_latency",
-                  "stat_type": "timer"
+                  "stat_type": "set",
+                  "name": "unique_users"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "status_count_per_user",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "request_per_user"
+                },
+                {
+                  "stat_type": "timer",
+                  "name": "upstream_latency"
+                },
+                {
+                  "stat_type": "timer",
+                  "name": "kong_latency"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "status_count_per_workspace",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "status_count_per_user"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "status_count_per_user_per_route",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "status_count_per_workspace"
+                },
+                {
+                  "stat_type": "counter",
+                  "sample_rate": 1,
+                  "name": "status_count_per_user_per_route"
                 },
                 {
                   "stat_type": "gauge",
-                  "name": "shdict_usage",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "shdict_usage"
+                },
+                {
+                  "stat_type": "gauge",
+                  "sample_rate": 1,
+                  "name": "lmdb_usage"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "cache_datastore_hits_total",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "cache_datastore_hits_total"
                 },
                 {
                   "stat_type": "counter",
-                  "name": "cache_datastore_misses_total",
-                  "sample_rate": 1
+                  "sample_rate": 1,
+                  "name": "cache_datastore_misses_total"
                 }
               ],
+              "description": "List of metrics to be logged.",
+              "type": "array",
               "elements": {
-                "entity_checks": [
-                  {
-                    "conditional": {
-                      "if_match": {
-                        "one_of": [
-                          "counter",
-                          "gauge"
-                        ]
-                      },
-                      "then_field": "sample_rate",
-                      "if_field": "stat_type",
-                      "then_match": {
-                        "required": true
-                      }
-                    }
-                  }
-                ],
                 "fields": [
                   {
                     "name": {
                       "type": "string",
-                      "required": true,
+                      "description": "StatsD metric’s name.",
                       "one_of": [
                         "kong_latency",
                         "latency",
@@ -177,15 +167,17 @@
                         "status_count_per_workspace",
                         "status_count_per_user_per_route",
                         "shdict_usage",
+                        "lmdb_usage",
                         "cache_datastore_hits_total",
                         "cache_datastore_misses_total"
-                      ]
+                      ],
+                      "required": true
                     }
                   },
                   {
                     "stat_type": {
                       "type": "string",
-                      "required": true,
+                      "description": "Determines what sort of event a metric represents.",
                       "one_of": [
                         "counter",
                         "gauge",
@@ -193,114 +185,137 @@
                         "meter",
                         "set",
                         "timer"
-                      ]
+                      ],
+                      "required": true
                     }
                   },
                   {
                     "sample_rate": {
-                      "gt": 0,
-                      "type": "number"
+                      "description": "Sampling rate",
+                      "type": "number",
+                      "gt": 0
                     }
                   },
                   {
                     "consumer_identifier": {
+                      "description": "Authenticated user detail.",
+                      "type": "string",
                       "one_of": [
                         "consumer_id",
                         "custom_id",
                         "username"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   },
                   {
                     "service_identifier": {
+                      "description": "Service detail.",
+                      "type": "string",
                       "one_of": [
                         "service_id",
                         "service_name",
                         "service_host",
                         "service_name_or_host"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   },
                   {
                     "workspace_identifier": {
+                      "description": "Workspace detail.",
+                      "type": "string",
                       "one_of": [
                         "workspace_id",
                         "workspace_name"
-                      ],
-                      "type": "string"
+                      ]
                     }
                   }
                 ],
-                "type": "record"
+                "type": "record",
+                "entity_checks": [
+                  {
+                    "conditional": {
+                      "if_field": "stat_type",
+                      "then_field": "sample_rate",
+                      "if_match": {
+                        "one_of": [
+                          "counter",
+                          "gauge"
+                        ]
+                      },
+                      "then_match": {
+                        "required": true
+                      }
+                    }
+                  }
+                ]
               }
             }
           },
           {
             "allow_status_codes": {
+              "description": "List of status code ranges that are allowed to be logged in metrics.",
+              "type": "array",
               "elements": {
-                "match": "^[0-9]+-[0-9]+$",
-                "type": "string"
-              },
-              "type": "array"
+                "type": "string",
+                "match": "^[0-9]+-[0-9]+$"
+              }
             }
           },
           {
             "udp_packet_size": {
+              "default": 0,
+              "type": "number",
               "between": [
                 0,
                 65507
-              ],
-              "type": "number",
-              "default": 0
+              ]
             }
           },
           {
             "use_tcp": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "hostname_in_prefix": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "consumer_identifier_default": {
               "default": "custom_id",
+              "type": "string",
               "one_of": [
                 "consumer_id",
                 "custom_id",
                 "username"
               ],
-              "type": "string",
               "required": true
             }
           },
           {
             "service_identifier_default": {
               "default": "service_name_or_host",
+              "type": "string",
               "one_of": [
                 "service_id",
                 "service_name",
                 "service_host",
                 "service_name_or_host"
               ],
-              "type": "string",
               "required": true
             }
           },
           {
             "workspace_identifier_default": {
               "default": "workspace_id",
+              "type": "string",
               "one_of": [
                 "workspace_id",
                 "workspace_name"
               ],
-              "type": "string",
               "required": true
             }
           },
@@ -322,79 +337,109 @@
           {
             "tag_style": {
               "type": "string",
-              "required": false,
               "one_of": [
                 "dogstatsd",
                 "influxdb",
                 "librato",
                 "signalfx"
-              ]
+              ],
+              "required": false
             }
           },
           {
             "queue": {
-              "required": true,
               "fields": [
                 {
                   "max_batch_size": {
+                    "default": 1,
+                    "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_coalescing_delay": {
+                    "default": 1,
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
                     "between": [
                       0,
                       3600
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_entries": {
+                    "default": 10000,
+                    "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 10000
+                    ]
                   }
                 },
                 {
                   "max_bytes": {
-                    "type": "number"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
                   "max_retry_time": {
                     "default": 60,
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
                     "type": "number"
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "type": "number"
+                    "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "type": "number"
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "custom_entity_check": {
+              "field_sources": [
+                "retry_count",
+                "queue_size",
+                "flush_timeout"
+              ]
+            }
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/syslog/3.4.x.json
+++ b/schemas/syslog/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,20 +25,25 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "log_level": {
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -44,13 +54,13 @@
                 "alert",
                 "emerg"
               ],
-              "type": "string",
               "required": true
             }
           },
           {
             "successful_severity": {
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -61,13 +71,13 @@
                 "alert",
                 "emerg"
               ],
-              "type": "string",
               "required": true
             }
           },
           {
             "client_errors_severity": {
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -78,13 +88,13 @@
                 "alert",
                 "emerg"
               ],
-              "type": "string",
               "required": true
             }
           },
           {
             "server_errors_severity": {
               "default": "info",
+              "type": "string",
               "one_of": [
                 "debug",
                 "info",
@@ -95,18 +105,18 @@
                 "alert",
                 "emerg"
               ],
-              "type": "string",
               "required": true
             }
           },
           {
             "custom_fields_by_lua": {
               "type": "map",
-              "keys": {
+              "description": "Lua code as a key-value map",
+              "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "values": {
+              "keys": {
                 "type": "string",
                 "len_min": 1
               }
@@ -114,7 +124,10 @@
           },
           {
             "facility": {
+              "required": true,
               "default": "user",
+              "description": "The facility is used by the operating system to decide how to handle each log message.",
+              "type": "string",
               "one_of": [
                 "auth",
                 "authpriv",
@@ -136,14 +149,16 @@
                 "local5",
                 "local6",
                 "local7"
-              ],
-              "type": "string",
-              "required": true
+              ]
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/tcp-log/3.4.x.json
+++ b/schemas/tcp-log/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,19 +25,24 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "host": {
+              "description": "The IP address or host name to send data to.",
               "type": "string",
               "required": true
             }
@@ -43,50 +53,60 @@
                 0,
                 65535
               ],
+              "description": "The port to send data to on the upstream server.",
               "type": "integer",
               "required": true
             }
           },
           {
             "timeout": {
-              "type": "number",
-              "default": 10000
+              "default": 10000,
+              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
+              "type": "number"
             }
           },
           {
             "keepalive": {
-              "type": "number",
-              "default": 60000
+              "default": 60000,
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
+              "type": "number"
             }
           },
           {
             "tls": {
+              "default": false,
+              "description": "Indicates whether to perform a TLS handshake against the remote server.",
               "type": "boolean",
-              "required": true,
-              "default": false
+              "required": true
             }
           },
           {
             "tls_sni": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string that defines the SNI (Server Name Indication) hostname to send in the TLS handshake."
             }
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "keys": {
+              "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "values": {
+              "description": "A list of key-value pairs, where the key is the name of a log field and the value is a chunk of Lua code, whose return value sets or replaces the log field value.",
+              "type": "map",
+              "keys": {
                 "type": "string",
                 "len_min": 1
               }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/tls-handshake-modifier/3.4.x.json
+++ b/schemas/tls-handshake-modifier/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -13,35 +14,47 @@
           "https",
           "grpcs"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "https",
             "grpcs",
             "tls"
-          ],
-          "type": "string"
-        },
-        "type": "set",
-        "required": true
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "tls_client_certificate": {
+              "required": false,
+              "default": "REQUEST",
+              "description": "TLS Client Certificate",
               "type": "string",
               "one_of": [
                 "REQUEST"
-              ],
-              "required": false,
-              "default": "REQUEST"
+              ]
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/tls-metadata-headers/3.4.x.json
+++ b/schemas/tls-metadata-headers/3.4.x.json
@@ -2,9 +2,10 @@
   "fields": [
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
@@ -13,66 +14,83 @@
           "https",
           "grpcs"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "https",
             "grpcs",
             "tls"
-          ],
-          "type": "string"
-        },
-        "type": "set",
-        "required": true
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "inject_client_cert_details": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Enables TLS client certificate metadata values to be injected into HTTP headers.",
+              "type": "boolean"
             }
           },
           {
             "client_cert_header_name": {
               "default": "X-Client-Cert",
-              "required": true,
-              "type": "string"
+              "description": "Define the HTTP header name used for the PEM format URL encoded client certificate.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "client_serial_header_name": {
               "default": "X-Client-Cert-Serial",
-              "required": true,
-              "type": "string"
+              "description": "Define the HTTP header name used for the serial number of the client certificate.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "client_cert_issuer_dn_header_name": {
               "default": "X-Client-Cert-Issuer-DN",
-              "required": true,
-              "type": "string"
+              "description": "Define the HTTP header name used for the issuer DN of the client certificate.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "client_cert_subject_dn_header_name": {
               "default": "X-Client-Cert-Subject-DN",
-              "required": true,
-              "type": "string"
+              "description": "Define the HTTP header name used for the subject DN of the client certificate.",
+              "type": "string",
+              "required": true
             }
           },
           {
             "client_cert_fingerprint_header_name": {
               "default": "X-Client-Cert-Fingerprint",
-              "required": true,
-              "type": "string"
+              "description": "Define the HTTP header name used for the SHA1 fingerprint of the client certificate.",
+              "type": "string",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/udp-log/3.4.x.json
+++ b/schemas/udp-log/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,19 +25,24 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "host": {
+              "description": "A string representing a host name, such as example.com.",
               "type": "string",
               "required": true
             }
@@ -43,32 +53,39 @@
                 0,
                 65535
               ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
               "required": true
             }
           },
           {
             "timeout": {
-              "type": "number",
-              "default": 10000
+              "default": 10000,
+              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
+              "type": "number"
             }
           },
           {
             "custom_fields_by_lua": {
               "type": "map",
-              "keys": {
+              "description": "Lua code as a key-value map",
+              "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "values": {
+              "keys": {
                 "type": "string",
                 "len_min": 1
               }
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/upstream-timeout/3.4.x.json
+++ b/schemas/upstream-timeout/3.4.x.json
@@ -2,28 +2,36 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "read_timeout": {
@@ -31,6 +39,7 @@
                 0,
                 2147483646
               ],
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer"
             }
           },
@@ -40,6 +49,7 @@
                 0,
                 2147483646
               ],
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer"
             }
           },
@@ -49,12 +59,17 @@
                 0,
                 2147483646
               ],
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/vault-auth/3.4.x.json
+++ b/schemas/vault-auth/3.4.x.json
@@ -2,89 +2,111 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "consumer": {
-        "eq": null,
         "reference": "consumers",
-        "type": "foreign"
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "access_token_name": {
-              "default": "access_token",
-              "elements": {
-                "type": "string"
-              },
               "required": true,
-              "type": "string"
+              "default": "access_token",
+              "description": "Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
+              "type": "string",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "secret_token_name": {
-              "default": "secret_token",
-              "elements": {
-                "type": "string"
-              },
               "required": true,
-              "type": "string"
+              "default": "secret_token",
+              "description": "Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
+              "type": "string",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "vault": {
-              "type": "foreign",
               "reference": "vault_auth_vaults",
+              "description": "A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.",
+              "type": "foreign",
               "required": true
             }
           },
           {
             "hide_credentials": {
               "default": false,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the header or querystring containing the key) before proxying it.",
               "type": "boolean"
             }
           },
           {
             "anonymous": {
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "tokens_in_body": {
               "default": false,
+              "description": "If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
               "type": "boolean"
             }
           },
           {
             "run_on_preflight": {
               "default": true,
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed.",
               "type": "boolean"
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/websocket-size-limit/3.4.x.json
+++ b/schemas/websocket-size-limit/3.4.x.json
@@ -6,28 +6,27 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "at_least_one_of": [
-              "client_max_payload",
-              "upstream_max_payload"
-            ]
-          }
-        ],
         "fields": [
           {
             "client_max_payload": {
@@ -35,8 +34,8 @@
                 1,
                 33554432
               ],
-              "required": false,
-              "type": "integer"
+              "type": "integer",
+              "required": false
             }
           },
           {
@@ -45,13 +44,25 @@
                 1,
                 33554432
               ],
-              "required": false,
-              "type": "integer"
+              "type": "integer",
+              "required": false
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "at_least_one_of": [
+              "client_max_payload",
+              "upstream_max_payload"
+            ]
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/websocket-validator/3.4.x.json
+++ b/schemas/websocket-validator/3.4.x.json
@@ -6,20 +6,203 @@
           "ws",
           "wss"
         ],
+        "required": true,
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
+        "fields": [
+          {
+            "client": {
+              "required": false,
+              "entity_checks": [
+                {
+                  "at_least_one_of": [
+                    "text",
+                    "binary"
+                  ]
+                }
+              ],
+              "type": "record",
+              "fields": [
+                {
+                  "text": {
+                    "required": false,
+                    "entity_checks": [
+                      {
+                        "custom_entity_check": {
+                          "field_sources": [
+                            "type",
+                            "schema"
+                          ]
+                        }
+                      }
+                    ],
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "type": "string",
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "required": true
+                        }
+                      },
+                      {
+                        "schema": {
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
+                          "type": "string",
+                          "required": true
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "binary": {
+                    "required": false,
+                    "entity_checks": [
+                      {
+                        "custom_entity_check": {
+                          "field_sources": [
+                            "type",
+                            "schema"
+                          ]
+                        }
+                      }
+                    ],
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "type": "string",
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "required": true
+                        }
+                      },
+                      {
+                        "schema": {
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
+                          "type": "string",
+                          "required": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "upstream": {
+              "required": false,
+              "entity_checks": [
+                {
+                  "at_least_one_of": [
+                    "text",
+                    "binary"
+                  ]
+                }
+              ],
+              "type": "record",
+              "fields": [
+                {
+                  "text": {
+                    "required": false,
+                    "entity_checks": [
+                      {
+                        "custom_entity_check": {
+                          "field_sources": [
+                            "type",
+                            "schema"
+                          ]
+                        }
+                      }
+                    ],
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "type": "string",
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "required": true
+                        }
+                      },
+                      {
+                        "schema": {
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
+                          "type": "string",
+                          "required": true
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "binary": {
+                    "required": false,
+                    "entity_checks": [
+                      {
+                        "custom_entity_check": {
+                          "field_sources": [
+                            "type",
+                            "schema"
+                          ]
+                        }
+                      }
+                    ],
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "type": "string",
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "required": true
+                        }
+                      },
+                      {
+                        "schema": {
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
+                          "type": "string",
+                          "required": true
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
         "required": true,
+        "type": "record",
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -27,175 +210,11 @@
               "upstream"
             ]
           }
-        ],
-        "fields": [
-          {
-            "client": {
-              "type": "record",
-              "entity_checks": [
-                {
-                  "at_least_one_of": [
-                    "text",
-                    "binary"
-                  ]
-                }
-              ],
-              "fields": [
-                {
-                  "text": {
-                    "type": "record",
-                    "entity_checks": [
-                      {
-                        "custom_entity_check": {
-                          "field_sources": [
-                            "type",
-                            "schema"
-                          ]
-                        }
-                      }
-                    ],
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "required": true,
-                          "one_of": [
-                            "draft4"
-                          ]
-                        }
-                      },
-                      {
-                        "schema": {
-                          "required": true,
-                          "type": "string"
-                        }
-                      }
-                    ],
-                    "required": false
-                  }
-                },
-                {
-                  "binary": {
-                    "type": "record",
-                    "entity_checks": [
-                      {
-                        "custom_entity_check": {
-                          "field_sources": [
-                            "type",
-                            "schema"
-                          ]
-                        }
-                      }
-                    ],
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "required": true,
-                          "one_of": [
-                            "draft4"
-                          ]
-                        }
-                      },
-                      {
-                        "schema": {
-                          "required": true,
-                          "type": "string"
-                        }
-                      }
-                    ],
-                    "required": false
-                  }
-                }
-              ],
-              "required": false
-            }
-          },
-          {
-            "upstream": {
-              "type": "record",
-              "entity_checks": [
-                {
-                  "at_least_one_of": [
-                    "text",
-                    "binary"
-                  ]
-                }
-              ],
-              "fields": [
-                {
-                  "text": {
-                    "type": "record",
-                    "entity_checks": [
-                      {
-                        "custom_entity_check": {
-                          "field_sources": [
-                            "type",
-                            "schema"
-                          ]
-                        }
-                      }
-                    ],
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "required": true,
-                          "one_of": [
-                            "draft4"
-                          ]
-                        }
-                      },
-                      {
-                        "schema": {
-                          "required": true,
-                          "type": "string"
-                        }
-                      }
-                    ],
-                    "required": false
-                  }
-                },
-                {
-                  "binary": {
-                    "type": "record",
-                    "entity_checks": [
-                      {
-                        "custom_entity_check": {
-                          "field_sources": [
-                            "type",
-                            "schema"
-                          ]
-                        }
-                      }
-                    ],
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "required": true,
-                          "one_of": [
-                            "draft4"
-                          ]
-                        }
-                      },
-                      {
-                        "schema": {
-                          "required": true,
-                          "type": "string"
-                        }
-                      }
-                    ],
-                    "required": false
-                  }
-                }
-              ],
-              "required": false
-            }
-          }
-        ],
-        "type": "record"
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/xml-threat-protection/3.4.x.json
+++ b/schemas/xml-threat-protection/3.4.x.json
@@ -2,264 +2,299 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing HTTP protocols.",
+        "type": "set",
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
             "http",
             "https"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
-        "entity_checks": [
-          {
-            "conditional": {
-              "if_match": {
-                "eq": true
-              },
-              "then_field": "max_namespaces",
-              "if_field": "namespace_aware",
-              "then_match": {
-                "required": true
-              }
-            }
-          },
-          {
-            "conditional": {
-              "if_match": {
-                "eq": true
-              },
-              "then_field": "prefix",
-              "if_field": "namespace_aware",
-              "then_match": {
-                "required": true
-              }
-            }
-          },
-          {
-            "conditional": {
-              "if_match": {
-                "eq": true
-              },
-              "then_field": "namespaceuri",
-              "if_field": "namespace_aware",
-              "then_match": {
-                "required": true
-              }
-            }
-          }
-        ],
         "fields": [
           {
             "checked_content_types": {
+              "required": true,
               "default": [
                 "application/xml"
               ],
-              "elements": {
-                "match": "^[^%s]+%/[^ ;]+$",
-                "type": "string",
-                "required": true
-              },
+              "description": "A list of Content-Type values with payloads that must be validated.",
               "type": "set",
-              "required": true
+              "elements": {
+                "required": true,
+                "type": "string",
+                "match": "^[^%s]+%/[^ ;]+$"
+              }
             }
           },
           {
             "allowed_content_types": {
+              "required": true,
               "default": [
 
               ],
-              "elements": {
-                "match": "^[^%s]+%/[^ ;]+$",
-                "type": "string",
-                "required": true
-              },
+              "description": "A list of Content-Type values with payloads that are allowed, but aren't validated.",
               "type": "set",
-              "required": true
+              "elements": {
+                "required": true,
+                "type": "string",
+                "match": "^[^%s]+%/[^ ;]+$"
+              }
             }
           },
           {
             "allow_dtd": {
               "default": false,
-              "required": true,
-              "type": "boolean"
+              "description": "Indicates whether an XML Document Type Definition (DTD) section is allowed.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "namespace_aware": {
               "default": true,
-              "required": true,
-              "type": "boolean"
+              "description": "If not parsing namespace aware, all prefixes and namespace attributes will be counted as regular attributes and element names, and validated as such.",
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "max_depth": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 50
+              "required": true,
+              "default": 50,
+              "description": "Maximum depth of tags. Child elements such as Text or Comments are not counted as another level.",
+              "type": "integer"
             }
           },
           {
             "max_children": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 100
+              "required": true,
+              "default": 100,
+              "description": "Maximum number of children allowed (Element, Text, Comment, ProcessingInstruction, CDATASection). Note: Adjacent text and CDATA sections are counted as one. For example, text-cdata-text-cdata is one child.",
+              "type": "integer"
             }
           },
           {
             "max_attributes": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 100
+              "required": true,
+              "default": 100,
+              "description": "Maximum number of attributes allowed on a tag, including default ones. Note: If namespace-aware parsing is disabled, then the namespaces definitions are counted as attributes.",
+              "type": "integer"
             }
           },
           {
             "max_namespaces": {
-              "type": "integer",
-              "required": false,
               "gt": 0,
-              "default": 20
+              "required": false,
+              "default": 20,
+              "description": "Maximum number of namespaces defined on a tag. This value is required if parsing is namespace-aware.",
+              "type": "integer"
             }
           },
           {
             "document": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 10485760
+              "required": true,
+              "default": 10485760,
+              "description": "Maximum size of the entire document.",
+              "type": "integer"
             }
           },
           {
             "buffer": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1048576
+              "required": true,
+              "default": 1048576,
+              "description": "Maximum size of the unparsed buffer (see below).",
+              "type": "integer"
             }
           },
           {
             "comment": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of comments.",
+              "type": "integer"
             }
           },
           {
             "localname": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of the localname. This applies to tags and attributes.",
+              "type": "integer"
             }
           },
           {
             "prefix": {
-              "type": "integer",
-              "required": false,
               "gt": 0,
-              "default": 1024
+              "required": false,
+              "default": 1024,
+              "description": "Maximum size of the prefix. This applies to tags and attributes. This value is required if parsing is namespace-aware.",
+              "type": "integer"
             }
           },
           {
             "namespaceuri": {
-              "type": "integer",
-              "required": false,
               "gt": 0,
-              "default": 1024
+              "required": false,
+              "default": 1024,
+              "description": "Maximum size of the namespace URI. This value is required if parsing is namespace-aware.",
+              "type": "integer"
             }
           },
           {
             "attribute": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1048576
+              "required": true,
+              "default": 1048576,
+              "description": "Maximum size of the attribute value.",
+              "type": "integer"
             }
           },
           {
             "text": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1048576
+              "required": true,
+              "default": 1048576,
+              "description": "Maximum text inside tags (counted over all adjacent text/CDATA elements combined).",
+              "type": "integer"
             }
           },
           {
             "pitarget": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of processing instruction targets.",
+              "type": "integer"
             }
           },
           {
             "pidata": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of processing instruction data.",
+              "type": "integer"
             }
           },
           {
             "entityname": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of entity names in EntityDecl.",
+              "type": "integer"
             }
           },
           {
             "entity": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of entity values in EntityDecl.",
+              "type": "integer"
             }
           },
           {
             "entityproperty": {
-              "type": "integer",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of systemId, publicId, or notationName in EntityDecl.",
+              "type": "integer"
             }
           },
           {
             "bla_max_amplification": {
-              "type": "number",
-              "required": true,
               "gt": 1,
-              "default": 100
+              "required": true,
+              "default": 100,
+              "description": "Sets the maximum allowed amplification. This protects against the Billion Laughs Attack.",
+              "type": "number"
             }
           },
           {
             "bla_threshold": {
-              "required": true,
-              "type": "integer",
               "gt": 1024,
-              "default": 8388608
+              "required": true,
+              "default": 8388608,
+              "description": "Sets the threshold after which the protection starts. This protects against the Billion Laughs Attack.",
+              "type": "integer"
             }
           }
         ],
-        "type": "record"
+        "required": true,
+        "type": "record",
+        "entity_checks": [
+          {
+            "conditional": {
+              "if_field": "namespace_aware",
+              "then_field": "max_namespaces",
+              "if_match": {
+                "eq": true
+              },
+              "then_match": {
+                "required": true
+              }
+            }
+          },
+          {
+            "conditional": {
+              "if_field": "namespace_aware",
+              "then_field": "prefix",
+              "if_match": {
+                "eq": true
+              },
+              "then_match": {
+                "required": true
+              }
+            }
+          },
+          {
+            "conditional": {
+              "if_field": "namespace_aware",
+              "then_field": "namespaceuri",
+              "if_match": {
+                "eq": true
+              },
+              "then_match": {
+                "required": true
+              }
+            }
+          }
+        ]
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }

--- a/schemas/zipkin/3.4.x.json
+++ b/schemas/zipkin/3.4.x.json
@@ -2,13 +2,18 @@
   "fields": [
     {
       "protocols": {
+        "required": true,
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
+        "description": "A set of strings representing protocols.",
+        "type": "set",
         "elements": {
+          "description": "A string representing a protocol, such as HTTP or HTTPS.",
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -20,47 +25,56 @@
             "udp",
             "ws",
             "wss"
-          ],
-          "type": "string"
-        },
-        "required": true,
-        "type": "set"
+          ]
+        }
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "type": "foreign",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "fields": [
           {
             "local_service_name": {
               "default": "kong",
+              "description": "The name of the service as displayed in Zipkin.",
               "type": "string",
               "required": true
             }
           },
           {
             "http_endpoint": {
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "sample_ratio": {
+              "default": 0.001,
+              "description": "How often to sample requests that do not contain trace IDs. Set to `0` to turn sampling off, or to `1` to sample **all** requests. ",
+              "type": "number",
               "between": [
                 0,
                 1
-              ],
-              "type": "number",
-              "default": 0.001
+              ]
             }
           },
           {
             "default_service_name": {
-              "type": "string"
+              "type": "string",
+              "description": "Set a default service name to override `unknown-service-name` in the Zipkin spans."
             }
           },
           {
             "include_credential": {
               "default": true,
+              "description": "Specify whether the credential of the currently authenticated consumer should be included in metadata sent to the Zipkin server.",
               "type": "boolean",
               "required": true
             }
@@ -68,17 +82,21 @@
           {
             "traceid_byte_count": {
               "required": true,
+              "default": 16,
+              "description": "The length in bytes of each request's Trace ID.",
+              "type": "integer",
               "one_of": [
                 8,
                 16
-              ],
-              "type": "integer",
-              "default": 16
+              ]
             }
           },
           {
             "header_type": {
               "required": true,
+              "default": "preserve",
+              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests",
+              "type": "string",
               "one_of": [
                 "preserve",
                 "ignore",
@@ -87,41 +105,47 @@
                 "w3c",
                 "jaeger",
                 "ot",
+                "aws",
                 "datadog"
-              ],
-              "type": "string",
-              "default": "preserve"
+              ]
             }
           },
           {
             "default_header_type": {
               "required": true,
+              "default": "b3",
+              "description": "Allows specifying the type of header to be added to requests with no pre-existing tracing headers and when `config.header_type` is set to `\"preserve\"`. When `header_type` is set to any other value, `default_header_type` is ignored.",
+              "type": "string",
               "one_of": [
                 "b3",
                 "b3-single",
                 "w3c",
                 "jaeger",
                 "ot",
+                "aws",
                 "datadog"
-              ],
-              "type": "string",
-              "default": "b3"
+              ]
             }
           },
           {
             "tags_header": {
               "default": "Zipkin-Tags",
+              "description": "The Zipkin plugin will add extra headers to the tags associated with any HTTP requests that come with a header named as configured by this property.",
               "type": "string",
               "required": true
             }
           },
           {
             "static_tags": {
+              "description": "The tags specified on this property will be added to the generated request traces.",
               "type": "array",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "name": {
+                      "required": true,
+                      "type": "string",
                       "not_one_of": [
                         "error",
                         "http.method",
@@ -136,9 +160,7 @@
                         "kong.service",
                         "lc",
                         "peer.hostname"
-                      ],
-                      "type": "string",
-                      "required": true
+                      ]
                     }
                   },
                   {
@@ -147,50 +169,53 @@
                       "required": true
                     }
                   }
-                ],
-                "type": "record"
+                ]
               }
             }
           },
           {
             "http_span_name": {
               "required": true,
+              "default": "method",
+              "description": "Specify whether to include the HTTP path in the span name.",
+              "type": "string",
               "one_of": [
                 "method",
                 "method_path"
-              ],
-              "type": "string",
-              "default": "method"
+              ]
             }
           },
           {
             "connect_timeout": {
+              "default": 2000,
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
               "between": [
                 0,
                 2147483646
-              ],
-              "type": "integer",
-              "default": 2000
+              ]
             }
           },
           {
             "send_timeout": {
+              "default": 5000,
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
               "between": [
                 0,
                 2147483646
-              ],
-              "type": "integer",
-              "default": 5000
+              ]
             }
           },
           {
             "read_timeout": {
+              "default": 5000,
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
               "between": [
                 0,
                 2147483646
-              ],
-              "type": "integer",
-              "default": 5000
+              ]
             }
           },
           {
@@ -201,78 +226,98 @@
           {
             "phase_duration_flavor": {
               "required": true,
+              "default": "annotations",
+              "description": "Specify whether to include the duration of each phase as an annotation or a tag.",
+              "type": "string",
               "one_of": [
                 "annotations",
                 "tags"
-              ],
-              "type": "string",
-              "default": "annotations"
+              ]
             }
           },
           {
             "queue": {
-              "required": true,
               "fields": [
                 {
                   "max_batch_size": {
+                    "default": 1,
+                    "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_coalescing_delay": {
+                    "default": 1,
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
                     "between": [
                       0,
                       3600
-                    ],
-                    "type": "number",
-                    "default": 1
+                    ]
                   }
                 },
                 {
                   "max_entries": {
+                    "default": 10000,
+                    "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ],
-                    "type": "number",
-                    "default": 10000
+                    ]
                   }
                 },
                 {
                   "max_bytes": {
-                    "type": "number"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
                   "max_retry_time": {
                     "default": 60,
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
                     "type": "number"
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "type": "number"
+                    "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "type": "number"
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "between": [
+                      0.001,
+                      1000000
+                    ]
                   }
                 }
               ],
-              "type": "record"
+              "type": "record",
+              "required": true
             }
           }
         ],
-        "type": "record"
+        "type": "record",
+        "required": true
       }
     }
+  ],
+  "entity_checks": [
+
   ]
 }


### PR DESCRIPTION
Now that the descriptions were merged into the schemas, we can pull them using the API.

Note: 
I've used the `kong/kong-gateway-dev` `latest` docker image.
One thing to point out is that I've tried to validate the examples, and [one of them](https://github.com/Kong/docs-plugin-toolkit/blob/main/examples/application-registration/_3.4.x.yaml) is failing:

```
---------------------------------
| Plugin: application-registration
| Source: ./examples/application-registration/_3.4.x.yaml
| Response Code: 400
| Valid?: ❌
| name: schema violation
| fields: {"service"=>{"id"=>"missing primary key"}}
| code: 2
| message: schema violation (service.id: missing primary key)
---------------------------------
```

The example works for versions 3.3.x and 3.2.x (I haven't verified the rest).
It looks like the schema didn't change so I need to look into this a bit more.
