### PR TITLE
Drop consumer_group from rate-limiting-advanced example

### DIFF
--- a/examples/rate-limiting-advanced/_3.4.x.yaml
+++ b/examples/rate-limiting-advanced/_3.4.x.yaml
@@ -9,7 +9,3 @@ config:
   namespace: example_namespace
   strategy: local
   hide_client_headers: false
-  enforce_consumer_groups: true
-  consumer_groups:
-    - group1
-    - group2


### PR DESCRIPTION
   Drop consumer_group from rate-limiting-advanced example.