### PR TITLE
Generate plugin schemas and referenceable fields for 3.4

### DIFF
--- a/data/referenceable_fields/3.4.x.json
+++ b/data/referenceable_fields/3.4.x.json
@@ -1,4 +1,24 @@
 {
+  "acme": [
+    "config.account_email",
+    "config.eab_kid",
+    "config.eab_hmac_key",
+    "config.storage_config.redis.auth",
+    "config.storage_config.consul.token",
+    "config.storage_config.vault.token"
+  ],
+  "aws-lambda": [
+    "config.aws_key",
+    "config.aws_secret",
+    "config.aws_assume_role_arn"
+  ],
+  "azure-functions": [
+    "config.apikey",
+    "config.clientid"
+  ],
+  "datadog": [
+    "config.host"
+  ],
   "forward-proxy": [
     "config.auth_username",
     "config.auth_password"
@@ -8,6 +28,10 @@
     "config.redis.password",
     "config.redis.sentinel_username",
     "config.redis.sentinel_password"
+  ],
+  "http-log": [
+    "config.http_endpoint",
+    "config.headers"
   ],
   "kafka-log": [
     "config.authentication.user",
@@ -20,6 +44,9 @@
   "ldap-auth-advanced": [
     "config.ldap_password",
     "config.bind_dn"
+  ],
+  "loggly": [
+    "config.key"
   ],
   "openid-connect": [
     "config.client_id",
@@ -38,11 +65,19 @@
     "config.session_redis_username",
     "config.session_redis_password"
   ],
+  "opentelemetry": [
+    "config.endpoint",
+    "config.headers"
+  ],
   "proxy-cache-advanced": [
     "config.redis.username",
     "config.redis.password",
     "config.redis.sentinel_username",
     "config.redis.sentinel_password"
+  ],
+  "rate-limiting": [
+    "config.redis_password",
+    "config.redis_username"
   ],
   "rate-limiting-advanced": [
     "config.redis.username",
@@ -64,6 +99,10 @@
     "config.append.headers",
     "config.append.querystring"
   ],
+  "response-ratelimiting": [
+    "config.redis_password",
+    "config.redis_username"
+  ],
   "saml": [
     "config.idp_certificate",
     "config.response_encryption_key",
@@ -72,44 +111,6 @@
     "config.session_secret",
     "config.session_redis_username",
     "config.session_redis_password"
-  ],
-  "acme": [
-    "config.account_email",
-    "config.eab_kid",
-    "config.eab_hmac_key",
-    "config.storage_config.redis.auth",
-    "config.storage_config.consul.token",
-    "config.storage_config.vault.token"
-  ],
-  "aws-lambda": [
-    "config.aws_key",
-    "config.aws_secret",
-    "config.aws_assume_role_arn"
-  ],
-  "azure-functions": [
-    "config.apikey",
-    "config.clientid"
-  ],
-  "datadog": [
-    "config.host"
-  ],
-  "http-log": [
-    "config.http_endpoint",
-    "config.headers"
-  ],
-  "loggly": [
-    "config.key"
-  ],
-  "opentelemetry": [
-    "config.headers"
-  ],
-  "rate-limiting": [
-    "config.redis_password",
-    "config.redis_username"
-  ],
-  "response-ratelimiting": [
-    "config.redis_password",
-    "config.redis_username"
   ],
   "session": [
     "config.secret"

--- a/schemas/acl/3.4.x.json
+++ b/schemas/acl/3.4.x.json
@@ -3,17 +3,17 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -25,7 +25,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -35,26 +34,28 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "allow": {
-              "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             }
           },
           {
             "deny": {
-              "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array"
             }
           },
           {
@@ -65,7 +66,6 @@
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/acme/3.4.x.json
+++ b/schemas/acme/3.4.x.json
@@ -3,33 +3,33 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "service": {
         "reference": "services",
-        "description": "A reference to the 'services' table with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "A reference to the 'services' table with a null value allowed."
       }
     },
     {
       "route": {
         "reference": "routes",
-        "description": "A reference to the 'routes' table with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "A reference to the 'routes' table with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -41,7 +41,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -51,145 +50,146 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "account_email": {
               "required": true,
               "referenceable": true,
-              "encrypted": true,
-              "description": "The account identifier. Can be reused in a different plugin instance.",
               "type": "string",
-              "match": "%w*%p*@+%w*%.?%w*"
+              "match": "%w*%p*@+%w*%.?%w*",
+              "encrypted": true,
+              "description": "The account identifier. Can be reused in a different plugin instance."
             }
           },
           {
             "account_key": {
               "required": false,
-              "description": "The private key associated with the account.",
               "type": "record",
               "fields": [
                 {
                   "key_id": {
-                    "description": "The Key ID.",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "description": "The Key ID."
                   }
                 },
                 {
                   "key_set": {
-                    "type": "string",
-                    "description": "The ID of the key set to associate the Key ID with."
+                    "description": "The ID of the key set to associate the Key ID with.",
+                    "type": "string"
                   }
                 }
-              ]
+              ],
+              "description": "The private key associated with the account."
             }
           },
           {
             "api_uri": {
               "default": "https://acme-v02.api.letsencrypt.org/directory",
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "tos_accepted": {
               "default": false,
-              "description": "If you are using Let's Encrypt, you must set this to `true` to agree the terms of service.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If you are using Let's Encrypt, you must set this to `true` to agree the terms of service."
             }
           },
           {
             "eab_kid": {
               "referenceable": true,
-              "description": "External account binding (EAB) key id. You usually don't need to set this unless it is explicitly required by the CA.",
               "type": "string",
-              "encrypted": true
+              "encrypted": true,
+              "description": "External account binding (EAB) key id. You usually don't need to set this unless it is explicitly required by the CA."
             }
           },
           {
             "eab_hmac_key": {
               "referenceable": true,
-              "description": "External account binding (EAB) base64-encoded URL string of the HMAC key. You usually don't need to set this unless it is explicitly required by the CA.",
               "type": "string",
-              "encrypted": true
+              "encrypted": true,
+              "description": "External account binding (EAB) base64-encoded URL string of the HMAC key. You usually don't need to set this unless it is explicitly required by the CA."
             }
           },
           {
             "cert_type": {
               "default": "rsa",
-              "description": "The certificate type to create. The possible values are `'rsa'` for RSA certificate or `'ecc'` for EC certificate.",
               "type": "string",
               "one_of": [
                 "rsa",
                 "ecc"
-              ]
+              ],
+              "description": "The certificate type to create. The possible values are `'rsa'` for RSA certificate or `'ecc'` for EC certificate."
             }
           },
           {
             "rsa_key_size": {
               "default": 4096,
-              "description": "RSA private key size for the certificate. The possible values are 2048, 3072, or 4096.",
               "type": "number",
               "one_of": [
                 2048,
                 3072,
                 4096
-              ]
+              ],
+              "description": "RSA private key size for the certificate. The possible values are 2048, 3072, or 4096."
             }
           },
           {
             "renew_threshold_days": {
               "default": 14,
-              "description": "Days remaining to renew the certificate before it expires.",
-              "type": "number"
+              "type": "number",
+              "description": "Days remaining to renew the certificate before it expires."
             }
           },
           {
             "domains": {
-              "description": "An array of strings representing hosts. A valid host is a string containing one or more labels separated by periods, with at most one wildcard label ('*')",
               "type": "array",
               "elements": {
-                "match_any": {
-                  "err": "invalid wildcard: must be placed at leftmost or rightmost label",
-                  "patterns": [
-                    "^%*%.",
-                    "%.%*$",
-                    "^[^*]*$"
-                  ]
-                },
                 "match_all": [
                   {
                     "pattern": "^[^*]*%*?[^*]*$",
                     "err": "invalid wildcard: must have at most one wildcard"
                   }
                 ],
-                "type": "string"
-              }
+                "type": "string",
+                "match_any": {
+                  "patterns": [
+                    "^%*%.",
+                    "%.%*$",
+                    "^[^*]*$"
+                  ],
+                  "err": "invalid wildcard: must be placed at leftmost or rightmost label"
+                }
+              },
+              "description": "An array of strings representing hosts. A valid host is a string containing one or more labels separated by periods, with at most one wildcard label ('*')"
             }
           },
           {
             "allow_any_domain": {
               "default": false,
-              "description": "If set to `true`, the plugin allows all domains and ignores any values in the `domains` list.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to `true`, the plugin allows all domains and ignores any values in the `domains` list."
             }
           },
           {
             "fail_backoff_minutes": {
               "default": 5,
-              "description": "Minutes to wait for each domain that fails to create a certificate. This applies to both a\nnew certificate and a renewal certificate.",
-              "type": "number"
+              "type": "number",
+              "description": "Minutes to wait for each domain that fails to create a certificate. This applies to both a\nnew certificate and a renewal certificate."
             }
           },
           {
             "storage": {
               "default": "shm",
-              "description": "The backend storage type to use. The possible values are `'kong'`, `'shm'`, `'redis'`, `'consul'`, or `'vault'`. In DB-less mode, `'kong'` storage is unavailable. Note that `'shm'` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `'kong'`, `'redis'`, `'consul'`, or `'vault'` in production. Please refer to the Hybrid Mode sections below as well.",
               "type": "string",
               "one_of": [
                 "kong",
@@ -197,249 +197,250 @@
                 "redis",
                 "consul",
                 "vault"
-              ]
+              ],
+              "description": "The backend storage type to use. The possible values are `'kong'`, `'shm'`, `'redis'`, `'consul'`, or `'vault'`. In DB-less mode, `'kong'` storage is unavailable. Note that `'shm'` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `'kong'`, `'redis'`, `'consul'`, or `'vault'` in production. Please refer to the Hybrid Mode sections below as well."
             }
           },
           {
             "storage_config": {
+              "type": "record",
               "fields": [
                 {
                   "shm": {
+                    "type": "record",
                     "fields": [
                       {
                         "shm_name": {
                           "default": "kong",
-                          "description": "Name of shared memory zone used for Kong API gateway storage",
-                          "type": "string"
+                          "type": "string",
+                          "description": "Name of shared memory zone used for Kong API gateway storage"
                         }
                       }
                     ],
-                    "type": "record",
                     "required": true
                   }
                 },
                 {
                   "kong": {
+                    "type": "record",
                     "fields": [
 
                     ],
-                    "type": "record",
                     "required": true
                   }
                 },
                 {
                   "redis": {
+                    "type": "record",
                     "fields": [
                       {
                         "host": {
-                          "type": "string",
-                          "description": "A string representing a host name, such as example.com."
+                          "description": "A string representing a host name, such as example.com.",
+                          "type": "string"
                         }
                       },
                       {
                         "port": {
+                          "type": "integer",
                           "between": [
                             0,
                             65535
                           ],
-                          "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                          "type": "integer"
+                          "description": "An integer representing a port number between 0 and 65535, inclusive."
                         }
                       },
                       {
                         "database": {
-                          "type": "number",
-                          "description": "The index of the Redis database to use."
+                          "description": "The index of the Redis database to use.",
+                          "type": "number"
                         }
                       },
                       {
                         "auth": {
-                          "description": "The Redis password to use for authentication. ",
                           "type": "string",
+                          "description": "The Redis password to use for authentication. ",
                           "referenceable": true
                         }
                       },
                       {
                         "ssl": {
                           "default": false,
-                          "description": "Whether to use SSL/TLS encryption when connecting to the Redis server.",
                           "type": "boolean",
-                          "required": true
+                          "required": true,
+                          "description": "Whether to use SSL/TLS encryption when connecting to the Redis server."
                         }
                       },
                       {
                         "ssl_verify": {
                           "default": false,
-                          "description": "Whether to verify the SSL/TLS certificate presented by the Redis server. This should be a boolean value.",
                           "type": "boolean",
-                          "required": true
+                          "required": true,
+                          "description": "Whether to verify the SSL/TLS certificate presented by the Redis server. This should be a boolean value."
                         }
                       },
                       {
                         "ssl_server_name": {
-                          "description": "The expected server name for the SSL/TLS certificate presented by the Redis server.",
                           "type": "string",
-                          "required": false
+                          "required": false,
+                          "description": "The expected server name for the SSL/TLS certificate presented by the Redis server."
                         }
                       },
                       {
                         "namespace": {
                           "required": true,
+                          "len_min": 0,
                           "default": "",
-                          "description": "A namespace to prepend to all keys stored in Redis.",
                           "type": "string",
-                          "len_min": 0
+                          "description": "A namespace to prepend to all keys stored in Redis."
                         }
                       }
                     ],
-                    "type": "record",
                     "required": true
                   }
                 },
                 {
                   "consul": {
+                    "type": "record",
                     "fields": [
                       {
                         "https": {
                           "default": false,
-                          "description": "Boolean representation of https.",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Boolean representation of https."
                         }
                       },
                       {
                         "host": {
-                          "type": "string",
-                          "description": "A string representing a host name, such as example.com."
+                          "description": "A string representing a host name, such as example.com.",
+                          "type": "string"
                         }
                       },
                       {
                         "port": {
+                          "type": "integer",
                           "between": [
                             0,
                             65535
                           ],
-                          "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                          "type": "integer"
+                          "description": "An integer representing a port number between 0 and 65535, inclusive."
                         }
                       },
                       {
                         "kv_path": {
-                          "type": "string",
-                          "description": "KV prefix path."
+                          "description": "KV prefix path.",
+                          "type": "string"
                         }
                       },
                       {
                         "timeout": {
-                          "type": "number",
-                          "description": "Timeout in milliseconds."
+                          "description": "Timeout in milliseconds.",
+                          "type": "number"
                         }
                       },
                       {
                         "token": {
-                          "description": "Consul ACL token.",
                           "type": "string",
+                          "description": "Consul ACL token.",
                           "referenceable": true
                         }
                       }
                     ],
-                    "type": "record",
                     "required": true
                   }
                 },
                 {
                   "vault": {
+                    "type": "record",
                     "fields": [
                       {
                         "https": {
                           "default": false,
-                          "description": "Boolean representation of https.",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Boolean representation of https."
                         }
                       },
                       {
                         "host": {
-                          "type": "string",
-                          "description": "A string representing a host name, such as example.com."
+                          "description": "A string representing a host name, such as example.com.",
+                          "type": "string"
                         }
                       },
                       {
                         "port": {
+                          "type": "integer",
                           "between": [
                             0,
                             65535
                           ],
-                          "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                          "type": "integer"
+                          "description": "An integer representing a port number between 0 and 65535, inclusive."
                         }
                       },
                       {
                         "kv_path": {
-                          "type": "string",
-                          "description": "KV prefix path."
+                          "description": "KV prefix path.",
+                          "type": "string"
                         }
                       },
                       {
                         "timeout": {
-                          "type": "number",
-                          "description": "Timeout in milliseconds."
+                          "description": "Timeout in milliseconds.",
+                          "type": "number"
                         }
                       },
                       {
                         "token": {
-                          "description": "Consul ACL token.",
                           "type": "string",
+                          "description": "Consul ACL token.",
                           "referenceable": true
                         }
                       },
                       {
                         "tls_verify": {
                           "default": true,
-                          "description": "Turn on TLS verification.",
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Turn on TLS verification."
                         }
                       },
                       {
                         "tls_server_name": {
-                          "type": "string",
-                          "description": "SNI used in request, default to host if omitted."
+                          "description": "SNI used in request, default to host if omitted.",
+                          "type": "string"
                         }
                       },
                       {
                         "auth_method": {
                           "default": "token",
-                          "description": "Auth Method, default to token, can be 'token' or 'kubernetes'.",
                           "type": "string",
                           "one_of": [
                             "token",
                             "kubernetes"
-                          ]
+                          ],
+                          "description": "Auth Method, default to token, can be 'token' or 'kubernetes'."
                         }
                       },
                       {
                         "auth_path": {
-                          "type": "string",
-                          "description": "Vault's authentication path to use."
+                          "description": "Vault's authentication path to use.",
+                          "type": "string"
                         }
                       },
                       {
                         "auth_role": {
-                          "type": "string",
-                          "description": "The role to try and assign."
+                          "description": "The role to try and assign.",
+                          "type": "string"
                         }
                       },
                       {
                         "jwt_path": {
-                          "type": "string",
-                          "description": "The path to the JWT."
+                          "description": "The path to the JWT.",
+                          "type": "string"
                         }
                       }
                     ],
-                    "type": "record",
                     "required": true
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
@@ -452,12 +453,11 @@
           {
             "enable_ipv4_common_name": {
               "default": true,
-              "description": "A boolean value that controls whether to include the IPv4 address in the common name field of generated certificates.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that controls whether to include the IPv4 address in the common name field of generated certificates."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }
@@ -465,18 +465,18 @@
   "entity_checks": [
     {
       "conditional": {
-        "then_field": "config.tos_accepted",
         "then_err": "terms of service must be accepted, see https://letsencrypt.org/repository/",
-        "then_match": {
-          "eq": true
-        },
         "if_match": {
           "one_of": [
             "https://acme-v02.api.letsencrypt.org",
             "https://acme-staging-v02.api.letsencrypt.org"
           ]
         },
-        "if_field": "config.api_uri"
+        "then_field": "config.tos_accepted",
+        "if_field": "config.api_uri",
+        "then_match": {
+          "eq": true
+        }
       }
     },
     {

--- a/schemas/application-registration/3.4.x.json
+++ b/schemas/application-registration/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -19,9 +19,9 @@
     {
       "route": {
         "reference": "routes",
-        "description": "A reference to the 'routes' table with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "A reference to the 'routes' table with a null value allowed."
       }
     },
     {
@@ -33,7 +33,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -42,54 +41,57 @@
             "grpcs",
             "http",
             "https"
-          ]
-        }
+          ],
+          "required": true,
+          "len_min": 1
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "display_name": {
               "unique": true,
-              "description": "Unique display name used for a Service in the Developer Portal.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Unique display name used for a Service in the Developer Portal."
             }
           },
           {
             "description": {
-              "description": "Unique description displayed in information about a Service in the Developer Portal.",
               "type": "string",
-              "unique": true
+              "unique": true,
+              "description": "Unique description displayed in information about a Service in the Developer Portal."
             }
           },
           {
             "auto_approve": {
               "default": false,
-              "description": "If enabled, all new Service Contracts requests are automatically approved.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If enabled, all new Service Contracts requests are automatically approved."
             }
           },
           {
             "show_issuer": {
               "default": false,
-              "description": "Displays the **Issuer URL** in the **Service Details** dialog.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Displays the **Issuer URL** in the **Service Details** dialog."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/aws-lambda/3.4.x.json
+++ b/schemas/aws-lambda/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,122 +18,124 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "timeout": {
               "default": 60000,
-              "description": "An optional timeout in milliseconds when invoking the function.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "An optional timeout in milliseconds when invoking the function."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed."
             }
           },
           {
             "aws_key": {
               "referenceable": true,
-              "description": "The AWS key credential to be used when invoking the function.",
               "type": "string",
-              "encrypted": true
+              "encrypted": true,
+              "description": "The AWS key credential to be used when invoking the function."
             }
           },
           {
             "aws_secret": {
               "referenceable": true,
-              "description": "The AWS secret credential to be used when invoking the function. ",
               "type": "string",
-              "encrypted": true
+              "encrypted": true,
+              "description": "The AWS secret credential to be used when invoking the function. "
             }
           },
           {
             "aws_assume_role_arn": {
               "referenceable": true,
-              "description": "The target AWS IAM role ARN used to invoke the Lambda function.",
               "type": "string",
-              "encrypted": true
+              "encrypted": true,
+              "description": "The target AWS IAM role ARN used to invoke the Lambda function."
             }
           },
           {
             "aws_role_session_name": {
               "default": "kong",
-              "description": "The identifier of the assumed role session.",
-              "type": "string"
+              "type": "string",
+              "description": "The identifier of the assumed role session."
             }
           },
           {
             "aws_region": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "function_name": {
-              "description": "The AWS Lambda function name to invoke.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The AWS Lambda function name to invoke."
             }
           },
           {
             "qualifier": {
-              "type": "string",
-              "description": "The qualifier to use when invoking the function."
+              "description": "The qualifier to use when invoking the function.",
+              "type": "string"
             }
           },
           {
             "invocation_type": {
               "required": true,
               "default": "RequestResponse",
-              "description": "The InvocationType to use when invoking the function. Available types are RequestResponse, Event, DryRun.",
               "type": "string",
               "one_of": [
                 "RequestResponse",
                 "Event",
                 "DryRun"
-              ]
+              ],
+              "description": "The InvocationType to use when invoking the function. Available types are RequestResponse, Event, DryRun."
             }
           },
           {
             "log_type": {
               "required": true,
               "default": "Tail",
-              "description": "The LogType to use when invoking the function. By default, None and Tail are supported.",
               "type": "string",
               "one_of": [
                 "Tail",
                 "None"
-              ]
+              ],
+              "description": "The LogType to use when invoking the function. By default, None and Tail are supported."
             }
           },
           {
             "host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "port": {
               "default": 443,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
@@ -149,90 +150,89 @@
           },
           {
             "unhandled_status": {
+              "type": "integer",
+              "description": "The response status code to use (instead of the default 200, 202, or 204) in the case of an Unhandled Function Error.",
               "between": [
                 100,
                 999
-              ],
-              "description": "The response status code to use (instead of the default 200, 202, or 204) in the case of an Unhandled Function Error.",
-              "type": "integer"
+              ]
             }
           },
           {
             "forward_request_method": {
               "default": false,
-              "description": "An optional value that defines whether the original HTTP request method verb is sent in the request_method field of the JSON-encoded request.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether the original HTTP request method verb is sent in the request_method field of the JSON-encoded request."
             }
           },
           {
             "forward_request_uri": {
               "default": false,
-              "description": "An optional value that defines whether the original HTTP request URI is sent in the request_uri field of the JSON-encoded request.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether the original HTTP request URI is sent in the request_uri field of the JSON-encoded request."
             }
           },
           {
             "forward_request_headers": {
               "default": false,
-              "description": "An optional value that defines whether the original HTTP request headers are sent as a map in the request_headers field of the JSON-encoded request.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether the original HTTP request headers are sent as a map in the request_headers field of the JSON-encoded request."
             }
           },
           {
             "forward_request_body": {
               "default": false,
-              "description": "An optional value that defines whether the request body is sent in the request_body field of the JSON-encoded request. If the body arguments can be parsed, they are sent in the separate request_body_args field of the request. ",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether the request body is sent in the request_body field of the JSON-encoded request. If the body arguments can be parsed, they are sent in the separate request_body_args field of the request. "
             }
           },
           {
             "is_proxy_integration": {
               "default": false,
-              "description": "An optional value that defines whether the response format to receive from the Lambda to this format.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether the response format to receive from the Lambda to this format."
             }
           },
           {
             "awsgateway_compatible": {
               "default": false,
-              "description": "An optional value that defines whether the plugin should wrap requests into the Amazon API gateway.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether the plugin should wrap requests into the Amazon API gateway."
             }
           },
           {
             "proxy_url": {
-              "type": "string",
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string"
             }
           },
           {
             "skip_large_bodies": {
               "default": true,
-              "description": "An optional value that defines whether Kong should send large bodies that are buffered to disk",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that defines whether Kong should send large bodies that are buffered to disk"
             }
           },
           {
             "base64_encode_body": {
               "default": true,
-              "description": "An optional value that Base64-encodes the request body.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional value that Base64-encodes the request body."
             }
           },
           {
             "aws_imds_protocol_version": {
               "required": true,
               "default": "v1",
-              "description": "Identifier to select the IMDS protocol version to use: `v1` or `v2`.",
               "type": "string",
               "one_of": [
                 "v1",
                 "v2"
-              ]
+              ],
+              "description": "Identifier to select the IMDS protocol version to use: `v1` or `v2`."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/azure-functions/3.4.x.json
+++ b/schemas/azure-functions/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,96 +23,98 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "timeout": {
               "default": 600000,
-              "description": "Timeout in milliseconds before closing a connection to the Azure Functions server.",
-              "type": "number"
+              "type": "number",
+              "description": "Timeout in milliseconds before closing a connection to the Azure Functions server."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "Time in milliseconds during which an idle connection to the Azure Functions server lives before being closed.",
-              "type": "number"
+              "type": "number",
+              "description": "Time in milliseconds during which an idle connection to the Azure Functions server lives before being closed."
             }
           },
           {
             "https": {
               "default": true,
-              "description": "Use of HTTPS to connect with the Azure Functions server.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Use of HTTPS to connect with the Azure Functions server."
             }
           },
           {
             "https_verify": {
               "default": false,
-              "description": "Set to `true` to authenticate the Azure Functions server.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Set to `true` to authenticate the Azure Functions server."
             }
           },
           {
             "apikey": {
-              "encrypted": true,
-              "description": "The apikey to access the Azure resources. If provided, it is injected as the `x-functions-key` header.",
+              "referenceable": true,
               "type": "string",
-              "referenceable": true
+              "encrypted": true,
+              "description": "The apikey to access the Azure resources. If provided, it is injected as the `x-functions-key` header."
             }
           },
           {
             "clientid": {
-              "encrypted": true,
-              "description": "The `clientid` to access the Azure resources. If provided, it is injected as the `x-functions-clientid` header.",
+              "referenceable": true,
               "type": "string",
-              "referenceable": true
+              "encrypted": true,
+              "description": "The `clientid` to access the Azure resources. If provided, it is injected as the `x-functions-clientid` header."
             }
           },
           {
             "appname": {
-              "description": "The Azure app name.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The Azure app name."
             }
           },
           {
             "hostdomain": {
               "default": "azurewebsites.net",
-              "description": "The domain where the function resides.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The domain where the function resides."
             }
           },
           {
             "routeprefix": {
               "default": "api",
-              "description": "Route prefix to use.",
-              "type": "string"
+              "type": "string",
+              "description": "Route prefix to use."
             }
           },
           {
             "functionname": {
-              "description": "Name of the Azure function to invoke.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Name of the Azure function to invoke."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/basic-auth/3.4.x.json
+++ b/schemas/basic-auth/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -18,8 +18,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,30 +36,30 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "anonymous": {
-              "type": "string",
-              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`."
+              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.",
+              "type": "string"
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/bot-detection/3.4.x.json
+++ b/schemas/bot-detection/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,31 +26,33 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "allow": {
               "default": [
 
               ],
-              "description": "An array of regular expressions that should be allowed. The regular expressions will be checked against the `User-Agent` header.",
               "type": "array",
               "elements": {
                 "is_regex": true,
                 "type": "string"
-              }
+              },
+              "description": "An array of regular expressions that should be allowed. The regular expressions will be checked against the `User-Agent` header."
             }
           },
           {
@@ -59,16 +60,15 @@
               "default": [
 
               ],
-              "description": "An array of regular expressions that should be denied. The regular expressions will be checked against the `User-Agent` header.",
               "type": "array",
               "elements": {
                 "is_regex": true,
                 "type": "string"
-              }
+              },
+              "description": "An array of regular expressions that should be denied. The regular expressions will be checked against the `User-Agent` header."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/canary/3.4.x.json
+++ b/schemas/canary/3.4.x.json
@@ -3,17 +3,17 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -25,7 +25,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -35,7 +34,8 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
@@ -43,14 +43,13 @@
         "fields": [
           {
             "start": {
-              "type": "number",
-              "description": "Future time in seconds since epoch, when the canary release will start. Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`."
+              "description": "Future time in seconds since epoch, when the canary release will start. Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`.",
+              "type": "number"
             }
           },
           {
             "hash": {
               "default": "consumer",
-              "description": "Hash algorithm to be used for canary release.\n\n* `consumer`: The hash will be based on the consumer.\n* `ip`: The hash will be based on the client IP address.\n* `none`: No hash will be applied.\n* `allow`: Allows the specified groups to access the canary release.\n* `deny`: Denies the specified groups from accessing the canary release.\n* `header`: The hash will be based on the specified header value.",
               "type": "string",
               "one_of": [
                 "consumer",
@@ -59,98 +58,99 @@
                 "allow",
                 "deny",
                 "header"
-              ]
+              ],
+              "description": "Hash algorithm to be used for canary release.\n\n* `consumer`: The hash will be based on the consumer.\n* `ip`: The hash will be based on the client IP address.\n* `none`: No hash will be applied.\n* `allow`: Allows the specified groups to access the canary release.\n* `deny`: Denies the specified groups from accessing the canary release.\n* `header`: The hash will be based on the specified header value."
             }
           },
           {
             "hash_header": {
-              "type": "string",
-              "description": "A string representing an HTTP header name."
+              "description": "A string representing an HTTP header name.",
+              "type": "string"
             }
           },
           {
             "duration": {
               "default": 3600,
-              "description": "The duration of the canary release in seconds.",
               "type": "number",
-              "gt": 0
+              "gt": 0,
+              "description": "The duration of the canary release in seconds."
             }
           },
           {
             "steps": {
               "default": 1000,
-              "description": "The number of steps for the canary release.",
               "type": "number",
-              "gt": 1
+              "gt": 1,
+              "description": "The number of steps for the canary release."
             }
           },
           {
             "percentage": {
+              "type": "number",
+              "description": "The percentage of traffic to be routed to the canary release.",
               "between": [
                 0,
                 100
-              ],
-              "description": "The percentage of traffic to be routed to the canary release.",
-              "type": "number"
+              ]
             }
           },
           {
             "upstream_host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "upstream_port": {
+              "type": "integer",
               "between": [
                 0,
                 65535
               ],
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer"
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "upstream_uri": {
-              "len_min": 1,
+              "type": "string",
               "description": "The URI of the upstream server to be used for the canary release.",
-              "type": "string"
+              "len_min": 1
             }
           },
           {
             "upstream_fallback": {
               "default": false,
-              "description": "Specifies whether to fallback to the upstream server if the canary release fails.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Specifies whether to fallback to the upstream server if the canary release fails."
             }
           },
           {
             "groups": {
-              "description": "The groups allowed to access the canary release.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "The groups allowed to access the canary release."
             }
           },
           {
             "canary_by_header_name": {
-              "type": "string",
-              "description": "A string representing an HTTP header name."
+              "description": "A string representing an HTTP header name.",
+              "type": "string"
             }
           }
         ],
         "type": "record",
+        "required": true,
         "shorthand_fields": [
           {
             "hash": {
-              "type": "string",
-              "description": "Hash algorithm to be used for canary release. `whitelist` is deprecated. Use `allow` instead `blacklist` is deprecated. Use `deny` instead."
+              "description": "Hash algorithm to be used for canary release. `whitelist` is deprecated. Use `allow` instead `blacklist` is deprecated. Use `deny` instead.",
+              "type": "string"
             }
           }
-        ],
-        "required": true
+        ]
       }
     }
   ],
@@ -164,11 +164,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.hash",
-        "then_field": "config.hash_header",
         "if_match": {
           "eq": "header"
         },
+        "then_field": "config.hash_header",
+        "if_field": "config.hash",
         "then_match": {
           "required": true
         }
@@ -176,11 +176,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.upstream_fallback",
-        "then_field": "config.upstream_host",
         "if_match": {
           "eq": true
         },
+        "then_field": "config.upstream_host",
+        "if_field": "config.upstream_fallback",
         "then_match": {
           "required": true
         }

--- a/schemas/correlation-id/3.4.x.json
+++ b/schemas/correlation-id/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,49 +18,50 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "header_name": {
               "default": "Kong-Request-ID",
-              "description": "The HTTP header name to use for the correlation ID.",
-              "type": "string"
+              "type": "string",
+              "description": "The HTTP header name to use for the correlation ID."
             }
           },
           {
             "generator": {
               "default": "uuid#counter",
-              "description": "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators).",
               "type": "string",
               "one_of": [
                 "uuid",
                 "uuid#counter",
                 "tracker"
-              ]
+              ],
+              "description": "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators)."
             }
           },
           {
             "echo_downstream": {
               "default": false,
-              "description": "Whether to echo the header back to downstream (the client).",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Whether to echo the header back to downstream (the client)."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/cors/3.4.x.json
+++ b/schemas/cors/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,10 +17,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
-          "len_min": 1,
           "type": "string",
           "one_of": [
             "grpc",
@@ -28,46 +26,49 @@
             "http",
             "https"
           ],
-          "required": true
-        }
+          "required": true,
+          "len_min": 1
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "origins": {
-              "description": "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes."
             }
           },
           {
             "headers": {
-              "description": "Value for the `Access-Control-Allow-Headers` header.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Value for the `Access-Control-Allow-Headers` header."
             }
           },
           {
             "exposed_headers": {
-              "description": "Value for the `Access-Control-Expose-Headers` header. If not specified, no custom headers are exposed.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Value for the `Access-Control-Expose-Headers` header. If not specified, no custom headers are exposed."
             }
           },
           {
@@ -83,7 +84,6 @@
                 "TRACE",
                 "CONNECT"
               ],
-              "description": "'Value for the `Access-Control-Allow-Methods` header. Available options include `GET`, `HEAD`, `PUT`, `PATCH`, `POST`, `DELETE`, `OPTIONS`, `TRACE`, `CONNECT`. By default, all options are allowed.'",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -98,7 +98,8 @@
                   "TRACE",
                   "CONNECT"
                 ]
-              }
+              },
+              "description": "'Value for the `Access-Control-Allow-Methods` header. Available options include `GET`, `HEAD`, `PUT`, `PATCH`, `POST`, `DELETE`, `OPTIONS`, `TRACE`, `CONNECT`. By default, all options are allowed.'"
             }
           },
           {
@@ -110,21 +111,20 @@
           {
             "credentials": {
               "default": false,
-              "description": "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value."
             }
           },
           {
             "preflight_continue": {
               "default": false,
-              "description": "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/datadog/3.4.x.json
+++ b/schemas/datadog/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,16 +23,18 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -43,16 +43,16 @@
           {
             "host": {
               "default": "localhost",
-              "description": "A string representing a host name, such as example.com.",
               "type": "string",
-              "referenceable": true
+              "referenceable": true,
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
               "default": 8125,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
@@ -62,29 +62,29 @@
           {
             "prefix": {
               "default": "kong",
-              "description": "String to be attached as a prefix to a metric's name.",
-              "type": "string"
+              "type": "string",
+              "description": "String to be attached as a prefix to a metric's name."
             }
           },
           {
             "service_name_tag": {
               "default": "name",
-              "description": "String to be attached as the name of the service.",
-              "type": "string"
+              "type": "string",
+              "description": "String to be attached as the name of the service."
             }
           },
           {
             "status_tag": {
               "default": "status",
-              "description": "String to be attached as the tag of the HTTP status.",
-              "type": "string"
+              "type": "string",
+              "description": "String to be attached as the tag of the HTTP status."
             }
           },
           {
             "consumer_tag": {
               "default": "consumer",
-              "description": "String to be attached as tag of the consumer.",
-              "type": "string"
+              "type": "string",
+              "description": "String to be attached as tag of the consumer."
             }
           },
           {
@@ -107,38 +107,39 @@
           },
           {
             "queue": {
+              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
                     "default": 1,
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
                     "default": 1,
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "type": "number",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
                     "default": 10000,
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
@@ -150,26 +151,26 @@
                 {
                   "max_retry_time": {
                     "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
-                    "type": "number"
+                    "type": "number",
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "type": "number",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
@@ -177,7 +178,6 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
@@ -186,63 +186,61 @@
               "required": true,
               "default": [
                 {
-                  "consumer_identifier": "custom_id",
-                  "tags": [
-                    "app:kong"
-                  ],
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "request_count"
-                },
-                {
+                  "stat_type": "counter",
+                  "name": "request_count",
+                  "consumer_identifier": "custom_id",
                   "tags": [
                     "app:kong"
-                  ],
+                  ]
+                },
+                {
+                  "consumer_identifier": "custom_id",
                   "name": "latency",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer"
-                },
-                {
                   "tags": [
                     "app:kong"
                   ],
+                  "stat_type": "timer"
+                },
+                {
+                  "consumer_identifier": "custom_id",
                   "name": "request_size",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer"
-                },
-                {
                   "tags": [
                     "app:kong"
                   ],
+                  "stat_type": "timer"
+                },
+                {
+                  "consumer_identifier": "custom_id",
                   "name": "response_size",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer"
-                },
-                {
                   "tags": [
                     "app:kong"
                   ],
+                  "stat_type": "timer"
+                },
+                {
+                  "consumer_identifier": "custom_id",
                   "name": "upstream_latency",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer"
-                },
-                {
                   "tags": [
                     "app:kong"
                   ],
-                  "name": "kong_latency",
+                  "stat_type": "timer"
+                },
+                {
                   "consumer_identifier": "custom_id",
+                  "name": "kong_latency",
+                  "tags": [
+                    "app:kong"
+                  ],
                   "stat_type": "timer"
                 }
               ],
-              "description": "List of metrics to be logged.",
               "type": "array",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "name": {
-                      "type": "string",
-                      "description": "Datadog metric’s name",
                       "one_of": [
                         "kong_latency",
                         "latency",
@@ -251,13 +249,13 @@
                         "response_size",
                         "upstream_latency"
                       ],
-                      "required": true
+                      "type": "string",
+                      "required": true,
+                      "description": "Datadog metric’s name"
                     }
                   },
                   {
                     "stat_type": {
-                      "type": "string",
-                      "description": "Determines what sort of event the metric represents",
                       "one_of": [
                         "counter",
                         "gauge",
@@ -267,65 +265,67 @@
                         "timer",
                         "distribution"
                       ],
-                      "required": true
+                      "type": "string",
+                      "required": true,
+                      "description": "Determines what sort of event the metric represents"
                     }
                   },
                   {
                     "tags": {
-                      "description": "List of tags",
                       "type": "array",
                       "elements": {
-                        "type": "string",
-                        "match": "^.*[^:]$"
-                      }
+                        "match": "^.*[^:]$",
+                        "type": "string"
+                      },
+                      "description": "List of tags"
                     }
                   },
                   {
                     "sample_rate": {
+                      "type": "number",
+                      "description": "Sampling rate",
                       "between": [
                         0,
                         1
-                      ],
-                      "description": "Sampling rate",
-                      "type": "number"
+                      ]
                     }
                   },
                   {
                     "consumer_identifier": {
-                      "description": "Authenticated user detail",
-                      "type": "string",
                       "one_of": [
                         "consumer_id",
                         "custom_id",
                         "username"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Authenticated user detail"
                     }
                   }
                 ],
-                "type": "record",
                 "entity_checks": [
                   {
                     "conditional": {
-                      "if_field": "stat_type",
-                      "then_field": "sample_rate",
                       "if_match": {
                         "one_of": [
                           "counter",
                           "gauge"
                         ]
                       },
+                      "then_field": "sample_rate",
+                      "if_field": "stat_type",
                       "then_match": {
                         "required": true
                       }
                     }
                   }
                 ]
-              }
+              },
+              "description": "List of metrics to be logged."
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "custom_entity_check": {

--- a/schemas/degraphql/3.4.x.json
+++ b/schemas/degraphql/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,37 +26,38 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "graphql_server_path": {
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "required": true,
+              "default": "/graphql",
+              "starts_with": "/",
+              "type": "string",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
-              "default": "/graphql",
-              "starts_with": "/",
-              "type": "string",
-              "required": true
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/exit-transformer/3.4.x.json
+++ b/schemas/exit-transformer/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,24 +18,26 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "functions": {
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
                 "type": "string"
               }
@@ -45,19 +46,18 @@
           {
             "handle_unknown": {
               "default": false,
-              "description": "Determines whether to handle unknown status codes by transforming their responses.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Determines whether to handle unknown status codes by transforming their responses."
             }
           },
           {
             "handle_unexpected": {
               "default": false,
-              "description": "Determines whether to handle unexpected errors by transforming their responses.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Determines whether to handle unexpected errors by transforming their responses."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/file-log/3.4.x.json
+++ b/schemas/file-log/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,42 +23,43 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "path": {
-              "err": "not a valid filename",
               "required": true,
-              "description": "The file path of the output log file. The plugin creates the log file if it doesn't exist yet.",
+              "err": "not a valid filename",
+              "match": "^[^*&%%\\`]+$",
               "type": "string",
-              "match": "^[^*&%%\\`]+$"
+              "description": "The file path of the output log file. The plugin creates the log file if it doesn't exist yet."
             }
           },
           {
             "reopen": {
               "default": false,
-              "description": "Determines whether the log file is closed and reopened on every request.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Determines whether the log file is closed and reopened on every request."
             }
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "description": "Lua code as a key-value map",
               "values": {
                 "len_min": 1,
                 "type": "string"
@@ -68,11 +67,12 @@
               "keys": {
                 "type": "string",
                 "len_min": 1
-              }
+              },
+              "type": "map",
+              "description": "Lua code as a key-value map"
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/forward-proxy/3.4.x.json
+++ b/schemas/forward-proxy/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,19 +18,104 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "required": true,
+        "fields": [
+          {
+            "x_headers": {
+              "required": true,
+              "default": "append",
+              "type": "string",
+              "one_of": [
+                "append",
+                "transparent",
+                "delete"
+              ],
+              "description": "Determines how to handle headers when forwarding the request."
+            }
+          },
+          {
+            "http_proxy_host": {
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
+            }
+          },
+          {
+            "http_proxy_port": {
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
+            }
+          },
+          {
+            "https_proxy_host": {
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
+            }
+          },
+          {
+            "https_proxy_port": {
+              "type": "integer",
+              "between": [
+                0,
+                65535
+              ],
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
+            }
+          },
+          {
+            "proxy_scheme": {
+              "required": true,
+              "default": "http",
+              "type": "string",
+              "one_of": [
+                "http"
+              ],
+              "description": "The proxy scheme to use when connecting. Only `http` is supported."
+            }
+          },
+          {
+            "auth_username": {
+              "description": "The username to authenticate with, if the forward proxy is protected\nby basic authentication.",
+              "type": "string",
+              "required": false,
+              "referenceable": true
+            }
+          },
+          {
+            "auth_password": {
+              "description": "The password to authenticate with, if the forward proxy is protected\nby basic authentication.",
+              "type": "string",
+              "required": false,
+              "referenceable": true
+            }
+          },
+          {
+            "https_verify": {
+              "default": false,
+              "type": "boolean",
+              "required": true,
+              "description": "Whether the server certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate."
+            }
+          }
+        ],
+        "type": "record",
         "shorthand_fields": [
           {
             "proxy_host": {
@@ -44,7 +128,6 @@
             }
           }
         ],
-        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -69,89 +152,6 @@
               "https_proxy_host",
               "https_proxy_port"
             ]
-          }
-        ],
-        "type": "record",
-        "fields": [
-          {
-            "x_headers": {
-              "required": true,
-              "default": "append",
-              "description": "Determines how to handle headers when forwarding the request.",
-              "type": "string",
-              "one_of": [
-                "append",
-                "transparent",
-                "delete"
-              ]
-            }
-          },
-          {
-            "http_proxy_host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
-            }
-          },
-          {
-            "http_proxy_port": {
-              "between": [
-                0,
-                65535
-              ],
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer"
-            }
-          },
-          {
-            "https_proxy_host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
-            }
-          },
-          {
-            "https_proxy_port": {
-              "between": [
-                0,
-                65535
-              ],
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer"
-            }
-          },
-          {
-            "proxy_scheme": {
-              "required": true,
-              "default": "http",
-              "description": "The proxy scheme to use when connecting. Only `http` is supported.",
-              "type": "string",
-              "one_of": [
-                "http"
-              ]
-            }
-          },
-          {
-            "auth_username": {
-              "referenceable": true,
-              "description": "The username to authenticate with, if the forward proxy is protected\nby basic authentication.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "auth_password": {
-              "referenceable": true,
-              "description": "The password to authenticate with, if the forward proxy is protected\nby basic authentication.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "https_verify": {
-              "default": false,
-              "description": "Whether the server certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate.",
-              "type": "boolean",
-              "required": true
-            }
           }
         ]
       }

--- a/schemas/graphql-proxy-cache-advanced/3.4.x.json
+++ b/schemas/graphql-proxy-cache-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,66 +18,67 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "strategy": {
               "required": true,
               "default": "memory",
-              "description": "The backing data store in which to hold cached entities. Accepted value is `memory`.",
               "type": "string",
               "one_of": [
                 "memory"
-              ]
+              ],
+              "description": "The backing data store in which to hold cached entities. Accepted value is `memory`."
             }
           },
           {
             "cache_ttl": {
-              "default": 300,
               "gt": 0,
               "type": "integer",
+              "default": 300,
               "description": "TTL in seconds of cache entities. Must be a value greater than 0."
             }
           },
           {
             "memory": {
+              "type": "record",
               "fields": [
                 {
                   "dictionary_name": {
                     "default": "kong_db_cache",
-                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. This dictionary currently must be defined manually in the Kong Nginx template.",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. This dictionary currently must be defined manually in the Kong Nginx template."
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "vary_headers": {
-              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/graphql-rate-limiting-advanced/3.4.x.json
+++ b/schemas/graphql-rate-limiting-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,75 +18,77 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "identifier": {
               "required": true,
               "default": "consumer",
-              "description": "How to define the rate limit key. Can be `ip`, `credential`, `consumer`.",
               "type": "string",
               "one_of": [
                 "ip",
                 "credential",
                 "consumer"
-              ]
+              ],
+              "description": "How to define the rate limit key. Can be `ip`, `credential`, `consumer`."
             }
           },
           {
             "window_size": {
               "required": true,
-              "description": "One or more window sizes to apply a limit to (defined in seconds).",
               "type": "array",
               "elements": {
                 "type": "number"
-              }
+              },
+              "description": "One or more window sizes to apply a limit to (defined in seconds)."
             }
           },
           {
             "window_type": {
               "default": "sliding",
-              "description": "Sets the time window to either `sliding` or `fixed`.",
               "type": "string",
               "one_of": [
                 "fixed",
                 "sliding"
-              ]
+              ],
+              "description": "Sets the time window to either `sliding` or `fixed`."
             }
           },
           {
             "limit": {
               "required": true,
-              "description": "One or more requests-per-window limits to apply.",
               "type": "array",
               "elements": {
                 "type": "number"
-              }
+              },
+              "description": "One or more requests-per-window limits to apply."
             }
           },
           {
             "sync_rate": {
-              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 syncs the counters in that many number of seconds.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 syncs the counters in that many number of seconds."
             }
           },
           {
             "namespace": {
-              "auto": true,
               "type": "string",
+              "auto": true,
               "description": "The rate limiting library namespace to use for this plugin instance."
             }
           },
@@ -95,38 +96,38 @@
             "strategy": {
               "required": true,
               "default": "cluster",
-              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits.",
               "type": "string",
               "one_of": [
                 "cluster",
                 "redis"
-              ]
+              ],
+              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits."
             }
           },
           {
             "dictionary_name": {
               "default": "kong_rate_limiting_counters",
-              "description": "The shared dictionary where counters will be stored until the next sync cycle.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The shared dictionary where counters will be stored until the next sync cycle."
             }
           },
           {
             "hide_client_headers": {
               "default": false,
-              "description": "Optionally hide informative response headers. Available options: `true` or `false`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Optionally hide informative response headers. Available options: `true` or `false`."
             }
           },
           {
             "cost_strategy": {
               "default": "default",
-              "description": "Strategy to use to evaluate query costs. Either `default` or `node_quantifier`.",
               "type": "string",
               "one_of": [
                 "default",
                 "node_quantifier"
-              ]
+              ],
+              "description": "Strategy to use to evaluate query costs. Either `default` or `node_quantifier`."
             }
           },
           {
@@ -134,16 +135,16 @@
               "gt": 0,
               "required": false,
               "default": 1,
-              "description": "A scoring factor to multiply (or divide) the cost. The `score_factor` must always be greater than 0.",
-              "type": "number"
+              "type": "number",
+              "description": "A scoring factor to multiply (or divide) the cost. The `score_factor` must always be greater than 0."
             }
           },
           {
             "max_cost": {
               "default": 0,
-              "description": "A defined maximum cost per query. 0 means unlimited.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "A defined maximum cost per query. 0 means unlimited."
             }
           },
           {
@@ -151,25 +152,25 @@
               "fields": [
                 {
                   "host": {
-                    "type": "string",
-                    "description": "A string representing a host name, such as example.com."
+                    "description": "A string representing a host name, such as example.com.",
+                    "type": "string"
                   }
                 },
                 {
                   "port": {
+                    "type": "integer",
                     "between": [
                       0,
                       65535
                     ],
-                    "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                    "type": "integer"
+                    "description": "An integer representing a port number between 0 and 65535, inclusive."
                   }
                 },
                 {
                   "timeout": {
                     "default": 2000,
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "type": "integer",
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "between": [
                       0,
                       2147483646
@@ -178,70 +179,76 @@
                 },
                 {
                   "connect_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "send_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "read_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "username": {
                     "type": "string",
-                    "referenceable": true
+                    "referenceable": true,
+                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
+                    "referenceable": true,
                     "type": "string",
-                    "referenceable": true
+                    "encrypted": true,
+                    "description": "Password to use for Redis connections. If undefined, no AUTH commands are sent to Redis."
                   }
                 },
                 {
                   "sentinel_username": {
                     "type": "string",
-                    "referenceable": true
+                    "referenceable": true,
+                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+."
                   }
                 },
                 {
                   "sentinel_password": {
-                    "encrypted": true,
+                    "referenceable": true,
                     "type": "string",
-                    "referenceable": true
+                    "encrypted": true,
+                    "description": "Sentinel password to authenticate with a Redis Sentinel instance. If undefined, no AUTH commands are sent to Redis Sentinels."
                   }
                 },
                 {
                   "database": {
+                    "default": 0,
                     "type": "integer",
-                    "default": 0
+                    "description": "Database to use for the Redis connection when using the `redis` strategy"
                   }
                 },
                 {
                   "keepalive_pool_size": {
                     "default": 30,
                     "type": "integer",
+                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value.",
                     "between": [
                       1,
                       2147483646
@@ -251,6 +258,7 @@
                 {
                   "keepalive_backlog": {
                     "type": "integer",
+                    "description": "Limits the total number of opened connections for a pool. If the connection pool is full, all connection queues beyond the maximum limit go into the backlog queue. If the backlog queue is full, subsequent connect operations fail and return `nil`. Queued connect operations resume once the number of connections in the pool is less than `keepalive_pool_size`. Note that queued connect operations are subject to set timeouts.",
                     "between": [
                       0,
                       2147483646
@@ -259,61 +267,67 @@
                 },
                 {
                   "sentinel_master": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_role": {
-                    "type": "string",
                     "one_of": [
                       "master",
                       "slave",
                       "any"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_addresses": {
-                    "len_min": 1,
+                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "type": "array",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "len_min": 1
                   }
                 },
                 {
                   "cluster_addresses": {
-                    "len_min": 1,
+                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "type": "array",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "len_min": 1
                   }
                 },
                 {
                   "ssl": {
                     "default": false,
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "If set to true, uses SSL to connect to Redis."
                   }
                 },
                 {
                   "ssl_verify": {
                     "default": false,
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "If set to true, verifies the validity of the server SSL certificate. If setting this parameter, also configure `lua_ssl_trusted_certificate` in `kong.conf` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly."
                   }
                 },
                 {
                   "server_name": {
-                    "description": "A string representing an SNI (server name indication) value for TLS.",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "description": "A string representing an SNI (server name indication) value for TLS."
                   }
                 }
               ],
-              "required": true,
               "type": "record",
+              "required": true,
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -375,7 +389,6 @@
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }
@@ -390,14 +403,14 @@
     },
     {
       "conditional_at_least_one_of": {
-        "then_at_least_one_of": [
-          "config.redis.host",
-          "config.redis.sentinel_master"
-        ],
         "if_match": {
           "eq": "redis"
         },
-        "if_field": "config.strategy"
+        "if_field": "config.strategy",
+        "then_at_least_one_of": [
+          "config.redis.host",
+          "config.redis.sentinel_master"
+        ]
       }
     }
   ]

--- a/schemas/grpc-gateway/3.4.x.json
+++ b/schemas/grpc-gateway/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,30 +23,32 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "proto": {
-              "description": "Describes the gRPC types and methods.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "Describes the gRPC types and methods."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/grpc-web/3.4.x.json
+++ b/schemas/grpc-web/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,45 +23,47 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "proto": {
-              "description": "If present, describes the gRPC types and methods. Required to support payload transcoding. When absent, the web client must use application/grpw-web+proto content.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "If present, describes the gRPC types and methods. Required to support payload transcoding. When absent, the web client must use application/grpw-web+proto content."
             }
           },
           {
             "pass_stripped_path": {
-              "description": "If set to `true` causes the plugin to pass the stripped request path to the upstream gRPC service.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to `true` causes the plugin to pass the stripped request path to the upstream gRPC service."
             }
           },
           {
             "allow_origin_header": {
               "default": "*",
-              "description": "The value of the `Access-Control-Allow-Origin` header in the response to the gRPC-Web client.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The value of the `Access-Control-Allow-Origin` header in the response to the gRPC-Web client."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/hmac-auth/3.4.x.json
+++ b/schemas/hmac-auth/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -18,8 +18,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,42 +36,43 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service."
             }
           },
           {
             "clock_skew": {
-              "default": 300,
               "gt": 0,
               "type": "number",
+              "default": 300,
               "description": "Clock skew in seconds to prevent replay attacks."
             }
           },
           {
             "anonymous": {
-              "type": "string",
-              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
+              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.",
+              "type": "string"
             }
           },
           {
             "validate_request_body": {
               "default": false,
-              "description": "A boolean value telling the plugin to enable body validation.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value telling the plugin to enable body validation."
             }
           },
           {
@@ -79,11 +80,11 @@
               "default": [
 
               ],
-              "description": "A list of headers that the client should at least use for HTTP signature creation.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "A list of headers that the client should at least use for HTTP signature creation."
             }
           },
           {
@@ -94,7 +95,6 @@
                 "hmac-sha384",
                 "hmac-sha512"
               ],
-              "description": "A list of HMAC digest algorithms that the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -104,11 +104,11 @@
                   "hmac-sha384",
                   "hmac-sha512"
                 ]
-              }
+              },
+              "description": "A list of HMAC digest algorithms that the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`"
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/http-log/3.4.x.json
+++ b/schemas/http-log/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,106 +23,92 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "entity_checks": [
-          {
-            "custom_entity_check": {
-              "field_sources": [
-                "retry_count",
-                "queue_size",
-                "flush_timeout"
-              ]
-            }
-          }
-        ],
         "fields": [
           {
             "http_endpoint": {
-              "required": true,
               "encrypted": true,
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "referenceable": true,
               "type": "string",
-              "referenceable": true
+              "required": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "method": {
               "default": "POST",
-              "description": "An optional method used to send data to the HTTP server. Supported values are `POST` (default), `PUT`, and `PATCH`.",
               "type": "string",
               "one_of": [
                 "POST",
                 "PUT",
                 "PATCH"
-              ]
+              ],
+              "description": "An optional method used to send data to the HTTP server. Supported values are `POST` (default), `PUT`, and `PATCH`."
             }
           },
           {
             "content_type": {
               "default": "application/json",
-              "description": "Indicates the type of data sent. The only available option is `application/json`.",
               "type": "string",
               "one_of": [
                 "application/json",
                 "application/json; charset=utf-8"
-              ]
+              ],
+              "description": "Indicates the type of data sent. The only available option is `application/json`."
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional timeout in milliseconds when sending data to the upstream server."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection will live before being closed.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional value in milliseconds that defines how long an idle connection will live before being closed."
             }
           },
           {
             "retry_count": {
-              "type": "integer",
-              "description": "Number of times to retry when sending data to the upstream server."
+              "description": "Number of times to retry when sending data to the upstream server.",
+              "type": "integer"
             }
           },
           {
             "queue_size": {
-              "type": "integer",
-              "description": "Maximum number of log entries to be sent on each message to the upstream server."
+              "description": "Maximum number of log entries to be sent on each message to the upstream server.",
+              "type": "integer"
             }
           },
           {
             "flush_timeout": {
-              "type": "number",
-              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records."
+              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.",
+              "type": "number"
             }
           },
           {
             "headers": {
-              "type": "map",
               "description": "An optional table of headers included in the HTTP message to the upstream server. Values are indexed by header name, and each header name accepts a single string.",
-              "values": {
-                "type": "string",
-                "referenceable": true
-              },
+              "type": "map",
               "keys": {
-                "description": "A string representing an HTTP header name.",
                 "type": "string",
                 "match_none": [
                   {
@@ -139,44 +123,50 @@
                     "pattern": "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Tt][Yy][Pp][Ee]$",
                     "err": "cannot contain 'Content-Type' header"
                   }
-                ]
+                ],
+                "description": "A string representing an HTTP header name."
+              },
+              "values": {
+                "referenceable": true,
+                "type": "string"
               }
             }
           },
           {
             "queue": {
+              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
                     "default": 1,
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
                     "default": 1,
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "type": "number",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
                     "default": 10000,
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
@@ -188,26 +178,26 @@
                 {
                   "max_retry_time": {
                     "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
-                    "type": "number"
+                    "type": "number",
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "type": "number",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
@@ -215,14 +205,11 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "description": "Lua code as a key-value map",
               "values": {
                 "len_min": 1,
                 "type": "string"
@@ -230,12 +217,25 @@
               "keys": {
                 "type": "string",
                 "len_min": 1
-              }
+              },
+              "type": "map",
+              "description": "Lua code as a key-value map"
             }
           }
         ],
         "type": "record",
-        "required": true
+        "required": true,
+        "entity_checks": [
+          {
+            "custom_entity_check": {
+              "field_sources": [
+                "retry_count",
+                "queue_size",
+                "flush_timeout"
+              ]
+            }
+          }
+        ]
       }
     }
   ],

--- a/schemas/ip-restriction/3.4.x.json
+++ b/schemas/ip-restriction/3.4.x.json
@@ -11,10 +11,8 @@
           "grpc",
           "grpcs"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -27,57 +25,59 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "allow": {
-              "description": "List of IPs or CIDR ranges to allow. One of `config.allow` or `config.deny` must be specified.",
               "type": "array",
               "elements": {
-                "type": "string",
-                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16."
-              }
+                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16.",
+                "type": "string"
+              },
+              "description": "List of IPs or CIDR ranges to allow. One of `config.allow` or `config.deny` must be specified."
             }
           },
           {
             "deny": {
-              "description": "List of IPs or CIDR ranges to deny. One of `config.allow` or `config.deny` must be specified.",
               "type": "array",
               "elements": {
-                "type": "string",
-                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16."
-              }
+                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16.",
+                "type": "string"
+              },
+              "description": "List of IPs or CIDR ranges to deny. One of `config.allow` or `config.deny` must be specified."
             }
           },
           {
             "status": {
-              "description": "The HTTP status of the requests that will be rejected by the plugin.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "The HTTP status of the requests that will be rejected by the plugin."
             }
           },
           {
             "message": {
-              "description": "The message to send as a response body to rejected requests.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The message to send as a response body to rejected requests."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/jq/3.4.x.json
+++ b/schemas/jq/3.4.x.json
@@ -1,6 +1,14 @@
 {
   "fields": [
     {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "eq": null,
+        "type": "foreign",
+        "description": "Custom type for representing a foreign key with a null value allowed."
+      }
+    },
+    {
       "protocols": {
         "required": true,
         "default": [
@@ -9,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,7 +26,8 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
@@ -27,8 +35,8 @@
         "fields": [
           {
             "request_jq_program": {
-              "type": "string",
-              "required": false
+              "required": false,
+              "type": "string"
             }
           },
           {
@@ -36,8 +44,8 @@
               "default": [
 
               ],
-              "required": false,
               "type": "record",
+              "required": false,
               "fields": [
                 {
                   "compact_output": {
@@ -82,8 +90,8 @@
               "default": [
                 "application/json"
               ],
-              "required": false,
               "type": "array",
+              "required": false,
               "elements": {
                 "type": "string"
               }
@@ -91,8 +99,8 @@
           },
           {
             "response_jq_program": {
-              "type": "string",
-              "required": false
+              "required": false,
+              "type": "string"
             }
           },
           {
@@ -100,8 +108,8 @@
               "default": [
 
               ],
-              "required": false,
               "type": "record",
+              "required": false,
               "fields": [
                 {
                   "compact_output": {
@@ -146,8 +154,8 @@
               "default": [
                 "application/json"
               ],
-              "required": false,
               "type": "array",
+              "required": false,
               "elements": {
                 "type": "string"
               }
@@ -158,8 +166,8 @@
               "default": [
                 200
               ],
-              "required": false,
               "type": "array",
+              "required": false,
               "elements": {
                 "type": "integer",
                 "between": [
@@ -170,8 +178,8 @@
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [

--- a/schemas/jwe-decrypt/3.4.x.json
+++ b/schemas/jwe-decrypt/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,63 +18,64 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "lookup_header_name": {
               "default": "Authorization",
-              "description": "The name of the header to look for the JWE token.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The name of the header to look for the JWE token."
             }
           },
           {
             "forward_header_name": {
               "default": "Authorization",
-              "description": "The name of the header that is used to set the decrypted value.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The name of the header that is used to set the decrypted value."
             }
           },
           {
             "key_sets": {
               "required": true,
-              "description": "Denote the name or names of all Key Sets that should be inspected when trying to find a suitable key to decrypt the JWE token.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Denote the name or names of all Key Sets that should be inspected when trying to find a suitable key to decrypt the JWE token."
             }
           },
           {
             "strict": {
               "default": true,
-              "description": "Defines how the plugin behaves in cases where no token was found in the request. When using `strict` mode, the request requires a token to be present and subsequently raise an error if none could be found.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Defines how the plugin behaves in cases where no token was found in the request. When using `strict` mode, the request requires a token to be present and subsequently raise an error if none could be found."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/jwt-signer/3.4.x.json
+++ b/schemas/jwt-signer/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,92 +26,93 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
         "type": "record",
+        "required": true,
         "fields": [
           {
             "realm": {
-              "description": "When authentication or authorization fails, or there is an unexpected error, the plugin sends an `WWW-Authenticate` header with the `realm` attribute value.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "When authentication or authorization fails, or there is an unexpected error, the plugin sends an `WWW-Authenticate` header with the `realm` attribute value."
             }
           },
           {
             "enable_hs_signatures": {
               "default": false,
-              "description": "Tokens signed with HMAC algorithms such as `HS256`, `HS384`, or `HS512` are not accepted by default. If you need to accept such tokens for verification, enable this setting.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Tokens signed with HMAC algorithms such as `HS256`, `HS384`, or `HS512` are not accepted by default. If you need to accept such tokens for verification, enable this setting."
             }
           },
           {
             "enable_instrumentation": {
               "default": false,
-              "description": "Writes log entries with some added information using `ngx.CRIT` (CRITICAL) level.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Writes log entries with some added information using `ngx.CRIT` (CRITICAL) level."
             }
           },
           {
             "access_token_issuer": {
               "default": "kong",
-              "description": "The `iss` claim of a signed or re-signed access token is set to this value. Original `iss` claim of the incoming token (possibly introspected) is stored in `original_iss` claim of the newly signed access token.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The `iss` claim of a signed or re-signed access token is set to this value. Original `iss` claim of the incoming token (possibly introspected) is stored in `original_iss` claim of the newly signed access token."
             }
           },
           {
             "access_token_keyset": {
               "default": "kong",
-              "description": "The name of the keyset containing signing keys.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The name of the keyset containing signing keys."
             }
           },
           {
             "access_token_jwks_uri": {
-              "description": "Specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the access token.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "Specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the access token."
             }
           },
           {
             "access_token_request_header": {
               "default": "Authorization",
-              "description": "This parameter tells the name of the header where to look for the access token.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "This parameter tells the name of the header where to look for the access token."
             }
           },
           {
             "access_token_leeway": {
               "default": 0,
-              "description": "Adjusts clock skew between the token issuer and Kong. The value is added to the token's `exp` claim before checking token expiry against Kong servers' current time in seconds. You can disable access token `expiry` verification altogether with `config.verify_access_token_expiry`.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "Adjusts clock skew between the token issuer and Kong. The value is added to the token's `exp` claim before checking token expiry against Kong servers' current time in seconds. You can disable access token `expiry` verification altogether with `config.verify_access_token_expiry`."
             }
           },
           {
             "access_token_scopes_required": {
               "required": false,
-              "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.access_token_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.access_token_scopes_claim`."
             }
           },
           {
@@ -121,21 +121,21 @@
               "default": [
                 "scope"
               ],
-              "description": "Specify the claim in an access token to verify against values of `config.access_token_scopes_required`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Specify the claim in an access token to verify against values of `config.access_token_scopes_required`."
             }
           },
           {
             "access_token_consumer_claim": {
               "required": false,
-              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (for example, `sub` or `username`) in an access token to Kong consumer entity.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (for example, `sub` or `username`) in an access token to Kong consumer entity."
             }
           },
           {
@@ -145,7 +145,6 @@
                 "username",
                 "custom_id"
               ],
-              "description": "When the plugin tries to apply an access token to a Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of alues. Valid values are `id`, `username`, and `custom_id`.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -154,72 +153,73 @@
                   "username",
                   "custom_id"
                 ]
-              }
+              },
+              "description": "When the plugin tries to apply an access token to a Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of alues. Valid values are `id`, `username`, and `custom_id`."
             }
           },
           {
             "access_token_upstream_header": {
               "default": "Authorization:Bearer",
-              "description": "Removes the `config.access_token_request_header` from the request after reading its value. With `config.access_token_upstream_header`, you can specify the upstream header where the plugin adds the Kong signed token. If you don't specify a value, such as use `null` or `\"\"` (empty string), the plugin does not even try to sign or re-sign the token.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "Removes the `config.access_token_request_header` from the request after reading its value. With `config.access_token_upstream_header`, you can specify the upstream header where the plugin adds the Kong signed token. If you don't specify a value, such as use `null` or `\"\"` (empty string), the plugin does not even try to sign or re-sign the token."
             }
           },
           {
             "access_token_upstream_leeway": {
               "default": 0,
-              "description": "If you want to add or subtract (using a negative value) expiry time (in seconds) of the original access token, you can specify a value that is added to the original access token's `exp` claim.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "If you want to add or subtract (using a negative value) expiry time (in seconds) of the original access token, you can specify a value that is added to the original access token's `exp` claim."
             }
           },
           {
             "access_token_introspection_endpoint": {
-              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter."
             }
           },
           {
             "access_token_introspection_authorization": {
-              "description": "If the introspection endpoint requires client authentication (client being the JWT Signer plugin), you can specify the `Authorization` header's value with this configuration parameter.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "If the introspection endpoint requires client authentication (client being the JWT Signer plugin), you can specify the `Authorization` header's value with this configuration parameter."
             }
           },
           {
             "access_token_introspection_body_args": {
-              "description": "This parameter allows you to pass URL encoded request body arguments. For example: `resource=` or `a=1&b=&c`.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "This parameter allows you to pass URL encoded request body arguments. For example: `resource=` or `a=1&b=&c`."
             }
           },
           {
             "access_token_introspection_hint": {
               "default": "access_token",
-              "description": "If you need to give `hint` parameter when introspecting an access token, use this parameter to specify the value. By default, the plugin sends `hint=access_token`.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "If you need to give `hint` parameter when introspecting an access token, use this parameter to specify the value. By default, the plugin sends `hint=access_token`."
             }
           },
           {
             "access_token_introspection_jwt_claim": {
               "required": false,
-              "description": "If your introspection endpoint returns an access token in one of the keys (or claims) within the introspection results (`JSON`). If the key cannot be found, the plugin responds with `401 Unauthorized`. Also if the key is found but cannot be decoded as JWT, it also responds with `401 Unauthorized`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "If your introspection endpoint returns an access token in one of the keys (or claims) within the introspection results (`JSON`). If the key cannot be found, the plugin responds with `401 Unauthorized`. Also if the key is found but cannot be decoded as JWT, it also responds with `401 Unauthorized`."
             }
           },
           {
             "access_token_introspection_scopes_required": {
               "required": false,
-              "description": "Specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.access_token_introspection_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.access_token_introspection_scopes_claim`."
             }
           },
           {
@@ -228,21 +228,21 @@
               "default": [
                 "scope"
               ],
-              "description": "Specify the claim/property in access token introspection results (`JSON`) to be verified against values of `config.access_token_introspection_scopes_required`. This supports nested claims. For example, with Keycloak you could use `[ \"realm_access\", \"roles\" ]`, hich can be given as `realm_access,roles` (form post). If the claim is not found in access token introspection results, and you have specified `config.access_token_introspection_scopes_required`, the plugin responds with `403 Forbidden`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Specify the claim/property in access token introspection results (`JSON`) to be verified against values of `config.access_token_introspection_scopes_required`. This supports nested claims. For example, with Keycloak you could use `[ \"realm_access\", \"roles\" ]`, hich can be given as `realm_access,roles` (form post). If the claim is not found in access token introspection results, and you have specified `config.access_token_introspection_scopes_required`, the plugin responds with `403 Forbidden`."
             }
           },
           {
             "access_token_introspection_consumer_claim": {
               "required": false,
-              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in access token introspection results to the Kong consumer entity.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in access token introspection results to the Kong consumer entity."
             }
           },
           {
@@ -252,7 +252,6 @@
                 "username",
                 "custom_id"
               ],
-              "description": "When the plugin tries to do access token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -261,29 +260,29 @@
                   "username",
                   "custom_id"
                 ]
-              }
+              },
+              "description": "When the plugin tries to do access token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values."
             }
           },
           {
             "access_token_introspection_leeway": {
               "default": 0,
-              "description": "Adjusts clock skew between the token issuer introspection results and Kong. The value is added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time in seconds. You can disable access token introspection `expiry` verification altogether with `config.verify_access_token_introspection_expiry`.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "Adjusts clock skew between the token issuer introspection results and Kong. The value is added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time in seconds. You can disable access token introspection `expiry` verification altogether with `config.verify_access_token_introspection_expiry`."
             }
           },
           {
             "access_token_introspection_timeout": {
-              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on access token introspection.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on access token introspection."
             }
           },
           {
             "access_token_signing_algorithm": {
               "required": true,
               "default": "RS256",
-              "description": "When this plugin sets the upstream header as specified with `config.access_token_upstream_header`, re-signs the original access token using the private keys of the JWT Signer plugin. Specify the algorithm that is used to sign the token. The `config.access_token_issuer` specifies which `keyset` is used to sign the new token issued by Kong using the specified signing algorithm.",
               "type": "string",
               "one_of": [
                 "HS256",
@@ -298,127 +297,128 @@
                 "PS384",
                 "PS512",
                 "EdDSA"
-              ]
+              ],
+              "description": "When this plugin sets the upstream header as specified with `config.access_token_upstream_header`, re-signs the original access token using the private keys of the JWT Signer plugin. Specify the algorithm that is used to sign the token. The `config.access_token_issuer` specifies which `keyset` is used to sign the new token issued by Kong using the specified signing algorithm."
             }
           },
           {
             "access_token_optional": {
               "default": false,
-              "description": "If an access token is not provided or no `config.access_token_request_header` is specified, the plugin cannot verify the access token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Use this parameter to allow the request to proceed even when there is no token to check. If the token is provided, then this parameter has no effect",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If an access token is not provided or no `config.access_token_request_header` is specified, the plugin cannot verify the access token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Use this parameter to allow the request to proceed even when there is no token to check. If the token is provided, then this parameter has no effect"
             }
           },
           {
             "verify_access_token_signature": {
               "default": true,
-              "description": "Quickly turn access token signature verification off and on as needed.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn access token signature verification off and on as needed."
             }
           },
           {
             "verify_access_token_expiry": {
               "default": true,
-              "description": "Quickly turn access token expiry verification off and on as needed.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn access token expiry verification off and on as needed."
             }
           },
           {
             "verify_access_token_scopes": {
               "default": true,
-              "description": "Quickly turn off and on the access token required scopes verification, specified with `config.access_token_scopes_required`.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn off and on the access token required scopes verification, specified with `config.access_token_scopes_required`."
             }
           },
           {
             "verify_access_token_introspection_expiry": {
               "default": true,
-              "description": "Quickly turn access token introspection expiry verification off and on as needed.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn access token introspection expiry verification off and on as needed."
             }
           },
           {
             "verify_access_token_introspection_scopes": {
               "default": true,
-              "description": "Quickly turn off and on the access token introspection scopes verification, specified with `config.access_token_introspection_scopes_required`.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn off and on the access token introspection scopes verification, specified with `config.access_token_introspection_scopes_required`."
             }
           },
           {
             "cache_access_token_introspection": {
               "default": true,
-              "description": "Whether to cache access token introspection results.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Whether to cache access token introspection results."
             }
           },
           {
             "trust_access_token_introspection": {
               "default": true,
-              "description": "Use this parameter to enable and disable further checks on a payload before the new token is signed. If you set this to `true`, the expiry or scopes are not checked on a payload.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Use this parameter to enable and disable further checks on a payload before the new token is signed. If you set this to `true`, the expiry or scopes are not checked on a payload."
             }
           },
           {
             "enable_access_token_introspection": {
               "default": true,
-              "description": "If you don't want to support opaque access tokens, change this configuration parameter to `false` to disable introspection.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If you don't want to support opaque access tokens, change this configuration parameter to `false` to disable introspection."
             }
           },
           {
             "channel_token_issuer": {
               "default": "kong",
-              "description": "The `iss` claim of the re-signed channel token is set to this value, which is `kong` by default. The original `iss` claim of the incoming token (possibly introspected) is stored in the `original_iss` claim of the newly signed channel token.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The `iss` claim of the re-signed channel token is set to this value, which is `kong` by default. The original `iss` claim of the incoming token (possibly introspected) is stored in the `original_iss` claim of the newly signed channel token."
             }
           },
           {
             "channel_token_keyset": {
               "default": "kong",
-              "description": "The name of the keyset containing signing keys.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The name of the keyset containing signing keys."
             }
           },
           {
             "channel_token_jwks_uri": {
-              "description": "If you want to use `config.verify_channel_token_signature`, you must specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the channel token. If you don't specify a URI and you pass a JWT token to the plugin, then the plugin responds with `401 Unauthorized`.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "If you want to use `config.verify_channel_token_signature`, you must specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the channel token. If you don't specify a URI and you pass a JWT token to the plugin, then the plugin responds with `401 Unauthorized`."
             }
           },
           {
             "channel_token_request_header": {
-              "description": "This parameter tells the name of the header where to look for the channel token. If you don't want to do anything with the channel token, then you can set this to `null` or `\"\"` (empty string).",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "This parameter tells the name of the header where to look for the channel token. If you don't want to do anything with the channel token, then you can set this to `null` or `\"\"` (empty string)."
             }
           },
           {
             "channel_token_leeway": {
               "default": 0,
-              "description": "Adjusts clock skew between the token issuer and Kong. The value will be added to token's `exp` claim before checking token expiry against Kong servers current time in seconds. You can disable channel token `expiry` verification altogether with `config.verify_channel_token_expiry`.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "Adjusts clock skew between the token issuer and Kong. The value will be added to token's `exp` claim before checking token expiry against Kong servers current time in seconds. You can disable channel token `expiry` verification altogether with `config.verify_channel_token_expiry`."
             }
           },
           {
             "channel_token_scopes_required": {
               "required": false,
-              "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.channel_token_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.channel_token_scopes_claim`."
             }
           },
           {
@@ -427,21 +427,21 @@
               "default": [
                 "scope"
               ],
-              "description": "Specify the claim in a channel token to verify against values of `config.channel_token_scopes_required`. This supports nested claims.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Specify the claim in a channel token to verify against values of `config.channel_token_scopes_required`. This supports nested claims."
             }
           },
           {
             "channel_token_consumer_claim": {
               "required": false,
-              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter. Kong consumers have an `id`, a `username`, and a `custom_id`. If this parameter is enabled but the mapping fails, such as when there's a non-existent Kong consumer, the plugin responds with `403 Forbidden`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter. Kong consumers have an `id`, a `username`, and a `custom_id`. If this parameter is enabled but the mapping fails, such as when there's a non-existent Kong consumer, the plugin responds with `403 Forbidden`."
             }
           },
           {
@@ -450,7 +450,6 @@
                 "username",
                 "custom_id"
               ],
-              "description": "When the plugin tries to do channel token to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of valid values: `id`, `username`, and `custom_id`.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -459,79 +458,80 @@
                   "username",
                   "custom_id"
                 ]
-              }
+              },
+              "description": "When the plugin tries to do channel token to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of valid values: `id`, `username`, and `custom_id`."
             }
           },
           {
             "channel_token_upstream_header": {
-              "description": "This plugin removes the `config.channel_token_request_header` from the request after reading its value.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "This plugin removes the `config.channel_token_request_header` from the request after reading its value."
             }
           },
           {
             "channel_token_upstream_leeway": {
               "default": 0,
-              "description": "If you want to add or perhaps subtract (using negative value) expiry time of the original channel token, you can specify a value that is added to the original channel token's `exp` claim.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "If you want to add or perhaps subtract (using negative value) expiry time of the original channel token, you can specify a value that is added to the original channel token's `exp` claim."
             }
           },
           {
             "channel_token_introspection_endpoint": {
-              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise, the plugin does not try introspection and returns `401 Unauthorized` instead.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise, the plugin does not try introspection and returns `401 Unauthorized` instead."
             }
           },
           {
             "channel_token_introspection_authorization": {
               "required": false,
-              "description": "When using `opaque` channel tokens, and you want to turn on channel token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise the plugin will not try introspection, and instead returns `401 Unauthorized` when using opaque channel tokens.",
               "type": "string",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "When using `opaque` channel tokens, and you want to turn on channel token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise the plugin will not try introspection, and instead returns `401 Unauthorized` when using opaque channel tokens."
             }
           },
           {
             "channel_token_introspection_body_args": {
               "required": false,
-              "description": "If you need to pass additional body arguments to introspection endpoint when the plugin introspects the opaque channel token, you can use this config parameter to specify them. You should URL encode the value. For example: `resource=` or `a=1&b=&c`.",
               "type": "string",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "If you need to pass additional body arguments to introspection endpoint when the plugin introspects the opaque channel token, you can use this config parameter to specify them. You should URL encode the value. For example: `resource=` or `a=1&b=&c`."
             }
           },
           {
             "channel_token_introspection_hint": {
               "required": false,
-              "description": "If you need to give `hint` parameter when introspecting a channel token, you can use this parameter to specify the value of such parameter. By default, a `hint` isn't sent with channel token introspection.",
               "type": "string",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "If you need to give `hint` parameter when introspecting a channel token, you can use this parameter to specify the value of such parameter. By default, a `hint` isn't sent with channel token introspection."
             }
           },
           {
             "channel_token_introspection_jwt_claim": {
               "required": false,
-              "description": "If your introspection endpoint returns a channel token in one of the keys (or claims) in the introspection results (`JSON`), the plugin can use that value instead of the introspection results when doing expiry verification and signing of the new token issued by Kong.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "If your introspection endpoint returns a channel token in one of the keys (or claims) in the introspection results (`JSON`), the plugin can use that value instead of the introspection results when doing expiry verification and signing of the new token issued by Kong."
             }
           },
           {
             "channel_token_introspection_scopes_required": {
               "required": false,
-              "description": "Use this parameter to specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.channel_token_introspection_scopes_claim`.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Use this parameter to specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.channel_token_introspection_scopes_claim`."
             }
           },
           {
@@ -540,21 +540,21 @@
               "default": [
                 "scope"
               ],
-              "description": "Use this parameter to specify the claim/property in channel token introspection results (`JSON`) to be verified against values of `config.channel_token_introspection_scopes_required`. This supports nested claims.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Use this parameter to specify the claim/property in channel token introspection results (`JSON`) to be verified against values of `config.channel_token_introspection_scopes_required`. This supports nested claims."
             }
           },
           {
             "channel_token_introspection_consumer_claim": {
               "required": false,
-              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in channel token introspection results to Kong consumer entity",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in channel token introspection results to Kong consumer entity"
             }
           },
           {
@@ -564,7 +564,6 @@
                 "username",
                 "custom_id"
               ],
-              "description": "When the plugin tries to do channel token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values. Valid values are `id`, `username` and `custom_id`.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -573,29 +572,29 @@
                   "username",
                   "custom_id"
                 ]
-              }
+              },
+              "description": "When the plugin tries to do channel token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values. Valid values are `id`, `username` and `custom_id`."
             }
           },
           {
             "channel_token_introspection_leeway": {
               "default": 0,
-              "description": "You can use this parameter to adjust clock skew between the token issuer introspection results and Kong. The value will be added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time (in seconds). You can disable channel token introspection `expiry` verification altogether with `config.verify_channel_token_introspection_expiry`.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "You can use this parameter to adjust clock skew between the token issuer introspection results and Kong. The value will be added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time (in seconds). You can disable channel token introspection `expiry` verification altogether with `config.verify_channel_token_introspection_expiry`."
             }
           },
           {
             "channel_token_introspection_timeout": {
-              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on channel token introspection.",
               "type": "number",
-              "required": false
+              "required": false,
+              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on channel token introspection."
             }
           },
           {
             "channel_token_signing_algorithm": {
               "required": true,
               "default": "RS256",
-              "description": "When this plugin sets the upstream header as specified with `config.channel_token_upstream_header`, it also re-signs the original channel token using private keys of this plugin. Specify the algorithm that is used to sign the token.",
               "type": "string",
               "one_of": [
                 "HS256",
@@ -610,23 +609,24 @@
                 "PS384",
                 "PS512",
                 "EdDSA"
-              ]
+              ],
+              "description": "When this plugin sets the upstream header as specified with `config.channel_token_upstream_header`, it also re-signs the original channel token using private keys of this plugin. Specify the algorithm that is used to sign the token."
             }
           },
           {
             "channel_token_optional": {
               "default": false,
-              "description": "If a channel token is not provided or no `config.channel_token_request_header` is specified, the plugin cannot verify the channel token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Enable this parameter to allow the request to proceed even when there is no channel token to check. If the channel token is provided, then this parameter has no effect",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If a channel token is not provided or no `config.channel_token_request_header` is specified, the plugin cannot verify the channel token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Enable this parameter to allow the request to proceed even when there is no channel token to check. If the channel token is provided, then this parameter has no effect"
             }
           },
           {
             "verify_channel_token_signature": {
               "default": true,
-              "description": "Quickly turn on/off the channel token signature verification.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn on/off the channel token signature verification."
             }
           },
           {
@@ -639,81 +639,81 @@
           {
             "verify_channel_token_scopes": {
               "default": true,
-              "description": "Quickly turn on/off the channel token required scopes verification specified with `config.channel_token_scopes_required`.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn on/off the channel token required scopes verification specified with `config.channel_token_scopes_required`."
             }
           },
           {
             "verify_channel_token_introspection_expiry": {
               "default": true,
-              "description": "Quickly turn on/off the channel token introspection expiry verification.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn on/off the channel token introspection expiry verification."
             }
           },
           {
             "verify_channel_token_introspection_scopes": {
               "default": true,
-              "description": "Quickly turn on/off the channel token introspection scopes verification specified with `config.channel_token_introspection_scopes_required`.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Quickly turn on/off the channel token introspection scopes verification specified with `config.channel_token_introspection_scopes_required`."
             }
           },
           {
             "cache_channel_token_introspection": {
               "default": true,
-              "description": "Whether to cache channel token introspection results.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Whether to cache channel token introspection results."
             }
           },
           {
             "trust_channel_token_introspection": {
               "default": true,
-              "description": "Providing an opaque channel token for plugin introspection, and verifying expiry and scopes on introspection results may make further payload checks unnecessary before the plugin signs a new token. This also applies when using a JWT token with introspection JSON as per config.channel_token_introspection_jwt_claim. Use this parameter to manage additional payload checks before signing a new token. With true (default), payload's expiry or scopes aren't checked.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Providing an opaque channel token for plugin introspection, and verifying expiry and scopes on introspection results may make further payload checks unnecessary before the plugin signs a new token. This also applies when using a JWT token with introspection JSON as per config.channel_token_introspection_jwt_claim. Use this parameter to manage additional payload checks before signing a new token. With true (default), payload's expiry or scopes aren't checked."
             }
           },
           {
             "enable_channel_token_introspection": {
               "default": true,
-              "description": "If you don't want to support opaque channel tokens, disable introspection by changing this configuration parameter to `false`.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If you don't want to support opaque channel tokens, disable introspection by changing this configuration parameter to `false`."
             }
           },
           {
             "add_claims": {
-              "values": {
+              "keys": {
                 "type": "string"
               },
               "required": false,
+              "values": {
+                "type": "string"
+              },
               "default": [
 
               ],
-              "description": "Add customized claims if they are not present yet.",
               "type": "map",
-              "keys": {
-                "type": "string"
-              }
+              "description": "Add customized claims if they are not present yet."
             }
           },
           {
             "set_claims": {
-              "values": {
+              "keys": {
                 "type": "string"
               },
               "required": false,
+              "values": {
+                "type": "string"
+              },
               "default": [
 
               ],
-              "description": "Set customized claims. If a claim is already present, it will be overwritten.",
               "type": "map",
-              "keys": {
-                "type": "string"
-              }
+              "description": "Set customized claims. If a claim is already present, it will be overwritten."
             }
           }
         ]

--- a/schemas/jwt/3.4.x.json
+++ b/schemas/jwt/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,30 +26,32 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "uri_param_names": {
               "default": [
                 "jwt"
               ],
-              "description": "A list of querystring parameters that Kong will inspect to retrieve JWTs.",
               "type": "set",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "A list of querystring parameters that Kong will inspect to retrieve JWTs."
             }
           },
           {
@@ -58,31 +59,30 @@
               "default": [
 
               ],
-              "description": "A list of cookie names that Kong will inspect to retrieve JWTs.",
               "type": "set",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "A list of cookie names that Kong will inspect to retrieve JWTs."
             }
           },
           {
             "key_claim_name": {
               "default": "iss",
-              "description": "The name of the claim in which the key identifying the secret must be passed. The plugin will attempt to read this claim from the JWT payload and the header, in that order.",
-              "type": "string"
+              "type": "string",
+              "description": "The name of the claim in which the key identifying the secret must be passed. The plugin will attempt to read this claim from the JWT payload and the header, in that order."
             }
           },
           {
             "secret_is_base64": {
               "default": false,
-              "description": "If true, the plugin assumes the credential’s secret to be base64 encoded. You will need to create a base64-encoded secret for your Consumer, and sign your JWT with the original secret.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If true, the plugin assumes the credential’s secret to be base64 encoded. You will need to create a base64-encoded secret for your Consumer, and sign your JWT with the original secret."
             }
           },
           {
             "claims_to_verify": {
-              "description": "A list of registered claims (according to RFC 7519) that Kong can verify as well. Accepted values: one of exp or nbf.",
               "type": "set",
               "elements": {
                 "type": "string",
@@ -90,28 +90,29 @@
                   "exp",
                   "nbf"
                 ]
-              }
+              },
+              "description": "A list of registered claims (according to RFC 7519) that Kong can verify as well. Accepted values: one of exp or nbf."
             }
           },
           {
             "anonymous": {
-              "type": "string",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.",
+              "type": "string"
             }
           },
           {
             "run_on_preflight": {
               "default": true,
-              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed."
             }
           },
           {
             "maximum_expiration": {
               "default": 0,
-              "description": "A value between 0 and 31536000 (365 days) limiting the lifetime of the JWT to maximum_expiration seconds in the future.",
               "type": "number",
+              "description": "A value between 0 and 31536000 (365 days) limiting the lifetime of the JWT to maximum_expiration seconds in the future.",
               "between": [
                 0,
                 31536000
@@ -123,15 +124,14 @@
               "default": [
                 "authorization"
               ],
-              "description": "A list of HTTP header names that Kong will inspect to retrieve JWTs.",
               "type": "set",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "A list of HTTP header names that Kong will inspect to retrieve JWTs."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }
@@ -139,11 +139,11 @@
   "entity_checks": [
     {
       "conditional": {
-        "if_field": "config.maximum_expiration",
-        "then_field": "config.claims_to_verify",
         "if_match": {
           "gt": 0
         },
+        "then_field": "config.claims_to_verify",
+        "if_field": "config.maximum_expiration",
         "then_match": {
           "contains": "exp"
         }

--- a/schemas/kafka-log/3.4.x.json
+++ b/schemas/kafka-log/3.4.x.json
@@ -10,8 +10,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -28,9 +28,9 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -38,217 +38,215 @@
         "fields": [
           {
             "bootstrap_servers": {
-              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format.",
               "type": "set",
               "elements": {
-                "type": "record",
                 "fields": [
                   {
                     "host": {
-                      "description": "A string representing a host name, such as example.com.",
                       "type": "string",
-                      "required": true
+                      "required": true,
+                      "description": "A string representing a host name, such as example.com."
                     }
                   },
                   {
                     "port": {
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "type": "integer",
+                      "required": true,
                       "between": [
                         0,
                         65535
-                      ],
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                      "type": "integer",
-                      "required": true
+                      ]
                     }
                   }
-                ]
-              }
+                ],
+                "type": "record"
+              },
+              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format."
             }
           },
           {
             "topic": {
-              "description": "The Kafka topic to publish to.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The Kafka topic to publish to."
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "Socket timeout in milliseconds.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Socket timeout in milliseconds."
             }
           },
           {
             "keepalive": {
-              "type": "integer",
-              "default": 60000
+              "default": 60000,
+              "type": "integer"
             }
           },
           {
             "keepalive_enabled": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "type": "boolean"
             }
           },
           {
             "authentication": {
+              "type": "record",
               "fields": [
                 {
                   "strategy": {
-                    "type": "string",
-                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`.",
                     "one_of": [
                       "sasl"
                     ],
-                    "required": false
+                    "type": "string",
+                    "required": false,
+                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`."
                   }
                 },
                 {
                   "mechanism": {
-                    "type": "string",
-                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN` or `SCRAM-SHA-256`.",
                     "one_of": [
                       "PLAIN",
                       "SCRAM-SHA-256",
                       "SCRAM-SHA-512"
                     ],
-                    "required": false
+                    "type": "string",
+                    "required": false,
+                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN` or `SCRAM-SHA-256`."
                   }
                 },
                 {
                   "tokenauth": {
-                    "description": "Enable this to indicate `DelegationToken` authentication",
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "Enable this to indicate `DelegationToken` authentication"
                   }
                 },
                 {
                   "user": {
                     "encrypted": true,
-                    "required": false,
                     "description": "Username for SASL authentication.",
                     "type": "string",
+                    "required": false,
                     "referenceable": true
                   }
                 },
                 {
                   "password": {
                     "encrypted": true,
-                    "required": false,
                     "description": "Password for SASL authentication.",
                     "type": "string",
+                    "required": false,
                     "referenceable": true
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "security": {
+              "type": "record",
               "fields": [
                 {
                   "certificate_id": {
                     "uuid": true,
-                    "description": "UUID of certificate entity for mTLS authentication.",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "description": "UUID of certificate entity for mTLS authentication."
                   }
                 },
                 {
                   "ssl": {
-                    "description": "Enables TLS.",
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "Enables TLS."
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "cluster_name": {
-              "auto": true,
               "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster.",
               "type": "string",
-              "required": false
+              "required": false,
+              "auto": true
             }
           },
           {
             "producer_request_acks": {
               "default": 1,
-              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set).",
               "type": "integer",
               "one_of": [
                 -1,
                 0,
                 1
-              ]
+              ],
+              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set)."
             }
           },
           {
             "producer_request_timeout": {
               "default": 2000,
-              "description": "Time to wait for a Produce response in milliseconds",
-              "type": "integer"
+              "type": "integer",
+              "description": "Time to wait for a Produce response in milliseconds"
             }
           },
           {
             "producer_request_limits_messages_per_request": {
               "default": 200,
-              "description": "Maximum number of messages to include into a single Produce request.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of messages to include into a single Produce request."
             }
           },
           {
             "producer_request_limits_bytes_per_request": {
               "default": 1048576,
-              "description": "Maximum size of a Produce request in bytes.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of a Produce request in bytes."
             }
           },
           {
             "producer_request_retries_max_attempts": {
               "default": 10,
-              "description": "Maximum number of retry attempts per single Produce request.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of retry attempts per single Produce request."
             }
           },
           {
             "producer_request_retries_backoff_timeout": {
               "default": 100,
-              "description": "Backoff interval between retry attempts in milliseconds.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Backoff interval between retry attempts in milliseconds."
             }
           },
           {
             "producer_async": {
               "default": true,
-              "description": "Flag to enable asynchronous mode.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Flag to enable asynchronous mode."
             }
           },
           {
             "producer_async_flush_timeout": {
               "default": 1000,
-              "description": "Maximum time interval in milliseconds between buffer flushes in asynchronous mode.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum time interval in milliseconds between buffer flushes in asynchronous mode."
             }
           },
           {
             "producer_async_buffering_limits_messages_in_memory": {
               "default": 50000,
-              "description": "Maximum number of messages that can be buffered in memory in asynchronous mode.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of messages that can be buffered in memory in asynchronous mode."
             }
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "description": "Lua code as a key-value map",
               "values": {
                 "len_min": 1,
                 "type": "string"
@@ -256,12 +254,14 @@
               "keys": {
                 "type": "string",
                 "len_min": 1
-              }
+              },
+              "type": "map",
+              "description": "Lua code as a key-value map"
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "custom_entity_check": {

--- a/schemas/kafka-upstream/3.4.x.json
+++ b/schemas/kafka-upstream/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,15 +18,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -35,52 +35,52 @@
         "fields": [
           {
             "bootstrap_servers": {
-              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format.",
               "type": "set",
               "elements": {
-                "type": "record",
                 "fields": [
                   {
                     "host": {
-                      "description": "A string representing a host name, such as example.com.",
                       "type": "string",
-                      "required": true
+                      "required": true,
+                      "description": "A string representing a host name, such as example.com."
                     }
                   },
                   {
                     "port": {
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "type": "integer",
+                      "required": true,
                       "between": [
                         0,
                         65535
-                      ],
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                      "type": "integer",
-                      "required": true
+                      ]
                     }
                   }
-                ]
-              }
+                ],
+                "type": "record"
+              },
+              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format."
             }
           },
           {
             "topic": {
-              "description": "The Kafka topic to publish to.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The Kafka topic to publish to."
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "Socket timeout in milliseconds.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Socket timeout in milliseconds."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "Keepalive timeout in milliseconds.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Keepalive timeout in milliseconds."
             }
           },
           {
@@ -91,189 +91,189 @@
           },
           {
             "authentication": {
+              "type": "record",
               "fields": [
                 {
                   "strategy": {
-                    "type": "string",
-                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`.",
                     "one_of": [
                       "sasl"
                     ],
-                    "required": false
+                    "type": "string",
+                    "required": false,
+                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`."
                   }
                 },
                 {
                   "mechanism": {
-                    "type": "string",
-                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.",
                     "one_of": [
                       "PLAIN",
                       "SCRAM-SHA-256",
                       "SCRAM-SHA-512"
                     ],
-                    "required": false
+                    "type": "string",
+                    "required": false,
+                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`."
                   }
                 },
                 {
                   "tokenauth": {
-                    "description": "Enable this to indicate `DelegationToken` authentication.",
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "Enable this to indicate `DelegationToken` authentication."
                   }
                 },
                 {
                   "user": {
-                    "encrypted": true,
-                    "referenceable": true,
+                    "required": false,
                     "description": "Username for SASL authentication.",
                     "type": "string",
-                    "required": false
+                    "encrypted": true,
+                    "referenceable": true
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
-                    "referenceable": true,
+                    "required": false,
                     "description": "Password for SASL authentication.",
                     "type": "string",
-                    "required": false
+                    "encrypted": true,
+                    "referenceable": true
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "security": {
+              "type": "record",
               "fields": [
                 {
                   "certificate_id": {
                     "uuid": true,
-                    "description": "UUID of certificate entity for mTLS authentication.",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "description": "UUID of certificate entity for mTLS authentication."
                   }
                 },
                 {
                   "ssl": {
-                    "description": "Enables TLS.",
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "Enables TLS."
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "forward_method": {
               "default": false,
-              "description": "Include the request method in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include the request method in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`."
             }
           },
           {
             "forward_uri": {
               "default": false,
-              "description": "Include the request URI and URI arguments (as in, query arguments) in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include the request URI and URI arguments (as in, query arguments) in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`."
             }
           },
           {
             "forward_headers": {
               "default": false,
-              "description": "Include the request headers in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include the request headers in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`."
             }
           },
           {
             "forward_body": {
               "default": true,
-              "description": "Include the request body in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include the request body in the message. At least one of these must be true: `forward_method`, `forward_uri`, `forward_headers`, `forward_body`."
             }
           },
           {
             "cluster_name": {
               "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster.",
-              "auto": true,
               "type": "string",
-              "required": false
+              "required": false,
+              "auto": true
             }
           },
           {
             "producer_request_acks": {
               "default": 1,
-              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set).",
               "type": "integer",
               "one_of": [
                 -1,
                 0,
                 1
-              ]
+              ],
+              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set)."
             }
           },
           {
             "producer_request_timeout": {
               "default": 2000,
-              "description": "Time to wait for a Produce response in milliseconds.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Time to wait for a Produce response in milliseconds."
             }
           },
           {
             "producer_request_limits_messages_per_request": {
               "default": 200,
-              "description": "Maximum number of messages to include into a single producer request.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of messages to include into a single producer request."
             }
           },
           {
             "producer_request_limits_bytes_per_request": {
               "default": 1048576,
-              "description": "Maximum size of a Produce request in bytes.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of a Produce request in bytes."
             }
           },
           {
             "producer_request_retries_max_attempts": {
               "default": 10,
-              "description": "Maximum number of retry attempts per single Produce request.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of retry attempts per single Produce request."
             }
           },
           {
             "producer_request_retries_backoff_timeout": {
               "default": 100,
-              "description": "Backoff interval between retry attempts in milliseconds.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Backoff interval between retry attempts in milliseconds."
             }
           },
           {
             "producer_async": {
               "default": true,
-              "description": "Flag to enable asynchronous mode.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Flag to enable asynchronous mode."
             }
           },
           {
             "producer_async_flush_timeout": {
               "default": 1000,
-              "description": "Maximum time interval in milliseconds between buffer flushes in asynchronous mode.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum time interval in milliseconds between buffer flushes in asynchronous mode."
             }
           },
           {
             "producer_async_buffering_limits_messages_in_memory": {
               "default": 50000,
-              "description": "Maximum number of messages that can be buffered in memory in asynchronous mode.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of messages that can be buffered in memory in asynchronous mode."
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "custom_entity_check": {

--- a/schemas/key-auth-enc/3.4.x.json
+++ b/schemas/key-auth-enc/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -18,8 +18,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,13 +36,14 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "key_names": {
@@ -50,19 +51,19 @@
               "default": [
                 "apikey"
               ],
-              "description": "Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name.  Key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.",
               "type": "array",
               "elements": {
-                "type": "string",
-                "description": "A string representing an HTTP header name."
-              }
+                "description": "A string representing an HTTP header name.",
+                "type": "string"
+              },
+              "description": "Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name.  Key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request (i.e., the header, query string, or request body containing the key) before proxying it.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request (i.e., the header, query string, or request body containing the key) before proxying it."
             }
           },
           {
@@ -74,33 +75,32 @@
           {
             "key_in_header": {
               "default": true,
-              "description": "If enabled (default), the plugin reads the request header and tries to find the key in it.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If enabled (default), the plugin reads the request header and tries to find the key in it."
             }
           },
           {
             "key_in_query": {
               "default": true,
-              "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it."
             }
           },
           {
             "key_in_body": {
               "default": false,
-              "description": "If enabled, the plugin reads the request body (if said request has one and its MIME type is supported) and tries to find the key in it. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If enabled, the plugin reads the request body (if said request has one and its MIME type is supported) and tries to find the key in it. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`."
             }
           },
           {
             "run_on_preflight": {
               "default": true,
-              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/key-auth/3.4.x.json
+++ b/schemas/key-auth/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -18,8 +18,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,13 +36,14 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "key_names": {
@@ -50,20 +51,20 @@
               "default": [
                 "apikey"
               ],
-              "description": "Describes an array of parameter names where the plugin will look for a key. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.",
               "type": "array",
               "elements": {
-                "type": "string",
-                "description": "A string representing an HTTP header name."
-              }
+                "description": "A string representing an HTTP header name.",
+                "type": "string"
+              },
+              "description": "Describes an array of parameter names where the plugin will look for a key. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request."
             }
           },
           {
@@ -75,37 +76,36 @@
           {
             "key_in_header": {
               "default": true,
-              "description": "If enabled (default), the plugin reads the request header and tries to find the key in it.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If enabled (default), the plugin reads the request header and tries to find the key in it."
             }
           },
           {
             "key_in_query": {
               "default": true,
-              "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it."
             }
           },
           {
             "key_in_body": {
               "default": false,
-              "description": "If enabled, the plugin reads the request body. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If enabled, the plugin reads the request body. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`."
             }
           },
           {
             "run_on_preflight": {
               "default": true,
-              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/konnect-application-auth/3.4.x.json
+++ b/schemas/konnect-application-auth/3.4.x.json
@@ -3,17 +3,17 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "route": {
         "reference": "routes",
-        "description": "A reference to the 'routes' table with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "A reference to the 'routes' table with a null value allowed."
       }
     },
     {
@@ -25,7 +25,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -35,15 +34,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -55,37 +55,37 @@
               "default": [
                 "apikey"
               ],
-              "description": "The names of the headers containing the API key. You can specify multiple header names.",
               "type": "array",
               "elements": {
-                "type": "string",
-                "description": "A string representing an HTTP header name."
-              }
+                "description": "A string representing an HTTP header name.",
+                "type": "string"
+              },
+              "description": "The names of the headers containing the API key. You can specify multiple header names."
             }
           },
           {
             "auth_type": {
               "required": true,
               "default": "openid-connect",
-              "description": "The type of authentication to be performed. Possible values are: 'openid-connect', 'key-auth'.",
               "type": "string",
               "one_of": [
                 "openid-connect",
                 "key-auth"
-              ]
+              ],
+              "description": "The type of authentication to be performed. Possible values are: 'openid-connect', 'key-auth'."
             }
           },
           {
             "scope": {
               "unique": true,
-              "description": "The unique scope identifier for the plugin configuration.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The unique scope identifier for the plugin configuration."
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
 
         ]

--- a/schemas/ldap-auth-advanced/3.4.x.json
+++ b/schemas/ldap-auth-advanced/3.4.x.json
@@ -10,8 +10,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -28,139 +28,140 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "ldap_host": {
-              "description": "Host on which the LDAP server is running.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Host on which the LDAP server is running."
             }
           },
           {
             "ldap_password": {
-              "encrypted": true,
               "description": "The password to the LDAP server.",
               "type": "string",
+              "encrypted": true,
               "referenceable": true
             }
           },
           {
             "ldap_port": {
               "default": 389,
-              "description": "TCP port where the LDAP server is listening. 389 is the default port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is configured, you must use port 636.",
-              "type": "number"
+              "type": "number",
+              "description": "TCP port where the LDAP server is listening. 389 is the default port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is configured, you must use port 636."
             }
           },
           {
             "bind_dn": {
-              "description": "The DN to bind to. Used to perform LDAP search of user. This `bind_dn` should have permissions to search for the user being authenticated.",
               "type": "string",
+              "description": "The DN to bind to. Used to perform LDAP search of user. This `bind_dn` should have permissions to search for the user being authenticated.",
               "referenceable": true
             }
           },
           {
             "ldaps": {
               "default": false,
-              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled."
             }
           },
           {
             "start_tls": {
               "default": false,
-              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled."
             }
           },
           {
             "verify_ldap_host": {
               "default": false,
-              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive."
             }
           },
           {
             "base_dn": {
-              "description": "Base DN as the starting point for the search; e.g., 'dc=example,dc=com'.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Base DN as the starting point for the search; e.g., 'dc=example,dc=com'."
             }
           },
           {
             "attribute": {
-              "description": "Attribute to be used to search the user; e.g., \"cn\".",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Attribute to be used to search the user; e.g., \"cn\"."
             }
           },
           {
             "cache_ttl": {
               "default": 60,
-              "description": "Cache expiry time in seconds.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "Cache expiry time in seconds."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request."
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed."
             }
           },
           {
             "anonymous": {
               "default": "",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
               "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
               "len_min": 0
             }
           },
           {
             "header_type": {
               "default": "ldap",
-              "description": "An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to \"basic\", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `'ldap'` and `'basic'`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to \"basic\", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `'ldap'` and `'basic'`."
             }
           },
           {
             "consumer_optional": {
               "default": false,
-              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user."
             }
           },
           {
@@ -170,7 +171,6 @@
                 "username",
                 "custom_id"
               ],
-              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -178,48 +178,48 @@
                   "username",
                   "custom_id"
                 ]
-              }
+              },
+              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both."
             }
           },
           {
             "group_base_dn": {
-              "type": "string",
-              "description": "Sets a distinguished name (DN) for the entry where LDAP searches for groups begin. This field is case-insensitive.',dc=com'."
+              "description": "Sets a distinguished name (DN) for the entry where LDAP searches for groups begin. This field is case-insensitive.',dc=com'.",
+              "type": "string"
             }
           },
           {
             "group_name_attribute": {
-              "type": "string",
-              "description": "Sets the attribute holding the name of a group, typically called `name` (in Active Directory) or `cn` (in OpenLDAP). This field is case-insensitive."
+              "description": "Sets the attribute holding the name of a group, typically called `name` (in Active Directory) or `cn` (in OpenLDAP). This field is case-insensitive.",
+              "type": "string"
             }
           },
           {
             "group_member_attribute": {
               "default": "memberOf",
-              "description": "Sets the attribute holding the members of the LDAP group. This field is case-sensitive.",
-              "type": "string"
+              "type": "string",
+              "description": "Sets the attribute holding the members of the LDAP group. This field is case-sensitive."
             }
           },
           {
             "log_search_results": {
               "default": false,
-              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment."
             }
           },
           {
             "groups_required": {
               "required": false,
-              "description": "The groups required to be present in the LDAP search result for successful authorization. This config parameter works in both **AND** / **OR** cases. - When `[\"group1 group2\"]` are in the same array indices, both `group1` AND `group2` need to be present in the LDAP search result. - When `[\"group1\", \"group2\"]` are in different array indices, either `group1` OR `group2` need to be present in the LDAP search result.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "The groups required to be present in the LDAP search result for successful authorization. This config parameter works in both **AND** / **OR** cases. - When `[\"group1 group2\"]` are in the same array indices, both `group1` AND `group2` need to be present in the LDAP search result. - When `[\"group1\", \"group2\"]` are in different array indices, either `group1` OR `group2` need to be present in the LDAP search result."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/ldap-auth/3.4.x.json
+++ b/schemas/ldap-auth/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -18,8 +18,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,9 +36,9 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -46,119 +46,119 @@
         "fields": [
           {
             "ldap_host": {
-              "description": "A string representing a host name, such as example.com.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "ldap_port": {
               "required": true,
-              "default": 389,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 389,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "ldaps": {
               "default": false,
-              "description": "Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled."
             }
           },
           {
             "start_tls": {
               "default": false,
-              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled."
             }
           },
           {
             "verify_ldap_host": {
               "default": false,
-              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive."
             }
           },
           {
             "base_dn": {
-              "description": "Base DN as the starting point for the search; e.g., dc=example,dc=com",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Base DN as the starting point for the search; e.g., dc=example,dc=com"
             }
           },
           {
             "attribute": {
-              "description": "Attribute to be used to search the user; e.g. cn",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Attribute to be used to search the user; e.g. cn"
             }
           },
           {
             "cache_ttl": {
               "default": 60,
-              "description": "Cache expiry time in seconds.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "Cache expiry time in seconds."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request."
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed."
             }
           },
           {
             "anonymous": {
-              "type": "string",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`."
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`.",
+              "type": "string"
             }
           },
           {
             "header_type": {
               "default": "ldap",
-              "description": "An optional string to use as part of the Authorization header",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string to use as part of the Authorization header"
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "conditional": {
-              "then_field": "start_tls",
               "then_err": "'ldaps' and 'start_tls' cannot be enabled simultaneously",
-              "then_match": {
-                "eq": false
-              },
               "if_match": {
                 "eq": true
               },
-              "if_field": "ldaps"
+              "then_field": "start_tls",
+              "if_field": "ldaps",
+              "then_match": {
+                "eq": false
+              }
             }
           }
         ]

--- a/schemas/loggly/3.4.x.json
+++ b/schemas/loggly/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,33 +23,36 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "host": {
               "default": "logs-01.loggly.com",
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
               "default": 514,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
@@ -61,8 +62,8 @@
           {
             "key": {
               "required": true,
-              "encrypted": true,
               "type": "string",
+              "encrypted": true,
               "referenceable": true
             }
           },
@@ -149,8 +150,6 @@
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "description": "Lua code as a key-value map",
               "values": {
                 "len_min": 1,
                 "type": "string"
@@ -158,11 +157,12 @@
               "keys": {
                 "type": "string",
                 "len_min": 1
-              }
+              },
+              "type": "map",
+              "description": "Lua code as a key-value map"
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/mocking/3.4.x.json
+++ b/schemas/mocking/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,81 +18,82 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "api_specification_filename": {
-              "description": "The path and name of the specification file loaded into Kong Gateway's database. You cannot use this option for DB-less or hybrid mode.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The path and name of the specification file loaded into Kong Gateway's database. You cannot use this option for DB-less or hybrid mode."
             }
           },
           {
             "api_specification": {
-              "description": "The contents of the specification file. You must use this option for hybrid or DB-less mode. You can include the full specification as part of the configuration. In Kong Manager, you can copy and paste the contents of the spec directly into the `Config.Api Specification` text field.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The contents of the specification file. You must use this option for hybrid or DB-less mode. You can include the full specification as part of the configuration. In Kong Manager, you can copy and paste the contents of the spec directly into the `Config.Api Specification` text field."
             }
           },
           {
             "random_delay": {
               "default": false,
-              "description": "Enables a random delay in the mocked response. Introduces delays to simulate real-time response times by APIs.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Enables a random delay in the mocked response. Introduces delays to simulate real-time response times by APIs."
             }
           },
           {
             "max_delay_time": {
               "default": 1,
-              "description": "The maximum value in seconds of delay time. Set this value when `random_delay` is enabled and you want to adjust the default. The value must be greater than the `min_delay_time`.",
-              "type": "number"
+              "type": "number",
+              "description": "The maximum value in seconds of delay time. Set this value when `random_delay` is enabled and you want to adjust the default. The value must be greater than the `min_delay_time`."
             }
           },
           {
             "min_delay_time": {
               "default": 0.001,
-              "description": "The minimum value in seconds of delay time. Set this value when `random_delay` is enabled and you want to adjust the default. The value must be less than the `max_delay_time`.",
-              "type": "number"
+              "type": "number",
+              "description": "The minimum value in seconds of delay time. Set this value when `random_delay` is enabled and you want to adjust the default. The value must be less than the `max_delay_time`."
             }
           },
           {
             "random_examples": {
               "default": false,
-              "description": "Randomly selects one example and returns it. This parameter requires the spec to have multiple examples configured.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Randomly selects one example and returns it. This parameter requires the spec to have multiple examples configured."
             }
           },
           {
             "included_status_codes": {
-              "description": "A global list of the HTTP status codes that can only be selected and returned.",
               "type": "array",
               "elements": {
                 "type": "integer"
-              }
+              },
+              "description": "A global list of the HTTP status codes that can only be selected and returned."
             }
           },
           {
             "random_status_code": {
               "default": false,
-              "description": "Determines whether to randomly select an HTTP status code from the responses of the corresponding API method. The default value is `false`, which means the minimum HTTP status code is always selected and returned.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Determines whether to randomly select an HTTP status code from the responses of the corresponding API method. The default value is `false`, which means the minimum HTTP status code is always selected and returned."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/mtls-auth/3.4.x.json
+++ b/schemas/mtls-auth/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,15 +26,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -54,7 +54,6 @@
                 "username",
                 "custom_id"
               ],
-              "description": "Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array), then auto-matching is disabled.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -62,125 +61,126 @@
                   "username",
                   "custom_id"
                 ]
-              }
+              },
+              "description": "Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array), then auto-matching is disabled."
             }
           },
           {
             "ca_certificates": {
               "required": true,
-              "description": "List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`).",
               "type": "array",
               "elements": {
                 "uuid": true,
                 "type": "string"
-              }
+              },
+              "description": "List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`)."
             }
           },
           {
             "cache_ttl": {
               "default": 60,
-              "description": "Cache expiry time in seconds.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "Cache expiry time in seconds."
             }
           },
           {
             "skip_consumer_lookup": {
               "default": false,
-              "description": "Skip consumer lookup once certificate is trusted against the configured CA list.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Skip consumer lookup once certificate is trusted against the configured CA list."
             }
           },
           {
             "allow_partial_chain": {
               "default": false,
-              "description": "Allow certificate verification with only an intermediate certificate. When this is enabled, you don't need to upload the full chain to Kong Certificates.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Allow certificate verification with only an intermediate certificate. When this is enabled, you don't need to upload the full chain to Kong Certificates."
             }
           },
           {
             "authenticated_group_by": {
               "required": false,
               "default": "CN",
-              "description": "Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API. To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users.",
               "type": "string",
               "one_of": [
                 "CN",
                 "DN"
-              ]
+              ],
+              "description": "Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API. To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users."
             }
           },
           {
             "revocation_check_mode": {
               "required": false,
               "default": "IGNORE_CA_ERROR",
-              "description": "Controls client certificate revocation check behavior. If set to `SKIP`, no revocation check is performed. If set to `IGNORE_CA_ERROR`, the plugin respects the revocation status when either OCSP or CRL URL is set, and doesn't fail on network issues. If set to `STRICT`, the plugin only treats the certificate as valid when it's able to verify the revocation status.",
               "type": "string",
               "one_of": [
                 "SKIP",
                 "IGNORE_CA_ERROR",
                 "STRICT"
-              ]
+              ],
+              "description": "Controls client certificate revocation check behavior. If set to `SKIP`, no revocation check is performed. If set to `IGNORE_CA_ERROR`, the plugin respects the revocation status when either OCSP or CRL URL is set, and doesn't fail on network issues. If set to `STRICT`, the plugin only treats the certificate as valid when it's able to verify the revocation status."
             }
           },
           {
             "http_timeout": {
               "default": 30000,
-              "description": "HTTP timeout threshold in milliseconds when communicating with the OCSP server or downloading CRL.",
-              "type": "number"
+              "type": "number",
+              "description": "HTTP timeout threshold in milliseconds when communicating with the OCSP server or downloading CRL."
             }
           },
           {
             "cert_cache_ttl": {
               "default": 60000,
-              "description": "The length of time in milliseconds between refreshes of the revocation check status cache.",
-              "type": "number"
+              "type": "number",
+              "description": "The length of time in milliseconds between refreshes of the revocation check status cache."
             }
           },
           {
             "send_ca_dn": {
               "default": false,
-              "description": "Sends the distinguished names (DN) of the configured CA list in the TLS handshake message.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Sends the distinguished names (DN) of the configured CA list in the TLS handshake message."
             }
           },
           {
             "http_proxy_host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "http_proxy_port": {
+              "type": "integer",
               "between": [
                 0,
                 65535
               ],
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer"
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "https_proxy_host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "https_proxy_port": {
+              "type": "integer",
               "between": [
                 0,
                 65535
               ],
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer"
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "mutually_required": [

--- a/schemas/oas-validation/3.4.x.json
+++ b/schemas/oas-validation/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,117 +18,118 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "api_spec": {
-              "description": "The API specification defined using either Swagger or the OpenAPI. This can be either a JSON or YAML based file. If using a YAML file, the spec needs to be URL encoded to preserve the YAML format.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The API specification defined using either Swagger or the OpenAPI. This can be either a JSON or YAML based file. If using a YAML file, the spec needs to be URL encoded to preserve the YAML format."
             }
           },
           {
             "verbose_response": {
               "default": false,
-              "description": "If set to true, returns a detailed error message for invalid requests & responses. This is useful while testing.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, returns a detailed error message for invalid requests & responses. This is useful while testing."
             }
           },
           {
             "validate_request_body": {
               "default": true,
-              "description": "If set to true, validates the request body content against the API specification.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, validates the request body content against the API specification."
             }
           },
           {
             "notify_only_request_validation_failure": {
               "default": false,
-              "description": "If set to true, notifications via event hooks are enabled, but request based validation failures don't affect the request flow.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, notifications via event hooks are enabled, but request based validation failures don't affect the request flow."
             }
           },
           {
             "validate_request_header_params": {
               "default": true,
-              "description": "If set to true, validates HTTP header parameters against the API specification.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, validates HTTP header parameters against the API specification."
             }
           },
           {
             "validate_request_query_params": {
               "default": true,
-              "description": "If set to true, validates query parameters against the API specification.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, validates query parameters against the API specification."
             }
           },
           {
             "validate_request_uri_params": {
               "default": true,
-              "description": "If set to true, validates URI parameters in the request against the API specification.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, validates URI parameters in the request against the API specification."
             }
           },
           {
             "validate_response_body": {
               "default": false,
-              "description": "If set to true, validates the response from the upstream services against the API specification. If validation fails, it results in an `HTTP 406 Not Acceptable` status code.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, validates the response from the upstream services against the API specification. If validation fails, it results in an `HTTP 406 Not Acceptable` status code."
             }
           },
           {
             "notify_only_response_body_validation_failure": {
               "default": false,
-              "description": "If set to true, notifications via event hooks are enabled, but response validation failures don't affect the response flow.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "If set to true, notifications via event hooks are enabled, but response validation failures don't affect the response flow."
             }
           },
           {
             "query_parameter_check": {
               "default": false,
-              "description": "If set to true, checks if query parameters in the request exist in the API specification.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If set to true, checks if query parameters in the request exist in the API specification."
             }
           },
           {
             "header_parameter_check": {
               "default": false,
-              "description": "If set to true, checks if HTTP header parameters in the request exist in the API specification.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If set to true, checks if HTTP header parameters in the request exist in the API specification."
             }
           },
           {
             "allowed_header_parameters": {
               "default": "Host,Content-Type,User-Agent,Accept,Content-Length",
-              "description": "List of header parameters in the request that will be ignored when performing HTTP header validation. These are additional headers added to an API request beyond those defined in the API specification.  For example, you might include the HTTP header `User-Agent`, which lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "List of header parameters in the request that will be ignored when performing HTTP header validation. These are additional headers added to an API request beyond those defined in the API specification.  For example, you might include the HTTP header `User-Agent`, which lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/oauth2-introspection/3.4.x.json
+++ b/schemas/oauth2-introspection/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,32 +26,34 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "introspection_url": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "ttl": {
               "default": 30,
-              "description": "The TTL in seconds for the introspection response. Set to 0 to disable the expiration.",
-              "type": "number"
+              "type": "number",
+              "description": "The TTL in seconds for the introspection response. Set to 0 to disable the expiration."
             }
           },
           {
@@ -63,81 +64,81 @@
           },
           {
             "authorization_value": {
-              "description": "The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`).",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`)."
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
-              "type": "integer"
+              "type": "integer",
+              "description": "An optional timeout in milliseconds when sending data to the upstream server."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
-              "type": "integer"
+              "type": "integer",
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed."
             }
           },
           {
             "introspect_request": {
               "default": false,
-              "description": "A boolean indicating whether to forward information about the current downstream request to the introspect endpoint. If true, headers `X-Request-Path` and `X-Request-Http-Method` will be inserted into the introspect request.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean indicating whether to forward information about the current downstream request to the introspect endpoint. If true, headers `X-Request-Path` and `X-Request-Http-Method` will be inserted into the introspect request."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream API server. It will be removed by Kong before proxying the request."
             }
           },
           {
             "run_on_preflight": {
               "default": true,
-              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed."
             }
           },
           {
             "anonymous": {
-              "len_min": 0,
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
+              "default": "",
               "type": "string",
-              "default": ""
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
+              "len_min": 0
             }
           },
           {
             "consumer_by": {
               "required": true,
               "default": "username",
-              "description": "A string indicating whether to associate OAuth2 `username` or `client_id` with the consumer's username. OAuth2 `username` is mapped to a consumer's `username` field, while an OAuth2 `client_id` maps to a consumer's `custom_id`.",
               "type": "string",
               "one_of": [
                 "username",
                 "client_id"
-              ]
+              ],
+              "description": "A string indicating whether to associate OAuth2 `username` or `client_id` with the consumer's username. OAuth2 `username` is mapped to a consumer's `username` field, while an OAuth2 `client_id` maps to a consumer's `custom_id`."
             }
           },
           {
             "custom_introspection_headers": {
-              "values": {
+              "keys": {
                 "type": "string"
               },
               "required": true,
+              "values": {
+                "type": "string"
+              },
               "default": [
 
               ],
-              "description": "A list of custom headers to be added in the introspection request.",
               "type": "map",
-              "keys": {
-                "type": "string"
-              }
+              "description": "A list of custom headers to be added in the introspection request."
             }
           },
           {
@@ -146,15 +147,14 @@
               "default": [
 
               ],
-              "description": "A list of custom claims to be forwarded from the introspection response to the upstream request. Claims are forwarded in headers with prefix `X-Credential-{claim-name}`.",
               "type": "set",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "A list of custom claims to be forwarded from the introspection response to the upstream request. Claims are forwarded in headers with prefix `X-Credential-{claim-name}`."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/oauth2/3.4.x.json
+++ b/schemas/oauth2/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -18,8 +18,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,109 +36,95 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "entity_checks": [
-          {
-            "conditional": {
-              "if_field": "mandatory_scope",
-              "then_field": "scopes",
-              "if_match": {
-                "eq": true
-              },
-              "then_match": {
-                "required": true
-              }
-            }
-          }
-        ],
         "fields": [
           {
             "scopes": {
-              "description": "Describes an array of scope names that will be available to the end user. If `mandatory_scope` is set to `true`, then `scopes` are required.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Describes an array of scope names that will be available to the end user. If `mandatory_scope` is set to `true`, then `scopes` are required."
             }
           },
           {
             "mandatory_scope": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to require at least one `scope` to be authorized by the end user.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value telling the plugin to require at least one `scope` to be authorized by the end user."
             }
           },
           {
             "provision_key": {
-              "encrypted": true,
               "required": true,
-              "unique": true,
-              "description": "The unique key the plugin has generated when it has been added to the Service.",
+              "auto": true,
+              "encrypted": true,
               "type": "string",
-              "auto": true
+              "unique": true,
+              "description": "The unique key the plugin has generated when it has been added to the Service."
             }
           },
           {
             "token_expiration": {
               "default": 7200,
-              "description": "An optional integer value telling the plugin how many seconds a token should last, after which the client will need to refresh the token. Set to `0` to disable the expiration.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "An optional integer value telling the plugin how many seconds a token should last, after which the client will need to refresh the token. Set to `0` to disable the expiration."
             }
           },
           {
             "enable_authorization_code": {
               "default": false,
-              "description": "An optional boolean value to enable the three-legged Authorization Code flow (RFC 6742 Section 4.1).",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value to enable the three-legged Authorization Code flow (RFC 6742 Section 4.1)."
             }
           },
           {
             "enable_implicit_grant": {
               "default": false,
-              "description": "An optional boolean value to enable the Implicit Grant flow which allows to provision a token as a result of the authorization process (RFC 6742 Section 4.2).",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value to enable the Implicit Grant flow which allows to provision a token as a result of the authorization process (RFC 6742 Section 4.2)."
             }
           },
           {
             "enable_client_credentials": {
               "default": false,
-              "description": "An optional boolean value to enable the Client Credentials Grant flow (RFC 6742 Section 4.4).",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value to enable the Client Credentials Grant flow (RFC 6742 Section 4.4)."
             }
           },
           {
             "enable_password_grant": {
               "default": false,
-              "description": "An optional boolean value to enable the Resource Owner Password Credentials Grant flow (RFC 6742 Section 4.3).",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value to enable the Resource Owner Password Credentials Grant flow (RFC 6742 Section 4.3)."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service."
             }
           },
           {
             "accept_http_if_already_terminated": {
               "default": false,
-              "description": "Accepts HTTPs requests that have already been terminated by a proxy or load balancer.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Accepts HTTPs requests that have already been terminated by a proxy or load balancer."
             }
           },
           {
@@ -150,36 +136,36 @@
           {
             "global_credentials": {
               "default": false,
-              "description": "An optional boolean value that allows using the same OAuth credentials generated by the plugin with any other service whose OAuth 2.0 plugin configuration also has `config.global_credentials=true`.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value that allows using the same OAuth credentials generated by the plugin with any other service whose OAuth 2.0 plugin configuration also has `config.global_credentials=true`."
             }
           },
           {
             "auth_header_name": {
               "default": "authorization",
-              "description": "The name of the header that is supposed to carry the access token.",
-              "type": "string"
+              "type": "string",
+              "description": "The name of the header that is supposed to carry the access token."
             }
           },
           {
             "refresh_token_ttl": {
               "required": true,
-              "default": 1209600,
-              "description": "Time-to-live value for data",
-              "type": "number",
               "between": [
                 0,
                 100000000
-              ]
+              ],
+              "default": 1209600,
+              "type": "number",
+              "description": "Time-to-live value for data"
             }
           },
           {
             "reuse_refresh_token": {
               "default": false,
-              "description": "An optional boolean value that indicates whether an OAuth refresh token is reused when refreshing an access token.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "An optional boolean value that indicates whether an OAuth refresh token is reused when refreshing an access token."
             }
           },
           {
@@ -193,18 +179,32 @@
             "pkce": {
               "required": false,
               "default": "lax",
-              "description": "Specifies a mode of how the Proof Key for Code Exchange (PKCE) should be handled by the plugin.",
               "type": "string",
               "one_of": [
                 "none",
                 "lax",
                 "strict"
-              ]
+              ],
+              "description": "Specifies a mode of how the Proof Key for Code Exchange (PKCE) should be handled by the plugin."
             }
           }
         ],
         "type": "record",
-        "required": true
+        "required": true,
+        "entity_checks": [
+          {
+            "conditional": {
+              "if_match": {
+                "eq": true
+              },
+              "then_field": "scopes",
+              "if_field": "mandatory_scope",
+              "then_match": {
+                "required": true
+              }
+            }
+          }
+        ]
       }
     }
   ],

--- a/schemas/opa/3.4.x.json
+++ b/schemas/opa/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,116 +26,117 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "opa_protocol": {
               "default": "http",
-              "description": "The protocol to use when talking to Open Policy Agent (OPA) server. Allowed protocols are `http` and `https`.",
               "type": "string",
               "one_of": [
                 "http",
                 "https"
-              ]
+              ],
+              "description": "The protocol to use when talking to Open Policy Agent (OPA) server. Allowed protocols are `http` and `https`."
             }
           },
           {
             "opa_host": {
               "default": "localhost",
-              "description": "A string representing a host name, such as example.com.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "opa_port": {
               "required": true,
-              "default": 8181,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 8181,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "opa_path": {
+              "required": true,
+              "starts_with": "/",
+              "type": "string",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
-              "required": true,
-              "starts_with": "/",
-              "type": "string",
               "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "include_service_in_opa_input": {
               "default": false,
-              "description": "If set to true, the Kong Gateway Service object in use for the current request is included as input to OPA.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to true, the Kong Gateway Service object in use for the current request is included as input to OPA."
             }
           },
           {
             "include_route_in_opa_input": {
               "default": false,
-              "description": "If set to true, the Kong Gateway Route object in use for the current request is included as input to OPA.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to true, the Kong Gateway Route object in use for the current request is included as input to OPA."
             }
           },
           {
             "include_consumer_in_opa_input": {
               "default": false,
-              "description": "If set to true, the Kong Gateway Consumer object in use for the current request (if any) is included as input to OPA.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to true, the Kong Gateway Consumer object in use for the current request (if any) is included as input to OPA."
             }
           },
           {
             "include_body_in_opa_input": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "type": "boolean"
             }
           },
           {
             "include_parsed_json_body_in_opa_input": {
               "default": false,
-              "description": "If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be JSON decoded and the decoded struct is included as input to OPA.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to true and the `Content-Type` header of the current request is `application/json`, the request body will be JSON decoded and the decoded struct is included as input to OPA."
             }
           },
           {
             "include_uri_captures_in_opa_input": {
               "default": false,
-              "description": "If set to true, the regex capture groups captured on the Kong Gateway Route's path field in the current request (if any) are included as input to OPA.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to true, the regex capture groups captured on the Kong Gateway Route's path field in the current request (if any) are included as input to OPA."
             }
           },
           {
             "ssl_verify": {
               "default": true,
-              "description": "If set to true, the OPA certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If set to true, the OPA certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/openid-connect/3.4.x.json
+++ b/schemas/openid-connect/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,2278 +26,20 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "fields": [
-          {
-            "issuer": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": true
-            }
-          },
-          {
-            "discovery_headers_names": {
-              "required": false,
-              "description": "Extra header names passed to the discovery endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "discovery_headers_values": {
-              "required": false,
-              "description": "Extra header values passed to the discovery endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "extra_jwks_uris": {
-              "required": false,
-              "description": "JWKS URIs whose public keys are trusted (in addition to the keys found with the discovery).",
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "rediscovery_lifetime": {
-              "default": 30,
-              "description": "Specifies how long (in seconds) the plugin waits between discovery attempts. Discovery is still triggered on an as-needed basis.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "auth_methods": {
-              "required": false,
-              "default": [
-                "password",
-                "client_credentials",
-                "authorization_code",
-                "bearer",
-                "introspection",
-                "userinfo",
-                "kong_oauth2",
-                "refresh_token",
-                "session"
-              ],
-              "description": "Types of credentials/grants to enable.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "bearer",
-                  "introspection",
-                  "userinfo",
-                  "kong_oauth2",
-                  "refresh_token",
-                  "session"
-                ]
-              }
-            }
-          },
-          {
-            "client_id": {
-              "encrypted": true,
-              "required": false,
-              "description": "The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "referenceable": true
-              }
-            }
-          },
-          {
-            "client_secret": {
-              "encrypted": true,
-              "required": false,
-              "description": "The client secret.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "referenceable": true
-              }
-            }
-          },
-          {
-            "client_auth": {
-              "required": false,
-              "description": "The authentication method used by the client (plugin) when calling the endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "client_secret_basic",
-                  "client_secret_post",
-                  "client_secret_jwt",
-                  "private_key_jwt",
-                  "none"
-                ]
-              }
-            }
-          },
-          {
-            "client_jwk": {
-              "required": false,
-              "type": "array",
-              "elements": {
-                "required": false,
-                "type": "record",
-                "fields": [
-                  {
-                    "issuer": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "kty": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "use": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "key_ops": {
-                      "required": false,
-                      "type": "array",
-                      "elements": {
-                        "type": "string",
-                        "required": false
-                      }
-                    }
-                  },
-                  {
-                    "alg": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "kid": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "x5u": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "x5c": {
-                      "required": false,
-                      "type": "array",
-                      "elements": {
-                        "type": "string",
-                        "required": false
-                      }
-                    }
-                  },
-                  {
-                    "x5t": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "x5t#S256": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "k": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "x": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "y": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "crv": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "n": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "e": {
-                      "type": "string",
-                      "required": false
-                    }
-                  },
-                  {
-                    "d": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "p": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "q": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "dp": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "dq": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "qi": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "oth": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "r": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  },
-                  {
-                    "t": {
-                      "required": false,
-                      "referenceable": true,
-                      "type": "string",
-                      "encrypted": true
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "client_alg": {
-              "required": false,
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "HS256",
-                  "HS384",
-                  "HS512",
-                  "RS256",
-                  "RS384",
-                  "RS512",
-                  "ES256",
-                  "ES384",
-                  "ES512",
-                  "PS256",
-                  "PS384",
-                  "PS512",
-                  "EdDSA"
-                ]
-              }
-            }
-          },
-          {
-            "client_arg": {
-              "default": "client_id",
-              "description": "The client to use for this request (the selection is made with a request parameter with the same name).",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "redirect_uri": {
-              "required": false,
-              "description": "The redirect URI passed to the authorization and token endpoints.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "login_redirect_uri": {
-              "required": false,
-              "description": "Where to redirect the client when `login_action` is set to `redirect`.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "logout_redirect_uri": {
-              "required": false,
-              "description": "Where to redirect the client after the logout.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "forbidden_redirect_uri": {
-              "required": false,
-              "description": "Where to redirect the client on forbidden requests.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "forbidden_error_message": {
-              "default": "Forbidden",
-              "description": "The error message for the forbidden requests (when not using the redirection).",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "forbidden_destroy_session": {
-              "default": true,
-              "description": "Destroy any active session for the forbidden requests.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "unauthorized_redirect_uri": {
-              "required": false,
-              "description": "Where to redirect the client on unauthorized requests.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "unauthorized_error_message": {
-              "default": "Unauthorized",
-              "description": "The error message for the unauthorized requests (when not using the redirection).",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "unexpected_redirect_uri": {
-              "required": false,
-              "description": "Where to redirect the client when unexpected errors happen with the requests.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
-              }
-            }
-          },
-          {
-            "response_mode": {
-              "required": false,
-              "default": "query",
-              "description": "The response mode passed to the authorization endpoint: - `query`: Instructs the identity provider to pass parameters in query string - `form_post`: Instructs the identity provider to pass parameters in request body - `fragment`: Instructs the identity provider to pass parameters in uri fragment (rarely useful as the plugin itself cannot read it)",
-              "type": "string",
-              "one_of": [
-                "query",
-                "form_post",
-                "fragment"
-              ]
-            }
-          },
-          {
-            "response_type": {
-              "required": false,
-              "default": [
-                "code"
-              ],
-              "description": "The response type passed to the authorization endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "scopes": {
-              "required": false,
-              "default": [
-                "openid"
-              ],
-              "description": "The scopes passed to the authorization and token endpoints.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "audience": {
-              "required": false,
-              "description": "The audience passed to the authorization endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "issuers_allowed": {
-              "required": false,
-              "description": "The issuers allowed to be present in the tokens (`iss` claim).",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "scopes_required": {
-              "required": false,
-              "description": "The scopes (`scopes_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "scopes_claim": {
-              "required": false,
-              "default": [
-                "scope"
-              ],
-              "description": "The claim that contains the scopes.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "audience_required": {
-              "required": false,
-              "description": "The audiences (`audience_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "audience_claim": {
-              "required": false,
-              "default": [
-                "aud"
-              ],
-              "description": "The claim that contains the audience.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "groups_required": {
-              "required": false,
-              "description": "The groups (`groups_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "groups_claim": {
-              "required": false,
-              "default": [
-                "groups"
-              ],
-              "description": "The claim that contains the groups.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "roles_required": {
-              "required": false,
-              "description": "The roles (`roles_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "roles_claim": {
-              "required": false,
-              "default": [
-                "roles"
-              ],
-              "description": "The claim that contains the roles.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "domains": {
-              "required": false,
-              "description": "The allowed values for the `hd` claim.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "max_age": {
-              "description": "The maximum age (in seconds) compared to the `auth_time` claim.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "authenticated_groups_claim": {
-              "required": false,
-              "description": "The claim that contains authenticated groups. This setting can be used together with ACL plugin, but it also enables IdP managed groups with other applications and integrations.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_query_args_names": {
-              "required": false,
-              "description": "Extra query argument names passed to the authorization endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_query_args_values": {
-              "required": false,
-              "description": "Extra query argument values passed to the authorization endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_query_args_client": {
-              "required": false,
-              "description": "Extra query arguments passed from the client to the authorization endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "authorization_rolling_timeout": {
-              "default": 600,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_name": {
-              "default": "authorization",
-              "description": "The authorization cookie name.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_path": {
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
-              "match_none": [
-                {
-                  "pattern": "//",
-                  "err": "must not have empty segments"
-                }
-              ],
-              "default": "/",
-              "starts_with": "/",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_domain": {
-              "description": "The authorization cookie Domain flag.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_same_site": {
-              "required": false,
-              "default": "Default",
-              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
-              "type": "string",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ]
-            }
-          },
-          {
-            "authorization_cookie_http_only": {
-              "default": true,
-              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "authorization_cookie_secure": {
-              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "preserve_query_args": {
-              "default": false,
-              "description": "With this parameter, you can preserve request query arguments even when doing authorization code flow.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "token_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "description": "The token endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
-              "one_of": [
-                "client_secret_basic",
-                "client_secret_post",
-                "client_secret_jwt",
-                "private_key_jwt",
-                "none"
-              ],
-              "required": false
-            }
-          },
-          {
-            "token_headers_names": {
-              "required": false,
-              "description": "Extra header names passed to the token endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_values": {
-              "required": false,
-              "description": "Extra header values passed to the token endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_client": {
-              "required": false,
-              "description": "Extra headers passed from the client to the token endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_replay": {
-              "required": false,
-              "description": "The names of token endpoint response headers to forward to the downstream client.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_headers_prefix": {
-              "description": "Add a prefix to the token endpoint response headers before forwarding them to the downstream client.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "token_headers_grants": {
-              "required": false,
-              "description": "Enable the sending of the token endpoint response headers only with certain grants: - `password`: with OAuth password grant - `client_credentials`: with OAuth client credentials grant - `authorization_code`: with authorization code flow - `refresh_token` with refresh token grant",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "refresh_token"
-                ]
-              }
-            }
-          },
-          {
-            "token_post_args_names": {
-              "required": false,
-              "description": "Extra post argument names passed to the token endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_post_args_values": {
-              "required": false,
-              "description": "Extra post argument values passed to the token endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_post_args_client": {
-              "required": false,
-              "description": "Pass extra arguments from the client to the OpenID-Connect plugin. If arguments exist, the client can pass them using: - Request Body - Query parameters  This parameter can be used with `scope` values, like this:  `config.token_post_args_client=scope`  In this case, the token would take the `scope` value from the query parameter or from the request body and send it to the token endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "introspection_endpoint_auth_method": {
-              "type": "string",
-              "description": "The introspection endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
-              "one_of": [
-                "client_secret_basic",
-                "client_secret_post",
-                "client_secret_jwt",
-                "private_key_jwt",
-                "none"
-              ],
-              "required": false
-            }
-          },
-          {
-            "introspection_hint": {
-              "default": "access_token",
-              "description": "Introspection hint parameter value passed to the introspection endpoint.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "introspection_check_active": {
-              "default": true,
-              "description": "Check that the introspection response has an `active` claim with a value of `true`.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "introspection_accept": {
-              "required": false,
-              "default": "application/json",
-              "description": "The value of `Accept` header for introspection requests: - `application/json`: introspection response as JSON - `application/token-introspection+jwt`: introspection response as JWT (from the current IETF draft document) - `application/jwt`: introspection response as JWT (from the obsolete IETF draft document)",
-              "type": "string",
-              "one_of": [
-                "application/json",
-                "application/token-introspection+jwt",
-                "application/jwt"
-              ]
-            }
-          },
-          {
-            "introspection_headers_names": {
-              "required": false,
-              "description": "Extra header names passed to the introspection endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_headers_values": {
-              "required": false,
-              "description": "Extra header values passed to the introspection endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_headers_client": {
-              "required": false,
-              "description": "Extra headers passed from the client to the introspection endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_post_args_names": {
-              "required": false,
-              "description": "Extra post argument names passed to the introspection endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_post_args_values": {
-              "required": false,
-              "description": "Extra post argument values passed to the introspection endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspection_post_args_client": {
-              "required": false,
-              "description": "Extra post arguments passed from the client to the introspection endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "introspect_jwt_tokens": {
-              "default": false,
-              "description": "Specifies whether to introspect the JWT access tokens (can be used to check for revocations).",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "revocation_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "revocation_endpoint_auth_method": {
-              "type": "string",
-              "description": "The revocation endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
-              "one_of": [
-                "client_secret_basic",
-                "client_secret_post",
-                "client_secret_jwt",
-                "private_key_jwt",
-                "none"
-              ],
-              "required": false
-            }
-          },
-          {
-            "end_session_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "userinfo_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "userinfo_accept": {
-              "required": false,
-              "default": "application/json",
-              "description": "The value of `Accept` header for user info requests: - `application/json`: user info response as JSON - `application/jwt`: user info response as JWT (from the obsolete IETF draft document)",
-              "type": "string",
-              "one_of": [
-                "application/json",
-                "application/jwt"
-              ]
-            }
-          },
-          {
-            "userinfo_headers_names": {
-              "required": false,
-              "description": "Extra header names passed to the user info endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_headers_values": {
-              "required": false,
-              "description": "Extra header values passed to the user info endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_headers_client": {
-              "required": false,
-              "description": "Extra headers passed from the client to the user info endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_query_args_names": {
-              "required": false,
-              "description": "Extra query argument names passed to the user info endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_query_args_values": {
-              "required": false,
-              "description": "Extra query argument values passed to the user info endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "userinfo_query_args_client": {
-              "required": false,
-              "description": "Extra query arguments passed from the client to the user info endpoint.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "token_exchange_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_secret": {
-              "required": false,
-              "referenceable": true,
-              "description": "The session secret.",
-              "type": "string",
-              "encrypted": true
-            }
-          },
-          {
-            "session_audience": {
-              "default": "default",
-              "description": "The session audience, which is the intended target application. For example `\"my-application\"`.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_name": {
-              "default": "session",
-              "description": "The session cookie name.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_remember": {
-              "default": false,
-              "description": "Enables or disables persistent sessions.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_remember_cookie_name": {
-              "default": "remember",
-              "description": "Persistent session cookie name. Use with the `remember` configuration parameter.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_remember_rolling_timeout": {
-              "default": 604800,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_remember_absolute_timeout": {
-              "default": 2592000,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_idling_timeout": {
-              "default": 900,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_rolling_timeout": {
-              "default": 3600,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_absolute_timeout": {
-              "default": 86400,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_path": {
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
-              "match_none": [
-                {
-                  "pattern": "//",
-                  "err": "must not have empty segments"
-                }
-              ],
-              "default": "/",
-              "starts_with": "/",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_domain": {
-              "description": "The session cookie Domain flag.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_same_site": {
-              "required": false,
-              "default": "Lax",
-              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
-              "type": "string",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ]
-            }
-          },
-          {
-            "session_cookie_http_only": {
-              "default": true,
-              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_secure": {
-              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_request_headers": {
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ]
-              }
-            }
-          },
-          {
-            "session_response_headers": {
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ]
-              }
-            }
-          },
-          {
-            "session_storage": {
-              "required": false,
-              "default": "cookie",
-              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie (the session cannot be invalidated or revoked without changing session secret, but is stateless, and doesn't require a database) - `memcache`: stores session data in memcached - `redis`: stores session data in Redis",
-              "type": "string",
-              "one_of": [
-                "cookie",
-                "memcache",
-                "memcached",
-                "redis"
-              ]
-            }
-          },
-          {
-            "session_store_metadata": {
-              "default": false,
-              "description": "Configures whether or not session metadata should be stored. This metadata includes information about the active sessions for a specific audience belonging to a specific subject.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_enforce_same_subject": {
-              "default": false,
-              "description": "When set to `true`, audiences are forced to share the same subject.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_hash_subject": {
-              "default": false,
-              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_hash_storage_key": {
-              "default": false,
-              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_prefix": {
-              "description": "The memcached session key prefix.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_socket": {
-              "description": "The memcached unix socket path.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_host": {
-              "default": "127.0.0.1",
-              "description": "The memcached host.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_port": {
-              "required": false,
-              "default": 11211,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ]
-            }
-          },
-          {
-            "session_redis_prefix": {
-              "description": "The Redis session key prefix.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_socket": {
-              "description": "The Redis unix socket path.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_host": {
-              "default": "127.0.0.1",
-              "description": "The Redis host",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_port": {
-              "required": false,
-              "default": 6379,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ]
-            }
-          },
-          {
-            "session_redis_username": {
-              "required": false,
-              "description": "Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired. If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-              "type": "string",
-              "referenceable": true
-            }
-          },
-          {
-            "session_redis_password": {
-              "required": false,
-              "referenceable": true,
-              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no AUTH commands are sent to Redis.",
-              "type": "string",
-              "encrypted": true
-            }
-          },
-          {
-            "session_redis_connect_timeout": {
-              "description": "Network IO timeout in milliseconds.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_read_timeout": {
-              "description": "Network IO timeout in milliseconds.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_send_timeout": {
-              "description": "Network IO timeout in milliseconds.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl": {
-              "default": false,
-              "description": "Use SSL/TLS for Redis connection.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl_verify": {
-              "default": false,
-              "description": "Verify identity provider server certificate.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_redis_server_name": {
-              "description": "The SNI used for connecting the Redis server.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_cluster_nodes": {
-              "required": false,
-              "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values.",
-              "type": "array",
-              "elements": {
-                "type": "record",
-                "fields": [
-                  {
-                    "ip": {
-                      "default": "127.0.0.1",
-                      "description": "A string representing a host name, such as example.com.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  {
-                    "port": {
-                      "default": 6379,
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                      "type": "integer",
-                      "between": [
-                        0,
-                        65535
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "session_redis_cluster_max_redirections": {
-              "description": "The Redis cluster maximum redirects.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "reverify": {
-              "default": false,
-              "description": "Specifies whether to always verify tokens stored in the session.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "jwt_session_claim": {
-              "default": "sid",
-              "description": "The claim to match against the JWT session cookie.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "jwt_session_cookie": {
-              "description": "The name of the JWT session cookie.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "bearer_token_param_type": {
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "description": "Where to look for the bearer token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body - `cookie`: search the HTTP request cookies specified with `config.bearer_token_cookie_name`",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "header",
-                  "cookie",
-                  "query",
-                  "body"
-                ]
-              }
-            }
-          },
-          {
-            "bearer_token_cookie_name": {
-              "description": "The name of the cookie in which the bearer token is passed.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "client_credentials_param_type": {
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "description": "Where to look for the client credentials: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search from the HTTP request body",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ]
-              }
-            }
-          },
-          {
-            "password_param_type": {
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "description": "Where to look for the username and password: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ]
-              }
-            }
-          },
-          {
-            "id_token_param_type": {
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "description": "Where to look for the id token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ]
-              }
-            }
-          },
-          {
-            "id_token_param_name": {
-              "description": "The name of the parameter used to pass the id token.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "refresh_token_param_type": {
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ],
-              "description": "Where to look for the refresh token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "header",
-                  "query",
-                  "body"
-                ]
-              }
-            }
-          },
-          {
-            "refresh_token_param_name": {
-              "description": "The name of the parameter used to pass the refresh token.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "refresh_tokens": {
-              "default": true,
-              "description": "Specifies whether the plugin should try to refresh (soon to be) expired access tokens if the plugin has a `refresh_token` available.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "upstream_headers_claims": {
-              "required": false,
-              "description": "The upstream header claims.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "upstream_headers_names": {
-              "required": false,
-              "description": "The upstream header names for the claim values.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "upstream_access_token_header": {
-              "default": "authorization:bearer",
-              "description": "The upstream access token header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_access_token_jwk_header": {
-              "description": "The upstream access token JWK header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_id_token_header": {
-              "description": "The upstream id token header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_id_token_jwk_header": {
-              "description": "The upstream id token JWK header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_refresh_token_header": {
-              "description": "The upstream refresh token header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_user_info_header": {
-              "description": "The upstream user info header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_user_info_jwt_header": {
-              "description": "The upstream user info JWT header (in case the user info returns a JWT response).",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_introspection_header": {
-              "description": "The upstream introspection header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_introspection_jwt_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "upstream_session_id_header": {
-              "description": "The upstream session id header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_headers_claims": {
-              "required": false,
-              "description": "The downstream header claims.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "downstream_headers_names": {
-              "required": false,
-              "description": "The downstream header names for the claim values.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "downstream_access_token_header": {
-              "description": "The downstream access token header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_access_token_jwk_header": {
-              "description": "The downstream access token JWK header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_id_token_header": {
-              "description": "The downstream id token header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_id_token_jwk_header": {
-              "description": "The downstream id token JWK header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_refresh_token_header": {
-              "description": "The downstream refresh token header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_user_info_header": {
-              "description": "The downstream user info header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_user_info_jwt_header": {
-              "description": "The downstream user info JWT header (in case the user info returns a JWT response).",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_introspection_header": {
-              "description": "The downstream introspection header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_introspection_jwt_header": {
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "downstream_session_id_header": {
-              "description": "The downstream session id header.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "login_methods": {
-              "required": false,
-              "default": [
-                "authorization_code"
-              ],
-              "description": "Enable login functionality with specified grants.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "bearer",
-                  "introspection",
-                  "userinfo",
-                  "kong_oauth2",
-                  "refresh_token",
-                  "session"
-                ]
-              }
-            }
-          },
-          {
-            "login_action": {
-              "required": false,
-              "default": "upstream",
-              "description": "What to do after successful login: - `upstream`: proxy request to upstream service - `response`: terminate request with a response - `redirect`: redirect to a different location",
-              "type": "string",
-              "one_of": [
-                "upstream",
-                "response",
-                "redirect"
-              ]
-            }
-          },
-          {
-            "login_tokens": {
-              "required": false,
-              "default": [
-                "id_token"
-              ],
-              "description": "What tokens to include in `response` body or `redirect` query string or fragment: - `id_token`: include id token - `access_token`: include access token - `refresh_token`: include refresh token - `tokens`: include the full token endpoint response - `introspection`: include introspection response",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id_token",
-                  "access_token",
-                  "refresh_token",
-                  "tokens",
-                  "introspection"
-                ]
-              }
-            }
-          },
-          {
-            "login_redirect_mode": {
-              "required": false,
-              "default": "fragment",
-              "description": "Where to place `login_tokens` when using `redirect` `login_action`: - `query`: place tokens in query string - `fragment`: place tokens in url fragment (not readable by servers)",
-              "type": "string",
-              "one_of": [
-                "query",
-                "fragment"
-              ]
-            }
-          },
-          {
-            "logout_query_arg": {
-              "description": "The request query argument that activates the logout.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_post_arg": {
-              "description": "The request body argument that activates the logout.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_uri_suffix": {
-              "description": "The request URI suffix that activates the logout.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "logout_methods": {
-              "required": false,
-              "default": [
-                "POST",
-                "DELETE"
-              ],
-              "description": "The request methods that can activate the logout: - `POST`: HTTP POST method - `GET`: HTTP GET method - `DELETE`: HTTP DELETE method",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "POST",
-                  "GET",
-                  "DELETE"
-                ]
-              }
-            }
-          },
-          {
-            "logout_revoke": {
-              "default": false,
-              "description": "Revoke tokens as part of the logout.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "logout_revoke_access_token": {
-              "default": true,
-              "description": "Revoke the access token as part of the logout.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "logout_revoke_refresh_token": {
-              "default": true,
-              "description": "Revoke the refresh token as part of the logout.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "consumer_claim": {
-              "required": false,
-              "description": "The claim used for consumer mapping.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "consumer_by": {
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ],
-              "description": "Consumer fields used for mapping: - `id`: try to find the matching Consumer by `id` - `username`: try to find the matching Consumer by `username` - `custom_id`: try to find the matching Consumer by `custom_id`",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "username",
-                  "custom_id"
-                ]
-              }
-            }
-          },
-          {
-            "consumer_optional": {
-              "default": false,
-              "description": "Do not terminate the request if consumer mapping fails.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "credential_claim": {
-              "required": false,
-              "default": [
-                "sub"
-              ],
-              "description": "The claim used to derive virtual credentials (e.g. to be consumed by the rate-limiting plugin), in case the consumer mapping is not used.",
-              "type": "array",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "anonymous": {
-              "description": "An optional string (consumer UUID or username) value that functions as an “anonymous” consumer if authentication fails. If empty (default null), requests that fail authentication will return a `4xx` HTTP status code. This value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "run_on_preflight": {
-              "default": true,
-              "description": "Specifies whether to run this plugin on pre-flight (`OPTIONS`) requests.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "leeway": {
-              "default": 0,
-              "description": "Allow some leeway (in seconds) on the ttl / expiry verification.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "verify_parameters": {
-              "default": false,
-              "description": "Verify plugin configuration against discovery.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "verify_nonce": {
-              "default": true,
-              "description": "Verify nonce on authorization code flow.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "verify_claims": {
-              "default": true,
-              "description": "Verify tokens for standard claims.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "verify_signature": {
-              "default": true,
-              "description": "Verify signature of tokens.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "ignore_signature": {
-              "required": false,
-              "default": [
-
-              ],
-              "description": "Skip the token signature verification on certain grants: - `password`: OAuth password grant - `client_credentials`: OAuth client credentials grant - `authorization_code`: authorization code flow - `refresh_token`: OAuth refresh token grant - `session`: session cookie authentication - `introspection`: OAuth introspection - `userinfo`: OpenID Connect user info endpoint authentication",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "refresh_token",
-                  "session",
-                  "introspection",
-                  "userinfo"
-                ]
-              }
-            }
-          },
-          {
-            "enable_hs_signatures": {
-              "default": false,
-              "description": "Enable shared secret, for example, HS256, signatures (when disabled they will not be accepted).",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "disable_session": {
-              "required": false,
-              "description": "Disable issuing the session cookie with the specified grants.",
-              "type": "array",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "password",
-                  "client_credentials",
-                  "authorization_code",
-                  "bearer",
-                  "introspection",
-                  "userinfo",
-                  "kong_oauth2",
-                  "refresh_token",
-                  "session"
-                ]
-              }
-            }
-          },
-          {
-            "cache_ttl": {
-              "default": 3600,
-              "description": "The default cache ttl in seconds that is used in case the cached object does not specify the expiry.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_max": {
-              "description": "The maximum cache ttl in seconds (enforced).",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_min": {
-              "description": "The minimum cache ttl in seconds (enforced).",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_neg": {
-              "description": "The negative cache ttl in seconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_ttl_resurrect": {
-              "description": "The resurrection ttl in seconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "cache_tokens": {
-              "default": true,
-              "description": "Cache the token endpoint requests.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "cache_tokens_salt": {
-              "auto": true,
-              "description": "Salt used for generating the cache key that is used for caching the token endpoint requests.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "cache_introspection": {
-              "default": true,
-              "description": "Cache the introspection endpoint requests.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "cache_token_exchange": {
-              "default": true,
-              "description": "Cache the token exchange endpoint requests.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "cache_user_info": {
-              "default": true,
-              "description": "Cache the user info requests.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "search_user_info": {
-              "default": false,
-              "description": "Specify whether to use the user info endpoint to get additional claims for consumer mapping, credential mapping, authenticated groups, and upstream and downstream headers.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "hide_credentials": {
-              "default": false,
-              "description": "Remove the credentials used for authentication from the request. If multiple credentials are sent with the same request, the plugin will remove those that were used for successful authentication.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "http_version": {
-              "default": 1.1,
-              "description": "The HTTP version used for the requests by this plugin: - `1.1`: HTTP 1.1 (the default) - `1.0`: HTTP 1.0",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "http_proxy": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "http_proxy_authorization": {
-              "description": "The HTTP proxy authorization.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "https_proxy": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "https_proxy_authorization": {
-              "description": "The HTTPS proxy authorization.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "no_proxy": {
-              "description": "Do not use proxy with these hosts.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "keepalive": {
-              "default": true,
-              "description": "Use keepalive with the HTTP client.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "ssl_verify": {
-              "default": false,
-              "description": "Verify identity provider server certificate.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "timeout": {
-              "default": 10000,
-              "description": "Network IO timeout in milliseconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "display_errors": {
-              "default": false,
-              "description": "Display errors on failure responses.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "by_username_ignore_case": {
-              "default": false,
-              "description": "If `consumer_by` is set to `username`, specify whether `username` can match consumers case-insensitively.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "resolve_distributed_claims": {
-              "default": false,
-              "description": "Distributed claims are represented by the `_claim_names` and `_claim_sources` members of the JSON object containing the claims. If this parameter is set to `true`, the plugin explicitly resolves these distributed claims.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "expose_error_code": {
-              "type": "boolean",
-              "default": true
-            }
-          }
-        ],
-        "type": "record",
         "shorthand_fields": [
           {
             "authorization_cookie_lifetime": {
@@ -2381,7 +122,2273 @@
             }
           }
         ],
-        "required": true
+        "type": "record",
+        "required": true,
+        "fields": [
+          {
+            "issuer": {
+              "type": "string",
+              "required": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "discovery_headers_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header names passed to the discovery endpoint."
+            }
+          },
+          {
+            "discovery_headers_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header values passed to the discovery endpoint."
+            }
+          },
+          {
+            "extra_jwks_uris": {
+              "required": false,
+              "type": "set",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "JWKS URIs whose public keys are trusted (in addition to the keys found with the discovery)."
+            }
+          },
+          {
+            "rediscovery_lifetime": {
+              "default": 30,
+              "type": "number",
+              "required": false,
+              "description": "Specifies how long (in seconds) the plugin waits between discovery attempts. Discovery is still triggered on an as-needed basis."
+            }
+          },
+          {
+            "auth_methods": {
+              "required": false,
+              "default": [
+                "password",
+                "client_credentials",
+                "authorization_code",
+                "bearer",
+                "introspection",
+                "userinfo",
+                "kong_oauth2",
+                "refresh_token",
+                "session"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "bearer",
+                  "introspection",
+                  "userinfo",
+                  "kong_oauth2",
+                  "refresh_token",
+                  "session"
+                ]
+              },
+              "description": "Types of credentials/grants to enable."
+            }
+          },
+          {
+            "client_id": {
+              "required": false,
+              "encrypted": true,
+              "type": "array",
+              "elements": {
+                "referenceable": true,
+                "type": "string"
+              },
+              "description": "The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider."
+            }
+          },
+          {
+            "client_secret": {
+              "required": false,
+              "encrypted": true,
+              "type": "array",
+              "elements": {
+                "referenceable": true,
+                "type": "string"
+              },
+              "description": "The client secret."
+            }
+          },
+          {
+            "client_auth": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "client_secret_basic",
+                  "client_secret_post",
+                  "client_secret_jwt",
+                  "private_key_jwt",
+                  "none"
+                ]
+              },
+              "description": "The authentication method used by the client (plugin) when calling the endpoint."
+            }
+          },
+          {
+            "client_jwk": {
+              "type": "array",
+              "required": false,
+              "elements": {
+                "type": "record",
+                "required": false,
+                "fields": [
+                  {
+                    "issuer": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "kty": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "use": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "key_ops": {
+                      "type": "array",
+                      "required": false,
+                      "elements": {
+                        "required": false,
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "alg": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "kid": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "x5u": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "x5c": {
+                      "type": "array",
+                      "required": false,
+                      "elements": {
+                        "required": false,
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "x5t": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "x5t#S256": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "k": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "x": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "y": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "crv": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "n": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "e": {
+                      "required": false,
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "d": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "p": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "q": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "dp": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "dq": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "qi": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "oth": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "r": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  },
+                  {
+                    "t": {
+                      "encrypted": true,
+                      "type": "string",
+                      "required": false,
+                      "referenceable": true
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "client_alg": {
+              "type": "array",
+              "required": false,
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "HS256",
+                  "HS384",
+                  "HS512",
+                  "RS256",
+                  "RS384",
+                  "RS512",
+                  "ES256",
+                  "ES384",
+                  "ES512",
+                  "PS256",
+                  "PS384",
+                  "PS512",
+                  "EdDSA"
+                ]
+              }
+            }
+          },
+          {
+            "client_arg": {
+              "default": "client_id",
+              "type": "string",
+              "required": false,
+              "description": "The client to use for this request (the selection is made with a request parameter with the same name)."
+            }
+          },
+          {
+            "redirect_uri": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "The redirect URI passed to the authorization and token endpoints."
+            }
+          },
+          {
+            "login_redirect_uri": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "Where to redirect the client when `login_action` is set to `redirect`."
+            }
+          },
+          {
+            "logout_redirect_uri": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "Where to redirect the client after the logout."
+            }
+          },
+          {
+            "forbidden_redirect_uri": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "Where to redirect the client on forbidden requests."
+            }
+          },
+          {
+            "forbidden_error_message": {
+              "default": "Forbidden",
+              "type": "string",
+              "required": false,
+              "description": "The error message for the forbidden requests (when not using the redirection)."
+            }
+          },
+          {
+            "forbidden_destroy_session": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Destroy any active session for the forbidden requests."
+            }
+          },
+          {
+            "unauthorized_redirect_uri": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "Where to redirect the client on unauthorized requests."
+            }
+          },
+          {
+            "unauthorized_error_message": {
+              "default": "Unauthorized",
+              "type": "string",
+              "required": false,
+              "description": "The error message for the unauthorized requests (when not using the redirection)."
+            }
+          },
+          {
+            "unexpected_redirect_uri": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+                "type": "string"
+              },
+              "description": "Where to redirect the client when unexpected errors happen with the requests."
+            }
+          },
+          {
+            "response_mode": {
+              "required": false,
+              "default": "query",
+              "type": "string",
+              "one_of": [
+                "query",
+                "form_post",
+                "fragment"
+              ],
+              "description": "The response mode passed to the authorization endpoint: - `query`: Instructs the identity provider to pass parameters in query string - `form_post`: Instructs the identity provider to pass parameters in request body - `fragment`: Instructs the identity provider to pass parameters in uri fragment (rarely useful as the plugin itself cannot read it)"
+            }
+          },
+          {
+            "response_type": {
+              "required": false,
+              "default": [
+                "code"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The response type passed to the authorization endpoint."
+            }
+          },
+          {
+            "scopes": {
+              "required": false,
+              "default": [
+                "openid"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The scopes passed to the authorization and token endpoints."
+            }
+          },
+          {
+            "audience": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The audience passed to the authorization endpoint."
+            }
+          },
+          {
+            "issuers_allowed": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The issuers allowed to be present in the tokens (`iss` claim)."
+            }
+          },
+          {
+            "scopes_required": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The scopes (`scopes_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases."
+            }
+          },
+          {
+            "scopes_claim": {
+              "required": false,
+              "default": [
+                "scope"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim that contains the scopes."
+            }
+          },
+          {
+            "audience_required": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The audiences (`audience_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases."
+            }
+          },
+          {
+            "audience_claim": {
+              "required": false,
+              "default": [
+                "aud"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim that contains the audience."
+            }
+          },
+          {
+            "groups_required": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The groups (`groups_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases."
+            }
+          },
+          {
+            "groups_claim": {
+              "required": false,
+              "default": [
+                "groups"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim that contains the groups."
+            }
+          },
+          {
+            "roles_required": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The roles (`roles_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases."
+            }
+          },
+          {
+            "roles_claim": {
+              "required": false,
+              "default": [
+                "roles"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim that contains the roles."
+            }
+          },
+          {
+            "domains": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The allowed values for the `hd` claim."
+            }
+          },
+          {
+            "max_age": {
+              "type": "number",
+              "required": false,
+              "description": "The maximum age (in seconds) compared to the `auth_time` claim."
+            }
+          },
+          {
+            "authenticated_groups_claim": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim that contains authenticated groups. This setting can be used together with ACL plugin, but it also enables IdP managed groups with other applications and integrations."
+            }
+          },
+          {
+            "authorization_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "authorization_query_args_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra query argument names passed to the authorization endpoint."
+            }
+          },
+          {
+            "authorization_query_args_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra query argument values passed to the authorization endpoint."
+            }
+          },
+          {
+            "authorization_query_args_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra query arguments passed from the client to the authorization endpoint."
+            }
+          },
+          {
+            "authorization_rolling_timeout": {
+              "default": 600,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "authorization_cookie_name": {
+              "default": "authorization",
+              "type": "string",
+              "required": false,
+              "description": "The authorization cookie name."
+            }
+          },
+          {
+            "authorization_cookie_path": {
+              "required": false,
+              "default": "/",
+              "starts_with": "/",
+              "type": "string",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
+            }
+          },
+          {
+            "authorization_cookie_domain": {
+              "type": "string",
+              "required": false,
+              "description": "The authorization cookie Domain flag."
+            }
+          },
+          {
+            "authorization_cookie_same_site": {
+              "required": false,
+              "default": "Default",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ],
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks."
+            }
+          },
+          {
+            "authorization_cookie_http_only": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property."
+            }
+          },
+          {
+            "authorization_cookie_secure": {
+              "type": "boolean",
+              "required": false,
+              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks."
+            }
+          },
+          {
+            "preserve_query_args": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "With this parameter, you can preserve request query arguments even when doing authorization code flow."
+            }
+          },
+          {
+            "token_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "token_endpoint_auth_method": {
+              "one_of": [
+                "client_secret_basic",
+                "client_secret_post",
+                "client_secret_jwt",
+                "private_key_jwt",
+                "none"
+              ],
+              "type": "string",
+              "required": false,
+              "description": "The token endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate"
+            }
+          },
+          {
+            "token_headers_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header names passed to the token endpoint."
+            }
+          },
+          {
+            "token_headers_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header values passed to the token endpoint."
+            }
+          },
+          {
+            "token_headers_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra headers passed from the client to the token endpoint."
+            }
+          },
+          {
+            "token_headers_replay": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The names of token endpoint response headers to forward to the downstream client."
+            }
+          },
+          {
+            "token_headers_prefix": {
+              "type": "string",
+              "required": false,
+              "description": "Add a prefix to the token endpoint response headers before forwarding them to the downstream client."
+            }
+          },
+          {
+            "token_headers_grants": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "refresh_token"
+                ]
+              },
+              "description": "Enable the sending of the token endpoint response headers only with certain grants: - `password`: with OAuth password grant - `client_credentials`: with OAuth client credentials grant - `authorization_code`: with authorization code flow - `refresh_token` with refresh token grant"
+            }
+          },
+          {
+            "token_post_args_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra post argument names passed to the token endpoint."
+            }
+          },
+          {
+            "token_post_args_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra post argument values passed to the token endpoint."
+            }
+          },
+          {
+            "token_post_args_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Pass extra arguments from the client to the OpenID-Connect plugin. If arguments exist, the client can pass them using: - Request Body - Query parameters  This parameter can be used with `scope` values, like this:  `config.token_post_args_client=scope`  In this case, the token would take the `scope` value from the query parameter or from the request body and send it to the token endpoint."
+            }
+          },
+          {
+            "introspection_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "introspection_endpoint_auth_method": {
+              "one_of": [
+                "client_secret_basic",
+                "client_secret_post",
+                "client_secret_jwt",
+                "private_key_jwt",
+                "none"
+              ],
+              "type": "string",
+              "required": false,
+              "description": "The introspection endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate"
+            }
+          },
+          {
+            "introspection_hint": {
+              "default": "access_token",
+              "type": "string",
+              "required": false,
+              "description": "Introspection hint parameter value passed to the introspection endpoint."
+            }
+          },
+          {
+            "introspection_check_active": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Check that the introspection response has an `active` claim with a value of `true`."
+            }
+          },
+          {
+            "introspection_accept": {
+              "required": false,
+              "default": "application/json",
+              "type": "string",
+              "one_of": [
+                "application/json",
+                "application/token-introspection+jwt",
+                "application/jwt"
+              ],
+              "description": "The value of `Accept` header for introspection requests: - `application/json`: introspection response as JSON - `application/token-introspection+jwt`: introspection response as JWT (from the current IETF draft document) - `application/jwt`: introspection response as JWT (from the obsolete IETF draft document)"
+            }
+          },
+          {
+            "introspection_headers_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header names passed to the introspection endpoint."
+            }
+          },
+          {
+            "introspection_headers_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header values passed to the introspection endpoint."
+            }
+          },
+          {
+            "introspection_headers_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra headers passed from the client to the introspection endpoint."
+            }
+          },
+          {
+            "introspection_post_args_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra post argument names passed to the introspection endpoint."
+            }
+          },
+          {
+            "introspection_post_args_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra post argument values passed to the introspection endpoint."
+            }
+          },
+          {
+            "introspection_post_args_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra post arguments passed from the client to the introspection endpoint."
+            }
+          },
+          {
+            "introspect_jwt_tokens": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Specifies whether to introspect the JWT access tokens (can be used to check for revocations)."
+            }
+          },
+          {
+            "revocation_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "revocation_endpoint_auth_method": {
+              "one_of": [
+                "client_secret_basic",
+                "client_secret_post",
+                "client_secret_jwt",
+                "private_key_jwt",
+                "none"
+              ],
+              "type": "string",
+              "required": false,
+              "description": "The revocation endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate"
+            }
+          },
+          {
+            "end_session_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "userinfo_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "userinfo_accept": {
+              "required": false,
+              "default": "application/json",
+              "type": "string",
+              "one_of": [
+                "application/json",
+                "application/jwt"
+              ],
+              "description": "The value of `Accept` header for user info requests: - `application/json`: user info response as JSON - `application/jwt`: user info response as JWT (from the obsolete IETF draft document)"
+            }
+          },
+          {
+            "userinfo_headers_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header names passed to the user info endpoint."
+            }
+          },
+          {
+            "userinfo_headers_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra header values passed to the user info endpoint."
+            }
+          },
+          {
+            "userinfo_headers_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra headers passed from the client to the user info endpoint."
+            }
+          },
+          {
+            "userinfo_query_args_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra query argument names passed to the user info endpoint."
+            }
+          },
+          {
+            "userinfo_query_args_values": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra query argument values passed to the user info endpoint."
+            }
+          },
+          {
+            "userinfo_query_args_client": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "Extra query arguments passed from the client to the user info endpoint."
+            }
+          },
+          {
+            "token_exchange_endpoint": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "session_secret": {
+              "required": false,
+              "description": "The session secret.",
+              "type": "string",
+              "encrypted": true,
+              "referenceable": true
+            }
+          },
+          {
+            "session_audience": {
+              "default": "default",
+              "type": "string",
+              "required": false,
+              "description": "The session audience, which is the intended target application. For example `\"my-application\"`."
+            }
+          },
+          {
+            "session_cookie_name": {
+              "default": "session",
+              "type": "string",
+              "required": false,
+              "description": "The session cookie name."
+            }
+          },
+          {
+            "session_remember": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Enables or disables persistent sessions."
+            }
+          },
+          {
+            "session_remember_cookie_name": {
+              "default": "remember",
+              "type": "string",
+              "required": false,
+              "description": "Persistent session cookie name. Use with the `remember` configuration parameter."
+            }
+          },
+          {
+            "session_remember_rolling_timeout": {
+              "default": 604800,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_remember_absolute_timeout": {
+              "default": 2592000,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_idling_timeout": {
+              "default": 900,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_rolling_timeout": {
+              "default": 3600,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_absolute_timeout": {
+              "default": 86400,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_cookie_path": {
+              "required": false,
+              "default": "/",
+              "starts_with": "/",
+              "type": "string",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
+            }
+          },
+          {
+            "session_cookie_domain": {
+              "type": "string",
+              "required": false,
+              "description": "The session cookie Domain flag."
+            }
+          },
+          {
+            "session_cookie_same_site": {
+              "required": false,
+              "default": "Lax",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ],
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks."
+            }
+          },
+          {
+            "session_cookie_http_only": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property."
+            }
+          },
+          {
+            "session_cookie_secure": {
+              "type": "boolean",
+              "required": false,
+              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks."
+            }
+          },
+          {
+            "session_request_headers": {
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              },
+              "type": "set"
+            }
+          },
+          {
+            "session_response_headers": {
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              },
+              "type": "set"
+            }
+          },
+          {
+            "session_storage": {
+              "required": false,
+              "default": "cookie",
+              "type": "string",
+              "one_of": [
+                "cookie",
+                "memcache",
+                "memcached",
+                "redis"
+              ],
+              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie (the session cannot be invalidated or revoked without changing session secret, but is stateless, and doesn't require a database) - `memcache`: stores session data in memcached - `redis`: stores session data in Redis"
+            }
+          },
+          {
+            "session_store_metadata": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Configures whether or not session metadata should be stored. This metadata includes information about the active sessions for a specific audience belonging to a specific subject."
+            }
+          },
+          {
+            "session_enforce_same_subject": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "When set to `true`, audiences are forced to share the same subject."
+            }
+          },
+          {
+            "session_hash_subject": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled."
+            }
+          },
+          {
+            "session_hash_storage_key": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie."
+            }
+          },
+          {
+            "session_memcached_prefix": {
+              "type": "string",
+              "required": false,
+              "description": "The memcached session key prefix."
+            }
+          },
+          {
+            "session_memcached_socket": {
+              "type": "string",
+              "required": false,
+              "description": "The memcached unix socket path."
+            }
+          },
+          {
+            "session_memcached_host": {
+              "default": "127.0.0.1",
+              "type": "string",
+              "required": false,
+              "description": "The memcached host."
+            }
+          },
+          {
+            "session_memcached_port": {
+              "required": false,
+              "between": [
+                0,
+                65535
+              ],
+              "default": 11211,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
+            }
+          },
+          {
+            "session_redis_prefix": {
+              "type": "string",
+              "required": false,
+              "description": "The Redis session key prefix."
+            }
+          },
+          {
+            "session_redis_socket": {
+              "type": "string",
+              "required": false,
+              "description": "The Redis unix socket path."
+            }
+          },
+          {
+            "session_redis_host": {
+              "default": "127.0.0.1",
+              "type": "string",
+              "required": false,
+              "description": "The Redis host"
+            }
+          },
+          {
+            "session_redis_port": {
+              "required": false,
+              "between": [
+                0,
+                65535
+              ],
+              "default": 6379,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
+            }
+          },
+          {
+            "session_redis_username": {
+              "referenceable": true,
+              "type": "string",
+              "required": false,
+              "description": "Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired. If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
+            }
+          },
+          {
+            "session_redis_password": {
+              "required": false,
+              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no AUTH commands are sent to Redis.",
+              "type": "string",
+              "encrypted": true,
+              "referenceable": true
+            }
+          },
+          {
+            "session_redis_connect_timeout": {
+              "type": "integer",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_redis_read_timeout": {
+              "type": "integer",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_redis_send_timeout": {
+              "type": "integer",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "session_redis_ssl": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Use SSL/TLS for Redis connection."
+            }
+          },
+          {
+            "session_redis_ssl_verify": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify identity provider server certificate."
+            }
+          },
+          {
+            "session_redis_server_name": {
+              "type": "string",
+              "required": false,
+              "description": "The SNI used for connecting the Redis server."
+            }
+          },
+          {
+            "session_redis_cluster_nodes": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "fields": [
+                  {
+                    "ip": {
+                      "default": "127.0.0.1",
+                      "type": "string",
+                      "required": true,
+                      "description": "A string representing a host name, such as example.com."
+                    }
+                  },
+                  {
+                    "port": {
+                      "default": 6379,
+                      "type": "integer",
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "between": [
+                        0,
+                        65535
+                      ]
+                    }
+                  }
+                ],
+                "type": "record"
+              },
+              "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values."
+            }
+          },
+          {
+            "session_redis_cluster_max_redirections": {
+              "type": "integer",
+              "required": false,
+              "description": "The Redis cluster maximum redirects."
+            }
+          },
+          {
+            "reverify": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Specifies whether to always verify tokens stored in the session."
+            }
+          },
+          {
+            "jwt_session_claim": {
+              "default": "sid",
+              "type": "string",
+              "required": false,
+              "description": "The claim to match against the JWT session cookie."
+            }
+          },
+          {
+            "jwt_session_cookie": {
+              "type": "string",
+              "required": false,
+              "description": "The name of the JWT session cookie."
+            }
+          },
+          {
+            "bearer_token_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "cookie",
+                  "query",
+                  "body"
+                ]
+              },
+              "description": "Where to look for the bearer token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body - `cookie`: search the HTTP request cookies specified with `config.bearer_token_cookie_name`"
+            }
+          },
+          {
+            "bearer_token_cookie_name": {
+              "type": "string",
+              "required": false,
+              "description": "The name of the cookie in which the bearer token is passed."
+            }
+          },
+          {
+            "client_credentials_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              },
+              "description": "Where to look for the client credentials: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search from the HTTP request body"
+            }
+          },
+          {
+            "password_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              },
+              "description": "Where to look for the username and password: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body"
+            }
+          },
+          {
+            "id_token_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              },
+              "description": "Where to look for the id token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body"
+            }
+          },
+          {
+            "id_token_param_name": {
+              "type": "string",
+              "required": false,
+              "description": "The name of the parameter used to pass the id token."
+            }
+          },
+          {
+            "refresh_token_param_type": {
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "header",
+                  "query",
+                  "body"
+                ]
+              },
+              "description": "Where to look for the refresh token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body"
+            }
+          },
+          {
+            "refresh_token_param_name": {
+              "type": "string",
+              "required": false,
+              "description": "The name of the parameter used to pass the refresh token."
+            }
+          },
+          {
+            "refresh_tokens": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Specifies whether the plugin should try to refresh (soon to be) expired access tokens if the plugin has a `refresh_token` available."
+            }
+          },
+          {
+            "upstream_headers_claims": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The upstream header claims."
+            }
+          },
+          {
+            "upstream_headers_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The upstream header names for the claim values."
+            }
+          },
+          {
+            "upstream_access_token_header": {
+              "default": "authorization:bearer",
+              "type": "string",
+              "required": false,
+              "description": "The upstream access token header."
+            }
+          },
+          {
+            "upstream_access_token_jwk_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream access token JWK header."
+            }
+          },
+          {
+            "upstream_id_token_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream id token header."
+            }
+          },
+          {
+            "upstream_id_token_jwk_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream id token JWK header."
+            }
+          },
+          {
+            "upstream_refresh_token_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream refresh token header."
+            }
+          },
+          {
+            "upstream_user_info_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream user info header."
+            }
+          },
+          {
+            "upstream_user_info_jwt_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream user info JWT header (in case the user info returns a JWT response)."
+            }
+          },
+          {
+            "upstream_introspection_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream introspection header."
+            }
+          },
+          {
+            "upstream_introspection_jwt_header": {
+              "required": false,
+              "type": "string"
+            }
+          },
+          {
+            "upstream_session_id_header": {
+              "type": "string",
+              "required": false,
+              "description": "The upstream session id header."
+            }
+          },
+          {
+            "downstream_headers_claims": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The downstream header claims."
+            }
+          },
+          {
+            "downstream_headers_names": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The downstream header names for the claim values."
+            }
+          },
+          {
+            "downstream_access_token_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream access token header."
+            }
+          },
+          {
+            "downstream_access_token_jwk_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream access token JWK header."
+            }
+          },
+          {
+            "downstream_id_token_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream id token header."
+            }
+          },
+          {
+            "downstream_id_token_jwk_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream id token JWK header."
+            }
+          },
+          {
+            "downstream_refresh_token_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream refresh token header."
+            }
+          },
+          {
+            "downstream_user_info_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream user info header."
+            }
+          },
+          {
+            "downstream_user_info_jwt_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream user info JWT header (in case the user info returns a JWT response)."
+            }
+          },
+          {
+            "downstream_introspection_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream introspection header."
+            }
+          },
+          {
+            "downstream_introspection_jwt_header": {
+              "required": false,
+              "type": "string"
+            }
+          },
+          {
+            "downstream_session_id_header": {
+              "type": "string",
+              "required": false,
+              "description": "The downstream session id header."
+            }
+          },
+          {
+            "login_methods": {
+              "required": false,
+              "default": [
+                "authorization_code"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "bearer",
+                  "introspection",
+                  "userinfo",
+                  "kong_oauth2",
+                  "refresh_token",
+                  "session"
+                ]
+              },
+              "description": "Enable login functionality with specified grants."
+            }
+          },
+          {
+            "login_action": {
+              "required": false,
+              "default": "upstream",
+              "type": "string",
+              "one_of": [
+                "upstream",
+                "response",
+                "redirect"
+              ],
+              "description": "What to do after successful login: - `upstream`: proxy request to upstream service - `response`: terminate request with a response - `redirect`: redirect to a different location"
+            }
+          },
+          {
+            "login_tokens": {
+              "required": false,
+              "default": [
+                "id_token"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id_token",
+                  "access_token",
+                  "refresh_token",
+                  "tokens",
+                  "introspection"
+                ]
+              },
+              "description": "What tokens to include in `response` body or `redirect` query string or fragment: - `id_token`: include id token - `access_token`: include access token - `refresh_token`: include refresh token - `tokens`: include the full token endpoint response - `introspection`: include introspection response"
+            }
+          },
+          {
+            "login_redirect_mode": {
+              "required": false,
+              "default": "fragment",
+              "type": "string",
+              "one_of": [
+                "query",
+                "fragment"
+              ],
+              "description": "Where to place `login_tokens` when using `redirect` `login_action`: - `query`: place tokens in query string - `fragment`: place tokens in url fragment (not readable by servers)"
+            }
+          },
+          {
+            "logout_query_arg": {
+              "type": "string",
+              "required": false,
+              "description": "The request query argument that activates the logout."
+            }
+          },
+          {
+            "logout_post_arg": {
+              "type": "string",
+              "required": false,
+              "description": "The request body argument that activates the logout."
+            }
+          },
+          {
+            "logout_uri_suffix": {
+              "type": "string",
+              "required": false,
+              "description": "The request URI suffix that activates the logout."
+            }
+          },
+          {
+            "logout_methods": {
+              "required": false,
+              "default": [
+                "POST",
+                "DELETE"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "POST",
+                  "GET",
+                  "DELETE"
+                ]
+              },
+              "description": "The request methods that can activate the logout: - `POST`: HTTP POST method - `GET`: HTTP GET method - `DELETE`: HTTP DELETE method"
+            }
+          },
+          {
+            "logout_revoke": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Revoke tokens as part of the logout."
+            }
+          },
+          {
+            "logout_revoke_access_token": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Revoke the access token as part of the logout."
+            }
+          },
+          {
+            "logout_revoke_refresh_token": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Revoke the refresh token as part of the logout."
+            }
+          },
+          {
+            "consumer_claim": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim used for consumer mapping."
+            }
+          },
+          {
+            "consumer_by": {
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "username",
+                  "custom_id"
+                ]
+              },
+              "description": "Consumer fields used for mapping: - `id`: try to find the matching Consumer by `id` - `username`: try to find the matching Consumer by `username` - `custom_id`: try to find the matching Consumer by `custom_id`"
+            }
+          },
+          {
+            "consumer_optional": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Do not terminate the request if consumer mapping fails."
+            }
+          },
+          {
+            "credential_claim": {
+              "required": false,
+              "default": [
+                "sub"
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              },
+              "description": "The claim used to derive virtual credentials (e.g. to be consumed by the rate-limiting plugin), in case the consumer mapping is not used."
+            }
+          },
+          {
+            "anonymous": {
+              "type": "string",
+              "required": false,
+              "description": "An optional string (consumer UUID or username) value that functions as an “anonymous” consumer if authentication fails. If empty (default null), requests that fail authentication will return a `4xx` HTTP status code. This value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
+            }
+          },
+          {
+            "run_on_preflight": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Specifies whether to run this plugin on pre-flight (`OPTIONS`) requests."
+            }
+          },
+          {
+            "leeway": {
+              "default": 0,
+              "type": "number",
+              "required": false,
+              "description": "Allow some leeway (in seconds) on the ttl / expiry verification."
+            }
+          },
+          {
+            "verify_parameters": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify plugin configuration against discovery."
+            }
+          },
+          {
+            "verify_nonce": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify nonce on authorization code flow."
+            }
+          },
+          {
+            "verify_claims": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify tokens for standard claims."
+            }
+          },
+          {
+            "verify_signature": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify signature of tokens."
+            }
+          },
+          {
+            "ignore_signature": {
+              "required": false,
+              "default": [
+
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "refresh_token",
+                  "session",
+                  "introspection",
+                  "userinfo"
+                ]
+              },
+              "description": "Skip the token signature verification on certain grants: - `password`: OAuth password grant - `client_credentials`: OAuth client credentials grant - `authorization_code`: authorization code flow - `refresh_token`: OAuth refresh token grant - `session`: session cookie authentication - `introspection`: OAuth introspection - `userinfo`: OpenID Connect user info endpoint authentication"
+            }
+          },
+          {
+            "enable_hs_signatures": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Enable shared secret, for example, HS256, signatures (when disabled they will not be accepted)."
+            }
+          },
+          {
+            "disable_session": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "password",
+                  "client_credentials",
+                  "authorization_code",
+                  "bearer",
+                  "introspection",
+                  "userinfo",
+                  "kong_oauth2",
+                  "refresh_token",
+                  "session"
+                ]
+              },
+              "description": "Disable issuing the session cookie with the specified grants."
+            }
+          },
+          {
+            "cache_ttl": {
+              "default": 3600,
+              "type": "number",
+              "required": false,
+              "description": "The default cache ttl in seconds that is used in case the cached object does not specify the expiry."
+            }
+          },
+          {
+            "cache_ttl_max": {
+              "type": "number",
+              "required": false,
+              "description": "The maximum cache ttl in seconds (enforced)."
+            }
+          },
+          {
+            "cache_ttl_min": {
+              "type": "number",
+              "required": false,
+              "description": "The minimum cache ttl in seconds (enforced)."
+            }
+          },
+          {
+            "cache_ttl_neg": {
+              "type": "number",
+              "required": false,
+              "description": "The negative cache ttl in seconds."
+            }
+          },
+          {
+            "cache_ttl_resurrect": {
+              "type": "number",
+              "required": false,
+              "description": "The resurrection ttl in seconds."
+            }
+          },
+          {
+            "cache_tokens": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Cache the token endpoint requests."
+            }
+          },
+          {
+            "cache_tokens_salt": {
+              "auto": true,
+              "type": "string",
+              "required": false,
+              "description": "Salt used for generating the cache key that is used for caching the token endpoint requests."
+            }
+          },
+          {
+            "cache_introspection": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Cache the introspection endpoint requests."
+            }
+          },
+          {
+            "cache_token_exchange": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Cache the token exchange endpoint requests."
+            }
+          },
+          {
+            "cache_user_info": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Cache the user info requests."
+            }
+          },
+          {
+            "search_user_info": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Specify whether to use the user info endpoint to get additional claims for consumer mapping, credential mapping, authenticated groups, and upstream and downstream headers."
+            }
+          },
+          {
+            "hide_credentials": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Remove the credentials used for authentication from the request. If multiple credentials are sent with the same request, the plugin will remove those that were used for successful authentication."
+            }
+          },
+          {
+            "http_version": {
+              "default": 1.1,
+              "type": "number",
+              "required": false,
+              "description": "The HTTP version used for the requests by this plugin: - `1.1`: HTTP 1.1 (the default) - `1.0`: HTTP 1.0"
+            }
+          },
+          {
+            "http_proxy": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "http_proxy_authorization": {
+              "type": "string",
+              "required": false,
+              "description": "The HTTP proxy authorization."
+            }
+          },
+          {
+            "https_proxy": {
+              "type": "string",
+              "required": false,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "https_proxy_authorization": {
+              "type": "string",
+              "required": false,
+              "description": "The HTTPS proxy authorization."
+            }
+          },
+          {
+            "no_proxy": {
+              "type": "string",
+              "required": false,
+              "description": "Do not use proxy with these hosts."
+            }
+          },
+          {
+            "keepalive": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Use keepalive with the HTTP client."
+            }
+          },
+          {
+            "ssl_verify": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify identity provider server certificate."
+            }
+          },
+          {
+            "timeout": {
+              "default": 10000,
+              "type": "number",
+              "required": false,
+              "description": "Network IO timeout in milliseconds."
+            }
+          },
+          {
+            "display_errors": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Display errors on failure responses."
+            }
+          },
+          {
+            "by_username_ignore_case": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "If `consumer_by` is set to `username`, specify whether `username` can match consumers case-insensitively."
+            }
+          },
+          {
+            "resolve_distributed_claims": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Distributed claims are represented by the `_claim_names` and `_claim_sources` members of the JSON object containing the claims. If this parameter is set to `true`, the plugin explicitly resolves these distributed claims."
+            }
+          },
+          {
+            "expose_error_code": {
+              "default": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "token_cache_key_include_scope": {
+              "default": false,
+              "type": "boolean",
+              "description": "Include the scope in the token cache key, so token with different scopes are considered diffrent tokens."
+            }
+          }
+        ]
       }
     }
   ],

--- a/schemas/opentelemetry/3.4.x.json
+++ b/schemas/opentelemetry/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,15 +18,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -35,72 +35,74 @@
         "fields": [
           {
             "endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "referenceable": true,
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "headers": {
-              "type": "map",
               "description": "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend.",
-              "values": {
-                "type": "string",
-                "referenceable": true
-              },
+              "type": "map",
               "keys": {
-                "type": "string",
-                "description": "A string representing an HTTP header name."
+                "description": "A string representing an HTTP header name.",
+                "type": "string"
+              },
+              "values": {
+                "referenceable": true,
+                "type": "string"
               }
             }
           },
           {
             "resource_attributes": {
+              "keys": {
+                "required": true,
+                "type": "string"
+              },
               "type": "map",
               "values": {
-                "type": "string",
-                "required": true
-              },
-              "keys": {
-                "type": "string",
-                "required": true
+                "required": true,
+                "type": "string"
               }
             }
           },
           {
             "queue": {
+              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
                     "default": 1,
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
                     "default": 1,
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "type": "number",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
                     "default": 10000,
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
@@ -112,26 +114,26 @@
                 {
                   "max_retry_time": {
                     "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
-                    "type": "number"
+                    "type": "number",
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "type": "number",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
@@ -139,7 +141,6 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
@@ -158,8 +159,8 @@
           {
             "connect_timeout": {
               "default": 1000,
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
@@ -169,8 +170,8 @@
           {
             "send_timeout": {
               "default": 5000,
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
@@ -180,8 +181,8 @@
           {
             "read_timeout": {
               "default": 5000,
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
@@ -197,6 +198,7 @@
             "header_type": {
               "default": "preserve",
               "type": "string",
+              "required": false,
               "one_of": [
                 "preserve",
                 "ignore",
@@ -206,13 +208,12 @@
                 "jaeger",
                 "ot",
                 "aws"
-              ],
-              "required": false
+              ]
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "custom_entity_check": {

--- a/schemas/post-function/3.4.x.json
+++ b/schemas/post-function/3.4.x.json
@@ -10,8 +10,8 @@
           "ws",
           "wss"
         ],
-        "required": false,
         "type": "set",
+        "required": false,
         "elements": {
           "type": "string",
           "one_of": [
@@ -28,9 +28,17 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "eq": null,
+        "type": "foreign",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -42,10 +50,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -58,23 +64,26 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "certificate": {
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -83,11 +92,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -96,11 +105,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -109,11 +118,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -122,11 +131,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -135,11 +144,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -148,11 +157,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -161,11 +170,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -174,11 +183,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -187,16 +196,15 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/pre-function/3.4.x.json
+++ b/schemas/pre-function/3.4.x.json
@@ -10,8 +10,8 @@
           "ws",
           "wss"
         ],
-        "required": false,
         "type": "set",
+        "required": false,
         "elements": {
           "type": "string",
           "one_of": [
@@ -28,9 +28,17 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "eq": null,
+        "type": "foreign",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -42,10 +50,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -58,23 +64,26 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "certificate": {
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -83,11 +92,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -96,11 +105,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -109,11 +118,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -122,11 +131,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -135,11 +144,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -148,11 +157,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -161,11 +170,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -174,11 +183,11 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           },
@@ -187,16 +196,15 @@
               "default": [
 
               ],
-              "required": true,
               "type": "array",
+              "required": true,
               "elements": {
-                "type": "string",
-                "required": false
+                "required": false,
+                "type": "string"
               }
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/prometheus/3.4.x.json
+++ b/schemas/prometheus/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,59 +23,61 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
+        "required": true,
         "fields": [
           {
             "per_consumer": {
               "default": false,
-              "description": "A boolean value that determines if per-consumer metrics should be collected. If enabled, the `kong_http_requests_total` and `kong_bandwidth_bytes` metrics fill in the consumer label when available.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that determines if per-consumer metrics should be collected. If enabled, the `kong_http_requests_total` and `kong_bandwidth_bytes` metrics fill in the consumer label when available."
             }
           },
           {
             "status_code_metrics": {
               "default": false,
-              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `http_requests_total`, `stream_sessions_total` metrics will be exported.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `http_requests_total`, `stream_sessions_total` metrics will be exported."
             }
           },
           {
             "latency_metrics": {
               "default": false,
-              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `kong_latency_ms`, `upstream_latency_ms` and `request_latency_ms` metrics will be exported.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `kong_latency_ms`, `upstream_latency_ms` and `request_latency_ms` metrics will be exported."
             }
           },
           {
             "bandwidth_metrics": {
               "default": false,
-              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `bandwidth_bytes` and `stream_sessions_total` metrics will be exported.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `bandwidth_bytes` and `stream_sessions_total` metrics will be exported."
             }
           },
           {
             "upstream_health_metrics": {
               "default": false,
-              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `upstream_target_health` metric will be exported.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that determines if status code metrics should be collected. If enabled, `upstream_target_health` metric will be exported."
             }
           }
-        ],
-        "type": "record",
-        "required": true
+        ]
       }
     }
   ],

--- a/schemas/proxy-cache-advanced/3.4.x.json
+++ b/schemas/proxy-cache-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,30 +18,31 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "response_code": {
-              "len_min": 1,
               "required": true,
+              "len_min": 1,
               "default": [
                 200,
                 301,
                 404
               ],
-              "description": "Upstream response status code considered cacheable. The integers must be a value between 100 and 900.",
               "type": "array",
               "elements": {
                 "type": "integer",
@@ -50,7 +50,8 @@
                   100,
                   900
                 ]
-              }
+              },
+              "description": "Upstream response status code considered cacheable. The integers must be a value between 100 and 900."
             }
           },
           {
@@ -60,7 +61,6 @@
                 "GET",
                 "HEAD"
               ],
-              "description": "Downstream request methods considered cacheable. Available options: `HEAD`, `GET`, `POST`, `PATCH`, `PUT`.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -71,7 +71,8 @@
                   "PATCH",
                   "PUT"
                 ]
-              }
+              },
+              "description": "Downstream request methods considered cacheable. Available options: `HEAD`, `GET`, `POST`, `PATCH`, `PUT`."
             }
           },
           {
@@ -81,46 +82,46 @@
                 "text/plain",
                 "application/json"
               ],
-              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned."
             }
           },
           {
             "cache_ttl": {
               "default": 300,
-              "gt": 0,
               "type": "integer",
+              "gt": 0,
               "description": "TTL in seconds of cache entities."
             }
           },
           {
             "strategy": {
-              "type": "string",
-              "description": "The backing data store in which to hold cache entities. Accepted values are: `memory` and `redis`.",
               "one_of": [
                 "memory",
                 "redis"
               ],
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "The backing data store in which to hold cache entities. Accepted values are: `memory` and `redis`."
             }
           },
           {
             "cache_control": {
               "default": false,
-              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234."
             }
           },
           {
             "ignore_uri_case": {
               "default": false,
-              "description": "Determines whether to treat URIs as case sensitive. By default, case sensitivity is enabled. If set to true, requests are cached while ignoring case sensitivity in the URI.",
               "type": "boolean",
-              "required": false
+              "required": false,
+              "description": "Determines whether to treat URIs as case sensitive. By default, case sensitivity is enabled. If set to true, requests are cached while ignoring case sensitivity in the URI."
             }
           },
           {
@@ -131,36 +132,36 @@
           },
           {
             "memory": {
+              "type": "record",
               "fields": [
                 {
                   "dictionary_name": {
                     "default": "kong_db_cache",
-                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template."
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "vary_query_params": {
-              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration."
             }
           },
           {
             "vary_headers": {
-              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration."
             }
           },
           {
@@ -168,25 +169,25 @@
               "fields": [
                 {
                   "host": {
-                    "type": "string",
-                    "description": "A string representing a host name, such as example.com."
+                    "description": "A string representing a host name, such as example.com.",
+                    "type": "string"
                   }
                 },
                 {
                   "port": {
+                    "type": "integer",
                     "between": [
                       0,
                       65535
                     ],
-                    "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                    "type": "integer"
+                    "description": "An integer representing a port number between 0 and 65535, inclusive."
                   }
                 },
                 {
                   "timeout": {
                     "default": 2000,
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "type": "integer",
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "between": [
                       0,
                       2147483646
@@ -195,70 +196,76 @@
                 },
                 {
                   "connect_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "send_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "read_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "username": {
                     "type": "string",
-                    "referenceable": true
+                    "referenceable": true,
+                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
+                    "referenceable": true,
                     "type": "string",
-                    "referenceable": true
+                    "encrypted": true,
+                    "description": "Password to use for Redis connections. If undefined, no AUTH commands are sent to Redis."
                   }
                 },
                 {
                   "sentinel_username": {
                     "type": "string",
-                    "referenceable": true
+                    "referenceable": true,
+                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+."
                   }
                 },
                 {
                   "sentinel_password": {
-                    "encrypted": true,
+                    "referenceable": true,
                     "type": "string",
-                    "referenceable": true
+                    "encrypted": true,
+                    "description": "Sentinel password to authenticate with a Redis Sentinel instance. If undefined, no AUTH commands are sent to Redis Sentinels."
                   }
                 },
                 {
                   "database": {
+                    "default": 0,
                     "type": "integer",
-                    "default": 0
+                    "description": "Database to use for the Redis connection when using the `redis` strategy"
                   }
                 },
                 {
                   "keepalive_pool_size": {
                     "default": 30,
                     "type": "integer",
+                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value.",
                     "between": [
                       1,
                       2147483646
@@ -268,6 +275,7 @@
                 {
                   "keepalive_backlog": {
                     "type": "integer",
+                    "description": "Limits the total number of opened connections for a pool. If the connection pool is full, all connection queues beyond the maximum limit go into the backlog queue. If the backlog queue is full, subsequent connect operations fail and return `nil`. Queued connect operations resume once the number of connections in the pool is less than `keepalive_pool_size`. Note that queued connect operations are subject to set timeouts.",
                     "between": [
                       0,
                       2147483646
@@ -276,61 +284,67 @@
                 },
                 {
                   "sentinel_master": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_role": {
-                    "type": "string",
                     "one_of": [
                       "master",
                       "slave",
                       "any"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_addresses": {
-                    "len_min": 1,
+                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "type": "array",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "len_min": 1
                   }
                 },
                 {
                   "cluster_addresses": {
-                    "len_min": 1,
+                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "type": "array",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "len_min": 1
                   }
                 },
                 {
                   "ssl": {
                     "default": false,
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "If set to true, uses SSL to connect to Redis."
                   }
                 },
                 {
                   "ssl_verify": {
                     "default": false,
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "If set to true, verifies the validity of the server SSL certificate. If setting this parameter, also configure `lua_ssl_trusted_certificate` in `kong.conf` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly."
                   }
                 },
                 {
                   "server_name": {
-                    "description": "A string representing an SNI (server name indication) value for TLS.",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "description": "A string representing an SNI (server name indication) value for TLS."
                   }
                 }
               ],
-              "required": true,
               "type": "record",
+              "required": true,
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -394,12 +408,11 @@
           {
             "bypass_on_err": {
               "default": false,
-              "description": "Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/proxy-cache/3.4.x.json
+++ b/schemas/proxy-cache/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,23 +23,33 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "eq": null,
+        "type": "foreign",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "response_code": {
-              "len_min": 1,
               "required": true,
+              "len_min": 1,
               "default": [
                 200,
                 301,
                 404
               ],
-              "description": "Upstream response status code considered cacheable.",
               "type": "array",
               "elements": {
                 "type": "integer",
@@ -49,7 +57,8 @@
                   100,
                   900
                 ]
-              }
+              },
+              "description": "Upstream response status code considered cacheable."
             }
           },
           {
@@ -59,7 +68,6 @@
                 "GET",
                 "HEAD"
               ],
-              "description": "Downstream request methods considered cacheable.",
               "type": "array",
               "elements": {
                 "type": "string",
@@ -70,7 +78,8 @@
                   "PATCH",
                   "PUT"
                 ]
-              }
+              },
+              "description": "Downstream request methods considered cacheable."
             }
           },
           {
@@ -80,37 +89,37 @@
                 "text/plain",
                 "application/json"
               ],
-              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value."
             }
           },
           {
             "cache_ttl": {
               "default": 300,
-              "description": "TTL, in seconds, of cache entities.",
               "type": "integer",
-              "gt": 0
+              "gt": 0,
+              "description": "TTL, in seconds, of cache entities."
             }
           },
           {
             "strategy": {
-              "type": "string",
-              "description": "The backing data store in which to hold cache entities.",
               "one_of": [
                 "memory"
               ],
-              "required": true
+              "type": "string",
+              "required": true,
+              "description": "The backing data store in which to hold cache entities."
             }
           },
           {
             "cache_control": {
               "default": false,
-              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234."
             }
           },
           {
@@ -128,40 +137,39 @@
           },
           {
             "memory": {
+              "type": "record",
               "fields": [
                 {
                   "dictionary_name": {
                     "default": "kong_db_cache",
-                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
                     "type": "string",
-                    "required": true
+                    "required": true,
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template."
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "vary_query_params": {
-              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration."
             }
           },
           {
             "vary_headers": {
-              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/rate-limiting-advanced/3.4.x.json
+++ b/schemas/rate-limiting-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,17 +18,18 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "identifier": {
               "required": true,
               "default": "consumer",
-              "description": "The type of identifier used to generate the rate limit key. Defines the scope used to increment the rate limiting counters. Can be `ip`, `credential`, `consumer`, `service`, `header`, or `path`.",
               "type": "string",
               "one_of": [
                 "ip",
@@ -38,38 +38,39 @@
                 "service",
                 "header",
                 "path"
-              ]
+              ],
+              "description": "The type of identifier used to generate the rate limit key. Defines the scope used to increment the rate limiting counters. Can be `ip`, `credential`, `consumer`, `service`, `header`, or `path`."
             }
           },
           {
             "window_size": {
               "required": true,
-              "description": "One or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.",
               "type": "array",
               "elements": {
                 "type": "number"
-              }
+              },
+              "description": "One or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified."
             }
           },
           {
             "window_type": {
               "default": "sliding",
-              "description": "Sets the time window type to either `sliding` (default) or `fixed`. Sliding windows apply the rate limiting logic while taking into account previous hit rates (from the window that immediately precedes the current) using a dynamic weight. Fixed windows consist of buckets that are statically assigned to a definitive time range, each request is mapped to only one fixed window based on its timestamp and will affect only that window's counters.",
               "type": "string",
               "one_of": [
                 "fixed",
                 "sliding"
-              ]
+              ],
+              "description": "Sets the time window type to either `sliding` (default) or `fixed`. Sliding windows apply the rate limiting logic while taking into account previous hit rates (from the window that immediately precedes the current) using a dynamic weight. Fixed windows consist of buckets that are statically assigned to a definitive time range, each request is mapped to only one fixed window based on its timestamp and will affect only that window's counters."
             }
           },
           {
             "limit": {
               "required": true,
-              "description": "One or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.",
               "type": "array",
               "elements": {
                 "type": "number"
-              }
+              },
+              "description": "One or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified."
             }
           },
           {
@@ -81,63 +82,63 @@
           {
             "namespace": {
               "auto": true,
-              "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace."
             }
           },
           {
             "strategy": {
               "required": true,
               "default": "local",
-              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits. Available values are: `local` and `cluster`.",
               "type": "string",
               "one_of": [
                 "cluster",
                 "redis",
                 "local"
-              ]
+              ],
+              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits. Available values are: `local` and `cluster`."
             }
           },
           {
             "dictionary_name": {
               "default": "kong_rate_limiting_counters",
-              "description": "The shared dictionary where counters are stored. When the plugin is configured to synchronize counter data externally (that is `config.strategy` is `cluster` or `redis` and `config.sync_rate` isn't `-1`), this dictionary serves as a buffer to populate counters in the data store on each synchronization cycle.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The shared dictionary where counters are stored. When the plugin is configured to synchronize counter data externally (that is `config.strategy` is `cluster` or `redis` and `config.sync_rate` isn't `-1`), this dictionary serves as a buffer to populate counters in the data store on each synchronization cycle."
             }
           },
           {
             "hide_client_headers": {
               "default": false,
-              "description": "Optionally hide informative response headers that would otherwise provide information about the current status of limits and counters.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Optionally hide informative response headers that would otherwise provide information about the current status of limits and counters."
             }
           },
           {
             "retry_after_jitter_max": {
               "default": 0,
-              "description": "The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header.",
-              "type": "number"
+              "type": "number",
+              "description": "The upper bound of a jitter (random delay) in seconds to be added to the `Retry-After` header of denied requests (status = `429`) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is `0`; in this case, the `Retry-After` header is equal to the `RateLimit-Reset` header."
             }
           },
           {
             "header_name": {
-              "type": "string",
-              "description": "A string representing an HTTP header name."
+              "description": "A string representing an HTTP header name.",
+              "type": "string"
             }
           },
           {
             "path": {
               "starts_with": "/",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "type": "string",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
-              ]
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
@@ -145,25 +146,25 @@
               "fields": [
                 {
                   "host": {
-                    "type": "string",
-                    "description": "A string representing a host name, such as example.com."
+                    "description": "A string representing a host name, such as example.com.",
+                    "type": "string"
                   }
                 },
                 {
                   "port": {
+                    "type": "integer",
                     "between": [
                       0,
                       65535
                     ],
-                    "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                    "type": "integer"
+                    "description": "An integer representing a port number between 0 and 65535, inclusive."
                   }
                 },
                 {
                   "timeout": {
                     "default": 2000,
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "type": "integer",
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "between": [
                       0,
                       2147483646
@@ -172,70 +173,76 @@
                 },
                 {
                   "connect_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "send_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "read_timeout": {
+                    "type": "integer",
                     "between": [
                       0,
                       2147483646
                     ],
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-                    "type": "integer"
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
                   "username": {
                     "type": "string",
-                    "referenceable": true
+                    "referenceable": true,
+                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
+                    "referenceable": true,
                     "type": "string",
-                    "referenceable": true
+                    "encrypted": true,
+                    "description": "Password to use for Redis connections. If undefined, no AUTH commands are sent to Redis."
                   }
                 },
                 {
                   "sentinel_username": {
                     "type": "string",
-                    "referenceable": true
+                    "referenceable": true,
+                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+."
                   }
                 },
                 {
                   "sentinel_password": {
-                    "encrypted": true,
+                    "referenceable": true,
                     "type": "string",
-                    "referenceable": true
+                    "encrypted": true,
+                    "description": "Sentinel password to authenticate with a Redis Sentinel instance. If undefined, no AUTH commands are sent to Redis Sentinels."
                   }
                 },
                 {
                   "database": {
+                    "default": 0,
                     "type": "integer",
-                    "default": 0
+                    "description": "Database to use for the Redis connection when using the `redis` strategy"
                   }
                 },
                 {
                   "keepalive_pool_size": {
                     "default": 30,
                     "type": "integer",
+                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value.",
                     "between": [
                       1,
                       2147483646
@@ -245,6 +252,7 @@
                 {
                   "keepalive_backlog": {
                     "type": "integer",
+                    "description": "Limits the total number of opened connections for a pool. If the connection pool is full, all connection queues beyond the maximum limit go into the backlog queue. If the backlog queue is full, subsequent connect operations fail and return `nil`. Queued connect operations resume once the number of connections in the pool is less than `keepalive_pool_size`. Note that queued connect operations are subject to set timeouts.",
                     "between": [
                       0,
                       2147483646
@@ -253,61 +261,67 @@
                 },
                 {
                   "sentinel_master": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_role": {
-                    "type": "string",
                     "one_of": [
                       "master",
                       "slave",
                       "any"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_addresses": {
-                    "len_min": 1,
+                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "type": "array",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "len_min": 1
                   }
                 },
                 {
                   "cluster_addresses": {
-                    "len_min": 1,
+                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "type": "array",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "len_min": 1
                   }
                 },
                 {
                   "ssl": {
                     "default": false,
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "If set to true, uses SSL to connect to Redis."
                   }
                 },
                 {
                   "ssl_verify": {
                     "default": false,
                     "type": "boolean",
-                    "required": false
+                    "required": false,
+                    "description": "If set to true, verifies the validity of the server SSL certificate. If setting this parameter, also configure `lua_ssl_trusted_certificate` in `kong.conf` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly."
                   }
                 },
                 {
                   "server_name": {
-                    "description": "A string representing an SNI (server name indication) value for TLS.",
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "description": "A string representing an SNI (server name indication) value for TLS."
                   }
                 }
               ],
-              "required": true,
               "type": "record",
+              "required": true,
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -371,43 +385,42 @@
           {
             "enforce_consumer_groups": {
               "default": false,
-              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`. Flipping `enforce_consumer_groups` from `true` to `false` disables the group override, but does not clear the list of consumer groups. You can then flip `enforce_consumer_groups` to `true` to re-enforce the groups.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`. Flipping `enforce_consumer_groups` from `true` to `false` disables the group override, but does not clear the list of consumer groups. You can then flip `enforce_consumer_groups` to `true` to re-enforce the groups."
             }
           },
           {
             "consumer_groups": {
-              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`. Flipping `enforce_consumer_groups` from `true` to `false` disables the group override, but does not clear the list of consumer groups. You can then flip `enforce_consumer_groups` to `true` to re-enforce the groups.",
               "type": "array",
               "elements": {
                 "type": "string"
-              }
+              },
+              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`. Flipping `enforce_consumer_groups` from `true` to `false` disables the group override, but does not clear the list of consumer groups. You can then flip `enforce_consumer_groups` to `true` to re-enforce the groups."
             }
           },
           {
             "disable_penalty": {
               "default": false,
-              "description": "If set to `true`, this doesn't count denied requests (status = `429`). If set to `false`, all requests, including denied ones, are counted. This parameter only affects the `sliding` window_type.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If set to `true`, this doesn't count denied requests (status = `429`). If set to `false`, all requests, including denied ones, are counted. This parameter only affects the `sliding` window_type."
             }
           },
           {
             "error_code": {
               "default": 429,
-              "description": "Set a custom error code to return when the rate limit is exceeded.",
               "type": "number",
-              "gt": 0
+              "gt": 0,
+              "description": "Set a custom error code to return when the rate limit is exceeded."
             }
           },
           {
             "error_message": {
               "default": "API rate limit exceeded",
-              "description": "Set a custom error message to return when the rate limit is exceeded.",
-              "type": "string"
+              "type": "string",
+              "description": "Set a custom error message to return when the rate limit is exceeded."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/rate-limiting/3.4.x.json
+++ b/schemas/rate-limiting/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,19 +18,22 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
+        "required": true,
         "fields": [
           {
             "second": {
@@ -78,7 +80,6 @@
           {
             "limit_by": {
               "default": "consumer",
-              "description": "The entity that is used when aggregating the limits.",
               "type": "string",
               "one_of": [
                 "consumer",
@@ -87,60 +88,61 @@
                 "service",
                 "header",
                 "path"
-              ]
+              ],
+              "description": "The entity that is used when aggregating the limits."
             }
           },
           {
             "header_name": {
-              "type": "string",
-              "description": "A string representing an HTTP header name."
+              "description": "A string representing an HTTP header name.",
+              "type": "string"
             }
           },
           {
             "path": {
               "starts_with": "/",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "type": "string",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
-              ]
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "policy": {
-              "default": "local",
               "len_min": 0,
-              "description": "The rate-limiting policies to use for retrieving and incrementing the limits.",
+              "default": "local",
+              "type": "string",
               "one_of": [
                 "local",
                 "cluster",
                 "redis"
               ],
-              "type": "string"
+              "description": "The rate-limiting policies to use for retrieving and incrementing the limits."
             }
           },
           {
             "fault_tolerant": {
               "default": true,
-              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party data store. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the data store is working again. If `false`, then the clients will see `500` errors.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party data store. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the data store is working again. If `false`, then the clients will see `500` errors."
             }
           },
           {
             "redis_host": {
-              "type": "string",
-              "description": "A string representing a host name, such as example.com."
+              "description": "A string representing a host name, such as example.com.",
+              "type": "string"
             }
           },
           {
             "redis_port": {
               "default": 6379,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
@@ -149,89 +151,87 @@
           },
           {
             "redis_password": {
-              "len_min": 0,
-              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
+              "referenceable": true,
               "type": "string",
-              "referenceable": true
+              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
+              "len_min": 0
             }
           },
           {
             "redis_username": {
-              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.",
               "type": "string",
-              "referenceable": true
+              "referenceable": true,
+              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired."
             }
           },
           {
             "redis_ssl": {
               "default": false,
-              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server."
             }
           },
           {
             "redis_ssl_verify": {
               "default": false,
-              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly."
             }
           },
           {
             "redis_server_name": {
-              "type": "string",
-              "description": "A string representing an SNI (server name indication) value for TLS."
+              "description": "A string representing an SNI (server name indication) value for TLS.",
+              "type": "string"
             }
           },
           {
             "redis_timeout": {
               "default": 2000,
-              "description": "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.",
-              "type": "number"
+              "type": "number",
+              "description": "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server."
             }
           },
           {
             "redis_database": {
               "default": 0,
-              "description": "When using the `redis` policy, this property specifies the Redis database to use.",
-              "type": "integer"
+              "type": "integer",
+              "description": "When using the `redis` policy, this property specifies the Redis database to use."
             }
           },
           {
             "hide_client_headers": {
               "default": false,
-              "description": "Optionally hide informative response headers.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Optionally hide informative response headers."
             }
           },
           {
             "error_code": {
               "default": 429,
-              "gt": 0,
               "type": "number",
+              "gt": 0,
               "description": "Set a custom error code to return when the rate limit is exceeded."
             }
           },
           {
             "error_message": {
               "default": "API rate limit exceeded",
-              "description": "Set a custom error message to return when the rate limit is exceeded.",
-              "type": "string"
+              "type": "string",
+              "description": "Set a custom error message to return when the rate limit is exceeded."
             }
           },
           {
             "sync_rate": {
               "default": -1,
-              "description": "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior.",
               "type": "number",
-              "required": true
+              "required": true,
+              "description": "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior."
             }
           }
-        ],
-        "type": "record",
-        "required": true
+        ]
       }
     }
   ],
@@ -248,23 +248,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.policy",
+        "if_match": {
+          "eq": "redis"
+        },
         "then_field": "config.redis_host",
-        "if_match": {
-          "eq": "redis"
-        },
-        "then_match": {
-          "required": true
-        }
-      }
-    },
-    {
-      "conditional": {
         "if_field": "config.policy",
-        "then_field": "config.redis_port",
-        "if_match": {
-          "eq": "redis"
-        },
         "then_match": {
           "required": true
         }
@@ -272,11 +260,23 @@
     },
     {
       "conditional": {
-        "if_field": "config.limit_by",
-        "then_field": "config.header_name",
+        "if_match": {
+          "eq": "redis"
+        },
+        "then_field": "config.redis_port",
+        "if_field": "config.policy",
+        "then_match": {
+          "required": true
+        }
+      }
+    },
+    {
+      "conditional": {
         "if_match": {
           "eq": "header"
         },
+        "then_field": "config.header_name",
+        "if_field": "config.limit_by",
         "then_match": {
           "required": true
         }
@@ -284,11 +284,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.limit_by",
-        "then_field": "config.path",
         "if_match": {
           "eq": "path"
         },
+        "then_field": "config.path",
+        "if_field": "config.limit_by",
         "then_match": {
           "required": true
         }
@@ -296,11 +296,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.policy",
-        "then_field": "config.redis_timeout",
         "if_match": {
           "eq": "redis"
         },
+        "then_field": "config.redis_timeout",
+        "if_field": "config.policy",
         "then_match": {
           "required": true
         }

--- a/schemas/request-size-limiting/3.4.x.json
+++ b/schemas/request-size-limiting/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,42 +18,51 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
+      }
+    },
+    {
+      "consumer_group": {
+        "reference": "consumer_groups",
+        "eq": null,
+        "type": "foreign",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "allowed_payload_size": {
               "default": 128,
-              "description": "Allowed request payload size in megabytes. Default is `128` megabytes (128000000 bytes).",
-              "type": "integer"
+              "type": "integer",
+              "description": "Allowed request payload size in megabytes. Default is `128` megabytes (128000000 bytes)."
             }
           },
           {
             "size_unit": {
               "required": true,
               "default": "megabytes",
-              "description": "Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is not available in versions prior to Kong Gateway 1.3 and Kong Gateway (OSS) 2.0.",
               "type": "string",
               "one_of": [
                 "megabytes",
                 "kilobytes",
                 "bytes"
-              ]
+              ],
+              "description": "Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is not available in versions prior to Kong Gateway 1.3 and Kong Gateway (OSS) 2.0."
             }
           },
           {
             "require_content_length": {
               "default": false,
-              "description": "Set to `true` to ensure a valid `Content-Length` header exists before reading the request body.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Set to `true` to ensure a valid `Content-Length` header exists before reading the request body."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/request-termination/3.4.x.json
+++ b/schemas/request-termination/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,67 +18,68 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
+        "required": true,
         "fields": [
           {
             "status_code": {
               "required": true,
-              "default": 503,
-              "description": "The response code to send. Must be an integer between 100 and 599.",
-              "type": "integer",
               "between": [
                 100,
                 599
-              ]
+              ],
+              "default": 503,
+              "type": "integer",
+              "description": "The response code to send. Must be an integer between 100 and 599."
             }
           },
           {
             "message": {
-              "type": "string",
-              "description": "The message to send, if using the default response generator."
+              "description": "The message to send, if using the default response generator.",
+              "type": "string"
             }
           },
           {
             "content_type": {
-              "type": "string",
-              "description": "Content type of the raw response configured with `config.body`."
+              "description": "Content type of the raw response configured with `config.body`.",
+              "type": "string"
             }
           },
           {
             "body": {
-              "type": "string",
-              "description": "The raw response body to send. This is mutually exclusive with the `config.message` field."
+              "description": "The raw response body to send. This is mutually exclusive with the `config.message` field.",
+              "type": "string"
             }
           },
           {
             "echo": {
               "default": false,
-              "description": "When set, the plugin will echo a copy of the request back to the client. The main usecase for this is debugging. It can be combined with `trigger` in order to debug requests on live systems without disturbing real traffic.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When set, the plugin will echo a copy of the request back to the client. The main usecase for this is debugging. It can be combined with `trigger` in order to debug requests on live systems without disturbing real traffic."
             }
           },
           {
             "trigger": {
-              "type": "string",
-              "description": "A string representing an HTTP header name."
+              "description": "A string representing an HTTP header name.",
+              "type": "string"
             }
           }
-        ],
-        "type": "record",
-        "required": true
+        ]
       }
     }
   ],

--- a/schemas/request-transformer-advanced/3.4.x.json
+++ b/schemas/request-transformer-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,21 +18,25 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
+        "type": "record",
+        "required": true,
         "fields": [
           {
             "http_method": {
-              "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
               "type": "string",
-              "match": "^%u+$"
+              "match": "^%u+$",
+              "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters."
             }
           },
           {
             "remove": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -69,12 +72,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "rename": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -113,12 +116,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "replace": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -178,12 +181,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "add": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -238,12 +241,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "append": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -298,36 +301,33 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "allow": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
-                    "type": "set",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "set"
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "dots_in_keys": {
               "default": true,
-              "description": "Specify whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects.  See [Arrays and nested objects](#arrays-and-nested-objects).",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Specify whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects.  See [Arrays and nested objects](#arrays-and-nested-objects)."
             }
           }
-        ],
-        "type": "record",
-        "required": true
+        ]
       }
     }
   ],

--- a/schemas/request-transformer/3.4.x.json
+++ b/schemas/request-transformer/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,30 +23,34 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "http_method": {
-              "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
               "type": "string",
-              "match": "^%u+$"
+              "match": "^%u+$",
+              "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters."
             }
           },
           {
             "remove": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -59,8 +61,8 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -71,28 +73,28 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "rename": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -103,11 +105,11 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -116,28 +118,28 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "replace": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -148,11 +150,11 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -161,8 +163,8 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -174,20 +176,20 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "add": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -198,11 +200,11 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -211,28 +213,28 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "append": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -243,11 +245,11 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -256,20 +258,18 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/request-validator/3.4.x.json
+++ b/schemas/request-validator/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,15 +18,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -35,9 +35,9 @@
         "fields": [
           {
             "body_schema": {
-              "description": "The request body schema specification. One of `body_schema` or `parameter_schema` must be specified.",
               "type": "string",
-              "required": false
+              "required": false,
+              "description": "The request body schema specification. One of `body_schema` or `parameter_schema` must be specified."
             }
           },
           {
@@ -45,54 +45,54 @@
               "default": [
                 "application/json"
               ],
-              "description": "List of allowed content types. The value can be configured with the `charset` parameter. For example, `application/json; charset=UTF-8`.",
               "type": "set",
               "elements": {
-                "type": "string",
-                "required": true
-              }
+                "required": true,
+                "type": "string"
+              },
+              "description": "List of allowed content types. The value can be configured with the `charset` parameter. For example, `application/json; charset=UTF-8`."
             }
           },
           {
             "version": {
               "required": true,
               "default": "kong",
-              "description": "Which validator to use. Supported values are `kong` (default) for using Kong's own schema validator, or `draft4` for using a JSON Schema Draft 4-compliant validator.",
               "one_of": [
                 "kong",
                 "draft4"
               ],
-              "type": "string"
+              "type": "string",
+              "description": "Which validator to use. Supported values are `kong` (default) for using Kong's own schema validator, or `draft4` for using a JSON Schema Draft 4-compliant validator."
             }
           },
           {
             "parameter_schema": {
               "required": false,
-              "description": "Array of parameter validator specification. One of `body_schema` or `parameter_schema` must be specified.",
               "type": "array",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "in": {
                       "type": "string",
+                      "required": true,
                       "one_of": [
                         "query",
                         "header",
                         "path"
-                      ],
-                      "required": true
+                      ]
                     }
                   },
                   {
                     "name": {
-                      "type": "string",
-                      "required": true
+                      "required": true,
+                      "type": "string"
                     }
                   },
                   {
                     "required": {
-                      "type": "boolean",
-                      "required": true
+                      "required": true,
+                      "type": "boolean"
                     }
                   },
                   {
@@ -120,7 +120,6 @@
                     }
                   }
                 ],
-                "type": "record",
                 "entity_checks": [
                   {
                     "mutually_required": [
@@ -138,20 +137,21 @@
                     }
                   }
                 ]
-              }
+              },
+              "description": "Array of parameter validator specification. One of `body_schema` or `parameter_schema` must be specified."
             }
           },
           {
             "verbose_response": {
               "default": false,
-              "description": "If enabled, the plugin returns more verbose and detailed validation errors.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If enabled, the plugin returns more verbose and detailed validation errors."
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [

--- a/schemas/response-ratelimiting/3.4.x.json
+++ b/schemas/response-ratelimiting/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,70 +18,72 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "header_name": {
               "default": "x-kong-limit",
-              "description": "The name of the response header used to increment the counters.",
-              "type": "string"
+              "type": "string",
+              "description": "The name of the response header used to increment the counters."
             }
           },
           {
             "limit_by": {
               "default": "consumer",
-              "description": "The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.",
               "type": "string",
               "one_of": [
                 "consumer",
                 "credential",
                 "ip"
-              ]
+              ],
+              "description": "The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`."
             }
           },
           {
             "policy": {
               "default": "local",
-              "description": "The rate-limiting policies to use for retrieving and incrementing the limits.",
               "type": "string",
               "one_of": [
                 "local",
                 "cluster",
                 "redis"
-              ]
+              ],
+              "description": "The rate-limiting policies to use for retrieving and incrementing the limits."
             }
           },
           {
             "fault_tolerant": {
               "default": true,
-              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors."
             }
           },
           {
             "redis_host": {
-              "type": "string",
-              "description": "When using the `redis` policy, this property specifies the address to the Redis server."
+              "description": "When using the `redis` policy, this property specifies the address to the Redis server.",
+              "type": "string"
             }
           },
           {
             "redis_port": {
               "default": 6379,
-              "description": "When using the `redis` policy, this property specifies the port of the Redis server.",
               "type": "integer",
+              "description": "When using the `redis` policy, this property specifies the port of the Redis server.",
               "between": [
                 0,
                 65535
@@ -92,113 +93,119 @@
           {
             "redis_password": {
               "len_min": 0,
-              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
               "type": "string",
+              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
               "referenceable": true
             }
           },
           {
             "redis_username": {
-              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.\nThis requires Redis v6.0.0+. The username **cannot** be set to `default`.",
               "type": "string",
+              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.\nThis requires Redis v6.0.0+. The username **cannot** be set to `default`.",
               "referenceable": true
             }
           },
           {
             "redis_ssl": {
               "default": false,
-              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server."
             }
           },
           {
             "redis_ssl_verify": {
               "default": false,
-              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly."
             }
           },
           {
             "redis_server_name": {
-              "type": "string",
-              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI)."
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI).",
+              "type": "string"
             }
           },
           {
             "redis_timeout": {
               "default": 2000,
-              "description": "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server.",
-              "type": "number"
+              "type": "number",
+              "description": "When using the `redis` policy, this property specifies the timeout in milliseconds of any command submitted to the Redis server."
             }
           },
           {
             "redis_database": {
               "default": 0,
-              "description": "When using the `redis` policy, this property specifies Redis database to use.",
-              "type": "number"
+              "type": "number",
+              "description": "When using the `redis` policy, this property specifies Redis database to use."
             }
           },
           {
             "block_on_first_violation": {
               "default": false,
-              "description": "A boolean value that determines if the requests should be blocked as soon as one limit is being exceeded. This will block requests that are supposed to consume other limits too.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "A boolean value that determines if the requests should be blocked as soon as one limit is being exceeded. This will block requests that are supposed to consume other limits too."
             }
           },
           {
             "hide_client_headers": {
               "default": false,
-              "description": "Optionally hide informative response headers.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Optionally hide informative response headers."
             }
           },
           {
             "limits": {
+              "keys": {
+                "type": "string"
+              },
+              "required": true,
+              "len_min": 1,
+              "type": "map",
               "values": {
-                "required": true,
                 "fields": [
                   {
                     "second": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   },
                   {
                     "minute": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   },
                   {
                     "hour": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   },
                   {
                     "day": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   },
                   {
                     "month": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   },
                   {
                     "year": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   }
                 ],
                 "type": "record",
+                "required": true,
                 "entity_checks": [
                   {
                     "at_least_one_of": [
@@ -212,17 +219,10 @@
                   }
                 ]
               },
-              "required": true,
-              "len_min": 1,
-              "description": "A map that defines rate limits for the plugin.",
-              "type": "map",
-              "keys": {
-                "type": "string"
-              }
+              "description": "A map that defines rate limits for the plugin."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }
@@ -230,11 +230,11 @@
   "entity_checks": [
     {
       "conditional": {
-        "if_field": "config.policy",
+        "if_match": {
+          "eq": "redis"
+        },
         "then_field": "config.redis_host",
-        "if_match": {
-          "eq": "redis"
-        },
+        "if_field": "config.policy",
         "then_match": {
           "required": true
         }
@@ -242,11 +242,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.policy",
+        "if_match": {
+          "eq": "redis"
+        },
         "then_field": "config.redis_port",
-        "if_match": {
-          "eq": "redis"
-        },
+        "if_field": "config.policy",
         "then_match": {
           "required": true
         }
@@ -254,11 +254,11 @@
     },
     {
       "conditional": {
-        "if_field": "config.policy",
-        "then_field": "config.redis_timeout",
         "if_match": {
           "eq": "redis"
         },
+        "then_field": "config.redis_timeout",
+        "if_field": "config.policy",
         "then_match": {
           "required": true
         }

--- a/schemas/response-transformer-advanced/3.4.x.json
+++ b/schemas/response-transformer-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,14 +18,17 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "remove": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
@@ -62,12 +64,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "rename": {
+              "type": "record",
               "fields": [
                 {
                   "headers": {
@@ -76,8 +78,8 @@
                     ],
                     "type": "array",
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -93,12 +95,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "replace": {
+              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -156,12 +158,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "add": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
@@ -213,12 +215,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "append": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
@@ -270,28 +272,28 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "allow": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
-                    "type": "set",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "set"
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "transform": {
+              "type": "record",
               "fields": [
                 {
                   "functions": {
@@ -327,19 +329,17 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "dots_in_keys": {
               "default": true,
-              "description": "Whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects..",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects.."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/response-transformer/3.4.x.json
+++ b/schemas/response-transformer/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,22 +18,25 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "remove": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
@@ -45,52 +47,52 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "rename": {
+              "type": "record",
               "fields": [
                 {
                   "headers": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "replace": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -100,7 +102,6 @@
                     "default": [
 
                     ],
-                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
                     "type": "array",
                     "elements": {
                       "type": "string",
@@ -109,7 +110,8 @@
                         "number",
                         "string"
                       ]
-                    }
+                    },
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string."
                   }
                 },
                 {
@@ -117,32 +119,32 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "add": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -152,7 +154,6 @@
                     "default": [
 
                     ],
-                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
                     "type": "array",
                     "elements": {
                       "type": "string",
@@ -161,7 +162,8 @@
                         "number",
                         "string"
                       ]
-                    }
+                    },
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string."
                   }
                 },
                 {
@@ -169,32 +171,32 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           },
           {
             "append": {
+              "type": "record",
               "fields": [
                 {
                   "json": {
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 },
@@ -204,7 +206,6 @@
                     "default": [
 
                     ],
-                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
                     "type": "array",
                     "elements": {
                       "type": "string",
@@ -213,7 +214,8 @@
                         "number",
                         "string"
                       ]
-                    }
+                    },
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string."
                   }
                 },
                 {
@@ -221,21 +223,19 @@
                     "default": [
 
                     ],
-                    "required": true,
                     "type": "array",
+                    "required": true,
                     "elements": {
-                      "type": "string",
-                      "match": "^[^:]+:.*$"
+                      "match": "^[^:]+:.*$",
+                      "type": "string"
                     }
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/route-by-header/3.4.x.json
+++ b/schemas/route-by-header/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,55 +18,56 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "rules": {
               "default": [
 
               ],
-              "description": "Route by header rules.",
               "type": "array",
               "elements": {
-                "type": "record",
                 "fields": [
                   {
                     "upstream_name": {
-                      "type": "string",
-                      "required": true
+                      "required": true,
+                      "type": "string"
                     }
                   },
                   {
                     "condition": {
-                      "values": {
+                      "keys": {
                         "type": "string"
                       },
                       "required": true,
                       "len_min": 1,
                       "type": "map",
-                      "keys": {
+                      "values": {
                         "type": "string"
                       }
                     }
                   }
-                ]
-              }
+                ],
+                "type": "record"
+              },
+              "description": "Route by header rules."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/route-transformer-advanced/3.4.x.json
+++ b/schemas/route-transformer-advanced/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,15 +18,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -50,13 +50,13 @@
           },
           {
             "escape_path": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "type": "boolean"
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [

--- a/schemas/saml/3.4.x.json
+++ b/schemas/saml/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,7 +17,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -27,547 +26,20 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "fields": [
-          {
-            "assertion_consumer_path": {
-              "match_none": [
-                {
-                  "pattern": "//",
-                  "err": "must not have empty segments"
-                }
-              ],
-              "required": true,
-              "starts_with": "/",
-              "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
-            }
-          },
-          {
-            "idp_sso_url": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string",
-              "required": true
-            }
-          },
-          {
-            "idp_certificate": {
-              "encrypted": true,
-              "referenceable": true,
-              "description": "The public certificate provided by the IdP. This is used to validate responses from the IdP.  Only include the contents of the certificate. Do not include the header (`BEGIN CERTIFICATE`) and footer (`END CERTIFICATE`) lines.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "response_encryption_key": {
-              "encrypted": true,
-              "referenceable": true,
-              "description": "The private encryption key required to decrypt encrypted assertions.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "request_signing_key": {
-              "encrypted": true,
-              "referenceable": true,
-              "description": "The private key for signing requests.  If this parameter is set, requests sent to the IdP are signed.  The `request_signing_certificate` parameter must be set as well.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "request_signing_certificate": {
-              "encrypted": true,
-              "referenceable": true,
-              "description": "The certificate for signing requests.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "request_signature_algorithm": {
-              "required": false,
-              "default": "SHA256",
-              "description": "The signature algorithm for signing Authn requests. Options available are: - `SHA256` - `SHA384` - `SHA512`",
-              "type": "string",
-              "one_of": [
-                "SHA256",
-                "SHA384",
-                "SHA512"
-              ]
-            }
-          },
-          {
-            "request_digest_algorithm": {
-              "required": false,
-              "default": "SHA256",
-              "description": "The digest algorithm for Authn requests: - `SHA256` - `SHA1`",
-              "type": "string",
-              "one_of": [
-                "SHA256",
-                "SHA1"
-              ]
-            }
-          },
-          {
-            "response_signature_algorithm": {
-              "required": false,
-              "default": "SHA256",
-              "description": "The algorithm for validating signatures in SAML responses. Options available are: - `SHA256` - `SHA384` - `SHA512`",
-              "type": "string",
-              "one_of": [
-                "SHA256",
-                "SHA384",
-                "SHA512"
-              ]
-            }
-          },
-          {
-            "response_digest_algorithm": {
-              "required": false,
-              "default": "SHA256",
-              "description": "The algorithm for verifying digest in SAML responses: - `SHA256` - `SHA1`",
-              "type": "string",
-              "one_of": [
-                "SHA256",
-                "SHA1"
-              ]
-            }
-          },
-          {
-            "issuer": {
-              "description": "The unique identifier of the IdP application. Formatted as a URL containing information about the IdP so the SP can validate that the SAML assertions it receives are issued from the correct IdP.",
-              "type": "string",
-              "required": true
-            }
-          },
-          {
-            "nameid_format": {
-              "required": false,
-              "default": "EmailAddress",
-              "description": "The requested `NameId` format. Options available are: - `Unspecified` - `EmailAddress` - `Persistent` - `Transient`",
-              "type": "string",
-              "one_of": [
-                "Unspecified",
-                "EmailAddress",
-                "Persistent",
-                "Transient"
-              ]
-            }
-          },
-          {
-            "validate_assertion_signature": {
-              "default": true,
-              "description": "Enable signature validation for SAML responses.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer. If not set, a Kong Consumer must exist for the SAML IdP user credentials, mapping the username format to the Kong Consumer username.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_secret": {
-              "referenceable": true,
-              "required": true,
-              "description": "The session secret. This must be a random string of 32 characters from the base64 alphabet (letters, numbers, `/`, `_` and `+`). It is used as the secret key for encrypting session data as well as state information that is sent to the IdP in the authentication exchange.",
-              "encrypted": true,
-              "len_min": 32,
-              "len_max": 32,
-              "type": "string",
-              "match": "^[0-9a-zA-Z/_+]+$"
-            }
-          },
-          {
-            "session_audience": {
-              "default": "default",
-              "description": "The session audience, for example \"my-application\"",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_name": {
-              "default": "session",
-              "description": "The session cookie name.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_remember": {
-              "default": false,
-              "description": "Enables or disables persistent sessions",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_remember_cookie_name": {
-              "default": "remember",
-              "description": "Persistent session cookie name",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_remember_rolling_timeout": {
-              "default": 604800,
-              "description": "Persistent session rolling timeout in seconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_remember_absolute_timeout": {
-              "default": 2592000,
-              "description": "Persistent session absolute timeout in seconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_idling_timeout": {
-              "default": 900,
-              "description": "The session cookie idle time in seconds.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_rolling_timeout": {
-              "default": 3600,
-              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_absolute_timeout": {
-              "default": 86400,
-              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
-              "type": "number",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_path": {
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
-              "match_none": [
-                {
-                  "pattern": "//",
-                  "err": "must not have empty segments"
-                }
-              ],
-              "default": "/",
-              "starts_with": "/",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_domain": {
-              "description": "The session cookie domain flag.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_same_site": {
-              "required": false,
-              "default": "Lax",
-              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
-              "type": "string",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ]
-            }
-          },
-          {
-            "session_cookie_http_only": {
-              "default": true,
-              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_cookie_secure": {
-              "description": "The cookie is only sent to the server when a request is made with the https:scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_request_headers": {
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ]
-              }
-            }
-          },
-          {
-            "session_response_headers": {
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ]
-              }
-            }
-          },
-          {
-            "session_storage": {
-              "required": false,
-              "default": "cookie",
-              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie. The session cannot be invalidated or revoked without changing the session secret, but is stateless, and doesn't require a database. - `memcached`: stores session data in memcached - `redis`: stores session data in Redis",
-              "type": "string",
-              "one_of": [
-                "cookie",
-                "memcache",
-                "memcached",
-                "redis"
-              ]
-            }
-          },
-          {
-            "session_store_metadata": {
-              "default": false,
-              "description": "Configures whether or not session metadata should be stored. This includes information about the active sessions for the `specific_audience` belonging to a specific subject.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_enforce_same_subject": {
-              "default": false,
-              "description": "When set to `true`, audiences are forced to share the same subject.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_hash_subject": {
-              "default": false,
-              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_hash_storage_key": {
-              "default": false,
-              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_prefix": {
-              "description": "The memcached session key prefix.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_socket": {
-              "description": "The memcached unix socket path.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_host": {
-              "default": "127.0.0.1",
-              "description": "The memcached host.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_memcached_port": {
-              "required": false,
-              "default": 11211,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ]
-            }
-          },
-          {
-            "session_redis_prefix": {
-              "description": "The Redis session key prefix.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_socket": {
-              "description": "The Redis unix socket path.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_host": {
-              "default": "127.0.0.1",
-              "description": "The Redis host IP.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_port": {
-              "required": false,
-              "default": 6379,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
-              "between": [
-                0,
-                65535
-              ]
-            }
-          },
-          {
-            "session_redis_username": {
-              "referenceable": true,
-              "description": "Redis username if the `redis` session storage is defined and ACL authentication is desired.If undefined, ACL authentication will not be performed.  This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_password": {
-              "encrypted": true,
-              "referenceable": true,
-              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no auth commands are sent to Redis. This value is pulled from",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_connect_timeout": {
-              "description": "The Redis connection timeout in milliseconds.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_read_timeout": {
-              "description": "The Redis read timeout in milliseconds.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_send_timeout": {
-              "description": "The Redis send timeout in milliseconds.",
-              "type": "integer",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl": {
-              "default": false,
-              "description": "Use SSL/TLS for the Redis connection.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_redis_ssl_verify": {
-              "default": false,
-              "description": "Verify the Redis server certificate.",
-              "type": "boolean",
-              "required": false
-            }
-          },
-          {
-            "session_redis_server_name": {
-              "description": "The SNI used for connecting to the Redis server.",
-              "type": "string",
-              "required": false
-            }
-          },
-          {
-            "session_redis_cluster_nodes": {
-              "required": false,
-              "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values.",
-              "type": "array",
-              "elements": {
-                "type": "record",
-                "fields": [
-                  {
-                    "ip": {
-                      "default": "127.0.0.1",
-                      "description": "A string representing a host name, such as example.com.",
-                      "type": "string",
-                      "required": true
-                    }
-                  },
-                  {
-                    "port": {
-                      "default": 6379,
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
-                      "type": "integer",
-                      "between": [
-                        0,
-                        65535
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "session_redis_cluster_max_redirections": {
-              "description": "The Redis cluster maximum redirects.",
-              "type": "integer",
-              "required": false
-            }
-          }
-        ],
-        "type": "record",
         "shorthand_fields": [
           {
             "session_cookie_lifetime": {
@@ -640,7 +112,535 @@
             }
           }
         ],
-        "required": true
+        "type": "record",
+        "required": true,
+        "fields": [
+          {
+            "assertion_consumer_path": {
+              "required": true,
+              "starts_with": "/",
+              "type": "string",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
+            }
+          },
+          {
+            "idp_sso_url": {
+              "type": "string",
+              "required": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+            }
+          },
+          {
+            "idp_certificate": {
+              "required": false,
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true,
+              "description": "The public certificate provided by the IdP. This is used to validate responses from the IdP.  Only include the contents of the certificate. Do not include the header (`BEGIN CERTIFICATE`) and footer (`END CERTIFICATE`) lines."
+            }
+          },
+          {
+            "response_encryption_key": {
+              "required": false,
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true,
+              "description": "The private encryption key required to decrypt encrypted assertions."
+            }
+          },
+          {
+            "request_signing_key": {
+              "required": false,
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true,
+              "description": "The private key for signing requests.  If this parameter is set, requests sent to the IdP are signed.  The `request_signing_certificate` parameter must be set as well."
+            }
+          },
+          {
+            "request_signing_certificate": {
+              "required": false,
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true,
+              "description": "The certificate for signing requests."
+            }
+          },
+          {
+            "request_signature_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA384",
+                "SHA512"
+              ],
+              "description": "The signature algorithm for signing Authn requests. Options available are: - `SHA256` - `SHA384` - `SHA512`"
+            }
+          },
+          {
+            "request_digest_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA1"
+              ],
+              "description": "The digest algorithm for Authn requests: - `SHA256` - `SHA1`"
+            }
+          },
+          {
+            "response_signature_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA384",
+                "SHA512"
+              ],
+              "description": "The algorithm for validating signatures in SAML responses. Options available are: - `SHA256` - `SHA384` - `SHA512`"
+            }
+          },
+          {
+            "response_digest_algorithm": {
+              "required": false,
+              "default": "SHA256",
+              "type": "string",
+              "one_of": [
+                "SHA256",
+                "SHA1"
+              ],
+              "description": "The algorithm for verifying digest in SAML responses: - `SHA256` - `SHA1`"
+            }
+          },
+          {
+            "issuer": {
+              "type": "string",
+              "required": true,
+              "description": "The unique identifier of the IdP application. Formatted as a URL containing information about the IdP so the SP can validate that the SAML assertions it receives are issued from the correct IdP."
+            }
+          },
+          {
+            "nameid_format": {
+              "required": false,
+              "default": "EmailAddress",
+              "type": "string",
+              "one_of": [
+                "Unspecified",
+                "EmailAddress",
+                "Persistent",
+                "Transient"
+              ],
+              "description": "The requested `NameId` format. Options available are: - `Unspecified` - `EmailAddress` - `Persistent` - `Transient`"
+            }
+          },
+          {
+            "validate_assertion_signature": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Enable signature validation for SAML responses."
+            }
+          },
+          {
+            "anonymous": {
+              "type": "string",
+              "required": false,
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer. If not set, a Kong Consumer must exist for the SAML IdP user credentials, mapping the username format to the Kong Consumer username."
+            }
+          },
+          {
+            "session_secret": {
+              "referenceable": true,
+              "required": true,
+              "encrypted": true,
+              "len_min": 32,
+              "len_max": 32,
+              "match": "^[0-9a-zA-Z/_+]+$",
+              "type": "string",
+              "description": "The session secret. This must be a random string of 32 characters from the base64 alphabet (letters, numbers, `/`, `_` and `+`). It is used as the secret key for encrypting session data as well as state information that is sent to the IdP in the authentication exchange."
+            }
+          },
+          {
+            "session_audience": {
+              "default": "default",
+              "type": "string",
+              "required": false,
+              "description": "The session audience, for example \"my-application\""
+            }
+          },
+          {
+            "session_cookie_name": {
+              "default": "session",
+              "type": "string",
+              "required": false,
+              "description": "The session cookie name."
+            }
+          },
+          {
+            "session_remember": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Enables or disables persistent sessions"
+            }
+          },
+          {
+            "session_remember_cookie_name": {
+              "default": "remember",
+              "type": "string",
+              "required": false,
+              "description": "Persistent session cookie name"
+            }
+          },
+          {
+            "session_remember_rolling_timeout": {
+              "default": 604800,
+              "type": "number",
+              "required": false,
+              "description": "Persistent session rolling timeout in seconds."
+            }
+          },
+          {
+            "session_remember_absolute_timeout": {
+              "default": 2592000,
+              "type": "number",
+              "required": false,
+              "description": "Persistent session absolute timeout in seconds."
+            }
+          },
+          {
+            "session_idling_timeout": {
+              "default": 900,
+              "type": "number",
+              "required": false,
+              "description": "The session cookie idle time in seconds."
+            }
+          },
+          {
+            "session_rolling_timeout": {
+              "default": 3600,
+              "type": "number",
+              "required": false,
+              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid."
+            }
+          },
+          {
+            "session_absolute_timeout": {
+              "default": 86400,
+              "type": "number",
+              "required": false,
+              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid."
+            }
+          },
+          {
+            "session_cookie_path": {
+              "required": false,
+              "default": "/",
+              "starts_with": "/",
+              "type": "string",
+              "match_none": [
+                {
+                  "pattern": "//",
+                  "err": "must not have empty segments"
+                }
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
+            }
+          },
+          {
+            "session_cookie_domain": {
+              "type": "string",
+              "required": false,
+              "description": "The session cookie domain flag."
+            }
+          },
+          {
+            "session_cookie_same_site": {
+              "required": false,
+              "default": "Lax",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ],
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks."
+            }
+          },
+          {
+            "session_cookie_http_only": {
+              "default": true,
+              "type": "boolean",
+              "required": false,
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property."
+            }
+          },
+          {
+            "session_cookie_secure": {
+              "type": "boolean",
+              "required": false,
+              "description": "The cookie is only sent to the server when a request is made with the https:scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks."
+            }
+          },
+          {
+            "session_request_headers": {
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              },
+              "type": "set"
+            }
+          },
+          {
+            "session_response_headers": {
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              },
+              "type": "set"
+            }
+          },
+          {
+            "session_storage": {
+              "required": false,
+              "default": "cookie",
+              "type": "string",
+              "one_of": [
+                "cookie",
+                "memcache",
+                "memcached",
+                "redis"
+              ],
+              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie. The session cannot be invalidated or revoked without changing the session secret, but is stateless, and doesn't require a database. - `memcached`: stores session data in memcached - `redis`: stores session data in Redis"
+            }
+          },
+          {
+            "session_store_metadata": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Configures whether or not session metadata should be stored. This includes information about the active sessions for the `specific_audience` belonging to a specific subject."
+            }
+          },
+          {
+            "session_enforce_same_subject": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "When set to `true`, audiences are forced to share the same subject."
+            }
+          },
+          {
+            "session_hash_subject": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled."
+            }
+          },
+          {
+            "session_hash_storage_key": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie."
+            }
+          },
+          {
+            "session_memcached_prefix": {
+              "type": "string",
+              "required": false,
+              "description": "The memcached session key prefix."
+            }
+          },
+          {
+            "session_memcached_socket": {
+              "type": "string",
+              "required": false,
+              "description": "The memcached unix socket path."
+            }
+          },
+          {
+            "session_memcached_host": {
+              "default": "127.0.0.1",
+              "type": "string",
+              "required": false,
+              "description": "The memcached host."
+            }
+          },
+          {
+            "session_memcached_port": {
+              "required": false,
+              "between": [
+                0,
+                65535
+              ],
+              "default": 11211,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
+            }
+          },
+          {
+            "session_redis_prefix": {
+              "type": "string",
+              "required": false,
+              "description": "The Redis session key prefix."
+            }
+          },
+          {
+            "session_redis_socket": {
+              "type": "string",
+              "required": false,
+              "description": "The Redis unix socket path."
+            }
+          },
+          {
+            "session_redis_host": {
+              "default": "127.0.0.1",
+              "type": "string",
+              "required": false,
+              "description": "The Redis host IP."
+            }
+          },
+          {
+            "session_redis_port": {
+              "required": false,
+              "between": [
+                0,
+                65535
+              ],
+              "default": 6379,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
+            }
+          },
+          {
+            "session_redis_username": {
+              "referenceable": true,
+              "type": "string",
+              "required": false,
+              "description": "Redis username if the `redis` session storage is defined and ACL authentication is desired.If undefined, ACL authentication will not be performed.  This requires Redis v6.0.0+. The username **cannot** be set to `default`."
+            }
+          },
+          {
+            "session_redis_password": {
+              "required": false,
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true,
+              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no auth commands are sent to Redis. This value is pulled from"
+            }
+          },
+          {
+            "session_redis_connect_timeout": {
+              "type": "integer",
+              "required": false,
+              "description": "The Redis connection timeout in milliseconds."
+            }
+          },
+          {
+            "session_redis_read_timeout": {
+              "type": "integer",
+              "required": false,
+              "description": "The Redis read timeout in milliseconds."
+            }
+          },
+          {
+            "session_redis_send_timeout": {
+              "type": "integer",
+              "required": false,
+              "description": "The Redis send timeout in milliseconds."
+            }
+          },
+          {
+            "session_redis_ssl": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Use SSL/TLS for the Redis connection."
+            }
+          },
+          {
+            "session_redis_ssl_verify": {
+              "default": false,
+              "type": "boolean",
+              "required": false,
+              "description": "Verify the Redis server certificate."
+            }
+          },
+          {
+            "session_redis_server_name": {
+              "type": "string",
+              "required": false,
+              "description": "The SNI used for connecting to the Redis server."
+            }
+          },
+          {
+            "session_redis_cluster_nodes": {
+              "required": false,
+              "type": "array",
+              "elements": {
+                "fields": [
+                  {
+                    "ip": {
+                      "default": "127.0.0.1",
+                      "type": "string",
+                      "required": true,
+                      "description": "A string representing a host name, such as example.com."
+                    }
+                  },
+                  {
+                    "port": {
+                      "default": 6379,
+                      "type": "integer",
+                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
+                      "between": [
+                        0,
+                        65535
+                      ]
+                    }
+                  }
+                ],
+                "type": "record"
+              },
+              "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values."
+            }
+          },
+          {
+            "session_redis_cluster_max_redirections": {
+              "type": "integer",
+              "required": false,
+              "description": "The Redis cluster maximum redirects."
+            }
+          }
+        ]
       }
     }
   ],

--- a/schemas/session/3.4.x.json
+++ b/schemas/session/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -17,10 +17,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -33,222 +31,22 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "fields": [
-          {
-            "secret": {
-              "referenceable": true,
-              "required": false,
-              "default": "as6rhTxJRUuWhaZKo58zQN1ZdWZSxGzYdKDnvRIEUSUp",
-              "description": "The secret that is used in keyed HMAC generation.",
-              "type": "string",
-              "encrypted": true
-            }
-          },
-          {
-            "storage": {
-              "default": "cookie",
-              "description": "Determines where the session data is stored. `kong`: Stores encrypted session data into Kong's current database strategy; the cookie will not contain any session data. `cookie`: Stores encrypted session data within the cookie itself.",
-              "type": "string",
-              "one_of": [
-                "cookie",
-                "kong"
-              ]
-            }
-          },
-          {
-            "audience": {
-              "default": "default",
-              "description": "The session audience, which is the intended target application. For example `\"my-application\"`.",
-              "type": "string"
-            }
-          },
-          {
-            "idling_timeout": {
-              "default": 900,
-              "description": "The session cookie idle time, in seconds.",
-              "type": "number"
-            }
-          },
-          {
-            "rolling_timeout": {
-              "default": 3600,
-              "description": "The session cookie rolling timeout, in seconds. Specifies how long the session can be used until it needs to be renewed.",
-              "type": "number"
-            }
-          },
-          {
-            "absolute_timeout": {
-              "default": 86400,
-              "description": "The session cookie absolute timeout, in seconds. Specifies how long the session can be used until it is no longer valid.",
-              "type": "number"
-            }
-          },
-          {
-            "stale_ttl": {
-              "default": 10,
-              "description": "The duration, in seconds, after which an old cookie is discarded, starting from the moment when the session becomes outdated and is replaced by a new one.",
-              "type": "number"
-            }
-          },
-          {
-            "cookie_name": {
-              "default": "session",
-              "description": "The name of the cookie.",
-              "type": "string"
-            }
-          },
-          {
-            "cookie_path": {
-              "default": "/",
-              "description": "The resource in the host where the cookie is available.",
-              "type": "string"
-            }
-          },
-          {
-            "cookie_domain": {
-              "type": "string",
-              "description": "The domain with which the cookie is intended to be exchanged."
-            }
-          },
-          {
-            "cookie_same_site": {
-              "default": "Strict",
-              "description": "Determines whether and how a cookie may be sent with cross-site requests.",
-              "type": "string",
-              "one_of": [
-                "Strict",
-                "Lax",
-                "None",
-                "Default"
-              ]
-            }
-          },
-          {
-            "cookie_http_only": {
-              "default": true,
-              "description": "Applies the `HttpOnly` tag so that the cookie is sent only to a server.",
-              "type": "boolean"
-            }
-          },
-          {
-            "cookie_secure": {
-              "default": true,
-              "description": "Applies the Secure directive so that the cookie may be sent to the server only with an encrypted request over the HTTPS protocol.",
-              "type": "boolean"
-            }
-          },
-          {
-            "remember": {
-              "default": false,
-              "description": "Enables or disables persistent sessions.",
-              "type": "boolean"
-            }
-          },
-          {
-            "remember_cookie_name": {
-              "default": "remember",
-              "description": "Persistent session cookie name. Use with the `remember` configuration parameter.",
-              "type": "string"
-            }
-          },
-          {
-            "remember_rolling_timeout": {
-              "default": 604800,
-              "description": "The persistent session rolling timeout window, in seconds.",
-              "type": "number"
-            }
-          },
-          {
-            "remember_absolute_timeout": {
-              "default": 2592000,
-              "description": "The persistent session absolute timeout limit, in seconds.",
-              "type": "number"
-            }
-          },
-          {
-            "response_headers": {
-              "description": "List of information to include, as headers, in the response to the downstream.",
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ]
-              }
-            }
-          },
-          {
-            "request_headers": {
-              "description": "List of information to include, as headers, in the response to the downstream.",
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "audience",
-                  "subject",
-                  "timeout",
-                  "idling-timeout",
-                  "rolling-timeout",
-                  "absolute-timeout"
-                ]
-              }
-            }
-          },
-          {
-            "logout_methods": {
-              "default": [
-                "POST",
-                "DELETE"
-              ],
-              "description": "A set of HTTP methods that the plugin will respond to.",
-              "type": "set",
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "GET",
-                  "POST",
-                  "DELETE"
-                ]
-              }
-            }
-          },
-          {
-            "logout_query_arg": {
-              "default": "session_logout",
-              "description": "The query argument passed to logout requests.",
-              "type": "string"
-            }
-          },
-          {
-            "logout_post_arg": {
-              "default": "session_logout",
-              "description": "The POST argument passed to logout requests. Do not change this property.",
-              "type": "string"
-            }
-          }
-        ],
-        "type": "record",
         "shorthand_fields": [
           {
             "cookie_lifetime": {
@@ -286,7 +84,209 @@
             }
           }
         ],
-        "required": true
+        "type": "record",
+        "required": true,
+        "fields": [
+          {
+            "secret": {
+              "required": false,
+              "description": "The secret that is used in keyed HMAC generation.",
+              "default": "wXhRlE4nPT2CwAuqu57egsj16Ij4G8g3F68UL06nBiUu",
+              "type": "string",
+              "encrypted": true,
+              "referenceable": true
+            }
+          },
+          {
+            "storage": {
+              "default": "cookie",
+              "type": "string",
+              "one_of": [
+                "cookie",
+                "kong"
+              ],
+              "description": "Determines where the session data is stored. `kong`: Stores encrypted session data into Kong's current database strategy; the cookie will not contain any session data. `cookie`: Stores encrypted session data within the cookie itself."
+            }
+          },
+          {
+            "audience": {
+              "default": "default",
+              "type": "string",
+              "description": "The session audience, which is the intended target application. For example `\"my-application\"`."
+            }
+          },
+          {
+            "idling_timeout": {
+              "default": 900,
+              "type": "number",
+              "description": "The session cookie idle time, in seconds."
+            }
+          },
+          {
+            "rolling_timeout": {
+              "default": 3600,
+              "type": "number",
+              "description": "The session cookie rolling timeout, in seconds. Specifies how long the session can be used until it needs to be renewed."
+            }
+          },
+          {
+            "absolute_timeout": {
+              "default": 86400,
+              "type": "number",
+              "description": "The session cookie absolute timeout, in seconds. Specifies how long the session can be used until it is no longer valid."
+            }
+          },
+          {
+            "stale_ttl": {
+              "default": 10,
+              "type": "number",
+              "description": "The duration, in seconds, after which an old cookie is discarded, starting from the moment when the session becomes outdated and is replaced by a new one."
+            }
+          },
+          {
+            "cookie_name": {
+              "default": "session",
+              "type": "string",
+              "description": "The name of the cookie."
+            }
+          },
+          {
+            "cookie_path": {
+              "default": "/",
+              "type": "string",
+              "description": "The resource in the host where the cookie is available."
+            }
+          },
+          {
+            "cookie_domain": {
+              "description": "The domain with which the cookie is intended to be exchanged.",
+              "type": "string"
+            }
+          },
+          {
+            "cookie_same_site": {
+              "default": "Strict",
+              "type": "string",
+              "one_of": [
+                "Strict",
+                "Lax",
+                "None",
+                "Default"
+              ],
+              "description": "Determines whether and how a cookie may be sent with cross-site requests."
+            }
+          },
+          {
+            "cookie_http_only": {
+              "default": true,
+              "type": "boolean",
+              "description": "Applies the `HttpOnly` tag so that the cookie is sent only to a server."
+            }
+          },
+          {
+            "cookie_secure": {
+              "default": true,
+              "type": "boolean",
+              "description": "Applies the Secure directive so that the cookie may be sent to the server only with an encrypted request over the HTTPS protocol."
+            }
+          },
+          {
+            "remember": {
+              "default": false,
+              "type": "boolean",
+              "description": "Enables or disables persistent sessions."
+            }
+          },
+          {
+            "remember_cookie_name": {
+              "default": "remember",
+              "type": "string",
+              "description": "Persistent session cookie name. Use with the `remember` configuration parameter."
+            }
+          },
+          {
+            "remember_rolling_timeout": {
+              "default": 604800,
+              "type": "number",
+              "description": "The persistent session rolling timeout window, in seconds."
+            }
+          },
+          {
+            "remember_absolute_timeout": {
+              "default": 2592000,
+              "type": "number",
+              "description": "The persistent session absolute timeout limit, in seconds."
+            }
+          },
+          {
+            "response_headers": {
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              },
+              "description": "List of information to include, as headers, in the response to the downstream."
+            }
+          },
+          {
+            "request_headers": {
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "audience",
+                  "subject",
+                  "timeout",
+                  "idling-timeout",
+                  "rolling-timeout",
+                  "absolute-timeout"
+                ]
+              },
+              "description": "List of information to include, as headers, in the response to the downstream."
+            }
+          },
+          {
+            "logout_methods": {
+              "default": [
+                "POST",
+                "DELETE"
+              ],
+              "type": "set",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "GET",
+                  "POST",
+                  "DELETE"
+                ]
+              },
+              "description": "A set of HTTP methods that the plugin will respond to."
+            }
+          },
+          {
+            "logout_query_arg": {
+              "default": "session_logout",
+              "type": "string",
+              "description": "The query argument passed to logout requests."
+            }
+          },
+          {
+            "logout_post_arg": {
+              "default": "session_logout",
+              "type": "string",
+              "description": "The POST argument passed to logout requests. Do not change this property."
+            }
+          }
+        ]
       }
     }
   ],

--- a/schemas/statsd-advanced/3.4.x.json
+++ b/schemas/statsd-advanced/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,33 +23,36 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "host": {
               "default": "localhost",
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
               "default": 8125,
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
@@ -61,16 +62,16 @@
           {
             "prefix": {
               "default": "kong",
-              "description": "String to prefix to each metric's name.",
-              "type": "string"
+              "type": "string",
+              "description": "String to prefix to each metric's name."
             }
           },
           {
             "metrics": {
               "default": [
                 {
-                  "name": "request_count",
                   "sample_rate": 1,
+                  "name": "request_count",
                   "stat_type": "counter"
                 },
                 {
@@ -82,8 +83,8 @@
                   "name": "request_size"
                 },
                 {
-                  "name": "status_count",
                   "sample_rate": 1,
+                  "name": "status_count",
                   "stat_type": "counter"
                 },
                 {
@@ -95,9 +96,9 @@
                   "name": "unique_users"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "request_per_user"
+                  "name": "request_per_user",
+                  "stat_type": "counter"
                 },
                 {
                   "stat_type": "timer",
@@ -108,43 +109,44 @@
                   "name": "kong_latency"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "status_count_per_user"
-                },
-                {
-                  "name": "status_count_per_workspace",
-                  "sample_rate": 1,
+                  "name": "status_count_per_user",
                   "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "status_count_per_user_per_route"
+                  "name": "status_count_per_workspace",
+                  "stat_type": "counter"
                 },
                 {
-                  "name": "shdict_usage",
                   "sample_rate": 1,
+                  "name": "status_count_per_user_per_route",
+                  "stat_type": "counter"
+                },
+                {
+                  "sample_rate": 1,
+                  "name": "shdict_usage",
                   "stat_type": "gauge"
                 },
                 {
-                  "name": "cache_datastore_hits_total",
                   "sample_rate": 1,
+                  "name": "cache_datastore_hits_total",
                   "stat_type": "counter"
                 },
                 {
-                  "name": "cache_datastore_misses_total",
                   "sample_rate": 1,
+                  "name": "cache_datastore_misses_total",
                   "stat_type": "counter"
                 }
               ],
-              "description": "List of Metrics to be logged.",
               "type": "array",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "name": {
                       "type": "string",
+                      "required": true,
                       "one_of": [
                         "kong_latency",
                         "latency",
@@ -161,13 +163,13 @@
                         "shdict_usage",
                         "cache_datastore_hits_total",
                         "cache_datastore_misses_total"
-                      ],
-                      "required": true
+                      ]
                     }
                   },
                   {
                     "stat_type": {
                       "type": "string",
+                      "required": true,
                       "one_of": [
                         "counter",
                         "gauge",
@@ -175,14 +177,13 @@
                         "meter",
                         "set",
                         "timer"
-                      ],
-                      "required": true
+                      ]
                     }
                   },
                   {
                     "sample_rate": {
-                      "type": "number",
-                      "gt": 0
+                      "gt": 0,
+                      "type": "number"
                     }
                   },
                   {
@@ -216,17 +217,16 @@
                     }
                   }
                 ],
-                "type": "record",
                 "entity_checks": [
                   {
                     "conditional": {
-                      "if_field": "name",
-                      "then_field": "stat_type",
                       "if_match": {
                         "one_of": [
                           "unique_users"
                         ]
                       },
+                      "then_field": "stat_type",
+                      "if_field": "name",
                       "then_match": {
                         "eq": "set"
                       }
@@ -234,8 +234,6 @@
                   },
                   {
                     "conditional": {
-                      "if_field": "name",
-                      "then_field": "stat_type",
                       "if_match": {
                         "one_of": [
                           "request_count",
@@ -248,6 +246,8 @@
                           "cache_datastore_misses_total"
                         ]
                       },
+                      "then_field": "stat_type",
+                      "if_field": "name",
                       "then_match": {
                         "eq": "counter"
                       }
@@ -255,13 +255,13 @@
                   },
                   {
                     "conditional": {
-                      "if_field": "name",
-                      "then_field": "stat_type",
                       "if_match": {
                         "one_of": [
                           "shdict_usage"
                         ]
                       },
+                      "then_field": "stat_type",
+                      "if_field": "name",
                       "then_match": {
                         "eq": "gauge"
                       }
@@ -269,38 +269,39 @@
                   },
                   {
                     "conditional": {
-                      "if_field": "stat_type",
-                      "then_field": "sample_rate",
                       "if_match": {
                         "one_of": [
                           "counter",
                           "gauge"
                         ]
                       },
+                      "then_field": "sample_rate",
+                      "if_field": "stat_type",
                       "then_match": {
                         "required": true
                       }
                     }
                   }
                 ]
-              }
+              },
+              "description": "List of Metrics to be logged."
             }
           },
           {
             "allow_status_codes": {
-              "description": "List of status code ranges that are allowed to be logged in metrics.",
               "type": "array",
               "elements": {
                 "type": "string",
                 "match": "^[0-9]+-[0-9]+$"
-              }
+              },
+              "description": "List of status code ranges that are allowed to be logged in metrics."
             }
           },
           {
             "udp_packet_size": {
               "default": 0,
-              "description": "Combine UDP packet up to the size configured. If zero (0), don't combine the UDP packet. Must be a number between 0 and 65507 (inclusive).",
               "type": "number",
+              "description": "Combine UDP packet up to the size configured. If zero (0), don't combine the UDP packet. Must be a number between 0 and 65507 (inclusive).",
               "between": [
                 0,
                 65507
@@ -310,90 +311,91 @@
           {
             "use_tcp": {
               "default": false,
-              "description": "Use TCP instead of UDP.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Use TCP instead of UDP."
             }
           },
           {
             "hostname_in_prefix": {
               "default": false,
-              "description": "Include the `hostname` in the `prefix` for each metric name.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include the `hostname` in the `prefix` for each metric name."
             }
           },
           {
             "consumer_identifier_default": {
               "required": true,
               "default": "custom_id",
-              "description": "The default consumer identifier for metrics. This will take effect when a metric's consumer identifier is omitted. Allowed values are `custom_id`, `consumer_id`, `username`.",
               "type": "string",
               "one_of": [
                 "consumer_id",
                 "custom_id",
                 "username"
-              ]
+              ],
+              "description": "The default consumer identifier for metrics. This will take effect when a metric's consumer identifier is omitted. Allowed values are `custom_id`, `consumer_id`, `username`."
             }
           },
           {
             "service_identifier_default": {
               "required": true,
               "default": "service_name_or_host",
-              "description": "The default service identifier for metrics. This will take effect when a metric's service identifier is omitted. Allowed values are `service_name_or_host`, `service_id`, `service_name`, `service_host`.",
               "type": "string",
               "one_of": [
                 "service_id",
                 "service_name",
                 "service_host",
                 "service_name_or_host"
-              ]
+              ],
+              "description": "The default service identifier for metrics. This will take effect when a metric's service identifier is omitted. Allowed values are `service_name_or_host`, `service_id`, `service_name`, `service_host`."
             }
           },
           {
             "workspace_identifier_default": {
               "required": true,
               "default": "workspace_id",
-              "description": "The default workspace identifier for metrics. This will take effect when a metric's workspace identifier is omitted. Allowed values are `workspace_id`, `workspace_name`.   ",
               "type": "string",
               "one_of": [
                 "workspace_id",
                 "workspace_name"
-              ]
+              ],
+              "description": "The default workspace identifier for metrics. This will take effect when a metric's workspace identifier is omitted. Allowed values are `workspace_id`, `workspace_name`.   "
             }
           },
           {
             "queue": {
+              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
                     "default": 1,
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
                     "default": 1,
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "type": "number",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
                     "default": 10000,
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
@@ -405,26 +407,26 @@
                 {
                   "max_retry_time": {
                     "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
-                    "type": "number"
+                    "type": "number",
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "type": "number",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
@@ -432,12 +434,10 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/statsd/3.4.x.json
+++ b/schemas/statsd/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,16 +23,18 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -43,15 +43,15 @@
           {
             "host": {
               "default": "localhost",
-              "description": "The IP address or hostname of StatsD server to send data to.",
-              "type": "string"
+              "type": "string",
+              "description": "The IP address or hostname of StatsD server to send data to."
             }
           },
           {
             "port": {
               "default": 8125,
-              "description": "The port of StatsD server to send data to.",
               "type": "integer",
+              "description": "The port of StatsD server to send data to.",
               "between": [
                 0,
                 65535
@@ -61,45 +61,45 @@
           {
             "prefix": {
               "default": "kong",
-              "description": "String to prefix to each metric's name.",
-              "type": "string"
+              "type": "string",
+              "description": "String to prefix to each metric's name."
             }
           },
           {
             "metrics": {
               "default": [
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "request_count"
+                  "name": "request_count",
+                  "stat_type": "counter"
                 },
                 {
                   "stat_type": "timer",
                   "name": "latency"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "request_size"
+                  "name": "request_size",
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "status_count"
+                  "name": "status_count",
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "response_size"
+                  "name": "response_size",
+                  "stat_type": "counter"
                 },
                 {
                   "stat_type": "set",
                   "name": "unique_users"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "request_per_user"
+                  "name": "request_per_user",
+                  "stat_type": "counter"
                 },
                 {
                   "stat_type": "timer",
@@ -110,49 +110,42 @@
                   "name": "kong_latency"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "status_count_per_user"
+                  "name": "status_count_per_user",
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "status_count_per_workspace"
+                  "name": "status_count_per_workspace",
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "status_count_per_user_per_route"
+                  "name": "status_count_per_user_per_route",
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "gauge",
                   "sample_rate": 1,
-                  "name": "shdict_usage"
+                  "name": "shdict_usage",
+                  "stat_type": "gauge"
                 },
                 {
-                  "stat_type": "gauge",
                   "sample_rate": 1,
-                  "name": "lmdb_usage"
+                  "name": "cache_datastore_hits_total",
+                  "stat_type": "counter"
                 },
                 {
-                  "stat_type": "counter",
                   "sample_rate": 1,
-                  "name": "cache_datastore_hits_total"
-                },
-                {
-                  "stat_type": "counter",
-                  "sample_rate": 1,
-                  "name": "cache_datastore_misses_total"
+                  "name": "cache_datastore_misses_total",
+                  "stat_type": "counter"
                 }
               ],
-              "description": "List of metrics to be logged.",
               "type": "array",
               "elements": {
+                "type": "record",
                 "fields": [
                   {
                     "name": {
-                      "type": "string",
-                      "description": "StatsD metric’s name.",
                       "one_of": [
                         "kong_latency",
                         "latency",
@@ -167,17 +160,16 @@
                         "status_count_per_workspace",
                         "status_count_per_user_per_route",
                         "shdict_usage",
-                        "lmdb_usage",
                         "cache_datastore_hits_total",
                         "cache_datastore_misses_total"
                       ],
-                      "required": true
+                      "type": "string",
+                      "required": true,
+                      "description": "StatsD metric’s name."
                     }
                   },
                   {
                     "stat_type": {
-                      "type": "string",
-                      "description": "Determines what sort of event a metric represents.",
                       "one_of": [
                         "counter",
                         "gauge",
@@ -186,79 +178,81 @@
                         "set",
                         "timer"
                       ],
-                      "required": true
+                      "type": "string",
+                      "required": true,
+                      "description": "Determines what sort of event a metric represents."
                     }
                   },
                   {
                     "sample_rate": {
-                      "description": "Sampling rate",
+                      "gt": 0,
                       "type": "number",
-                      "gt": 0
+                      "description": "Sampling rate"
                     }
                   },
                   {
                     "consumer_identifier": {
-                      "description": "Authenticated user detail.",
-                      "type": "string",
                       "one_of": [
                         "consumer_id",
                         "custom_id",
                         "username"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Authenticated user detail."
                     }
                   },
                   {
                     "service_identifier": {
-                      "description": "Service detail.",
-                      "type": "string",
                       "one_of": [
                         "service_id",
                         "service_name",
                         "service_host",
                         "service_name_or_host"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Service detail."
                     }
                   },
                   {
                     "workspace_identifier": {
-                      "description": "Workspace detail.",
-                      "type": "string",
                       "one_of": [
                         "workspace_id",
                         "workspace_name"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Workspace detail."
                     }
                   }
                 ],
-                "type": "record",
                 "entity_checks": [
                   {
                     "conditional": {
-                      "if_field": "stat_type",
-                      "then_field": "sample_rate",
                       "if_match": {
                         "one_of": [
                           "counter",
                           "gauge"
                         ]
                       },
+                      "then_field": "sample_rate",
+                      "if_field": "stat_type",
                       "then_match": {
                         "required": true
                       }
                     }
                   }
                 ]
-              }
+              },
+              "description": "List of metrics to be logged."
             }
           },
           {
             "allow_status_codes": {
-              "description": "List of status code ranges that are allowed to be logged in metrics.",
               "type": "array",
               "elements": {
                 "type": "string",
                 "match": "^[0-9]+-[0-9]+$"
-              }
+              },
+              "description": "List of status code ranges that are allowed to be logged in metrics."
             }
           },
           {
@@ -273,50 +267,50 @@
           },
           {
             "use_tcp": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "type": "boolean"
             }
           },
           {
             "hostname_in_prefix": {
-              "type": "boolean",
-              "default": false
+              "default": false,
+              "type": "boolean"
             }
           },
           {
             "consumer_identifier_default": {
               "default": "custom_id",
               "type": "string",
+              "required": true,
               "one_of": [
                 "consumer_id",
                 "custom_id",
                 "username"
-              ],
-              "required": true
+              ]
             }
           },
           {
             "service_identifier_default": {
               "default": "service_name_or_host",
               "type": "string",
+              "required": true,
               "one_of": [
                 "service_id",
                 "service_name",
                 "service_host",
                 "service_name_or_host"
-              ],
-              "required": true
+              ]
             }
           },
           {
             "workspace_identifier_default": {
               "default": "workspace_id",
               "type": "string",
+              "required": true,
               "one_of": [
                 "workspace_id",
                 "workspace_name"
-              ],
-              "required": true
+              ]
             }
           },
           {
@@ -337,49 +331,50 @@
           {
             "tag_style": {
               "type": "string",
+              "required": false,
               "one_of": [
                 "dogstatsd",
                 "influxdb",
                 "librato",
                 "signalfx"
-              ],
-              "required": false
+              ]
             }
           },
           {
             "queue": {
+              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
                     "default": 1,
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
                     "default": 1,
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "type": "number",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
                     "default": 10000,
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
@@ -391,26 +386,26 @@
                 {
                   "max_retry_time": {
                     "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
-                    "type": "number"
+                    "type": "number",
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "type": "number",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
@@ -418,13 +413,12 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "custom_entity_check": {

--- a/schemas/syslog/3.4.x.json
+++ b/schemas/syslog/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,25 +23,29 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "log_level": {
               "default": "info",
               "type": "string",
+              "required": true,
               "one_of": [
                 "debug",
                 "info",
@@ -53,14 +55,14 @@
                 "crit",
                 "alert",
                 "emerg"
-              ],
-              "required": true
+              ]
             }
           },
           {
             "successful_severity": {
               "default": "info",
               "type": "string",
+              "required": true,
               "one_of": [
                 "debug",
                 "info",
@@ -70,14 +72,14 @@
                 "crit",
                 "alert",
                 "emerg"
-              ],
-              "required": true
+              ]
             }
           },
           {
             "client_errors_severity": {
               "default": "info",
               "type": "string",
+              "required": true,
               "one_of": [
                 "debug",
                 "info",
@@ -87,14 +89,14 @@
                 "crit",
                 "alert",
                 "emerg"
-              ],
-              "required": true
+              ]
             }
           },
           {
             "server_errors_severity": {
               "default": "info",
               "type": "string",
+              "required": true,
               "one_of": [
                 "debug",
                 "info",
@@ -104,14 +106,11 @@
                 "crit",
                 "alert",
                 "emerg"
-              ],
-              "required": true
+              ]
             }
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "description": "Lua code as a key-value map",
               "values": {
                 "len_min": 1,
                 "type": "string"
@@ -119,14 +118,15 @@
               "keys": {
                 "type": "string",
                 "len_min": 1
-              }
+              },
+              "type": "map",
+              "description": "Lua code as a key-value map"
             }
           },
           {
             "facility": {
               "required": true,
               "default": "user",
-              "description": "The facility is used by the operating system to decide how to handle each log message.",
               "type": "string",
               "one_of": [
                 "auth",
@@ -149,11 +149,11 @@
                 "local5",
                 "local6",
                 "local7"
-              ]
+              ],
+              "description": "The facility is used by the operating system to decide how to handle each log message."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/tcp-log/3.4.x.json
+++ b/schemas/tcp-log/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,59 +23,62 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "host": {
-              "description": "The IP address or host name to send data to.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The IP address or host name to send data to."
             }
           },
           {
             "port": {
+              "description": "The port to send data to on the upstream server.",
+              "type": "integer",
+              "required": true,
               "between": [
                 0,
                 65535
-              ],
-              "description": "The port to send data to on the upstream server.",
-              "type": "integer",
-              "required": true
+              ]
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional timeout in milliseconds when sending data to the upstream server."
             }
           },
           {
             "keepalive": {
               "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed."
             }
           },
           {
             "tls": {
               "default": false,
-              "description": "Indicates whether to perform a TLS handshake against the remote server.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Indicates whether to perform a TLS handshake against the remote server."
             }
           },
           {
@@ -88,20 +89,19 @@
           },
           {
             "custom_fields_by_lua": {
-              "values": {
-                "len_min": 1,
-                "type": "string"
-              },
               "description": "A list of key-value pairs, where the key is the name of a log field and the value is a chunk of Lua code, whose return value sets or replaces the log field value.",
-              "type": "map",
               "keys": {
                 "type": "string",
                 "len_min": 1
+              },
+              "type": "map",
+              "values": {
+                "len_min": 1,
+                "type": "string"
               }
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/tls-handshake-modifier/3.4.x.json
+++ b/schemas/tls-handshake-modifier/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -14,8 +14,8 @@
           "https",
           "grpcs"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -29,27 +29,27 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "tls_client_certificate": {
               "required": false,
               "default": "REQUEST",
-              "description": "TLS Client Certificate",
               "type": "string",
               "one_of": [
                 "REQUEST"
-              ]
+              ],
+              "description": "TLS Client Certificate"
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/tls-metadata-headers/3.4.x.json
+++ b/schemas/tls-metadata-headers/3.4.x.json
@@ -3,9 +3,9 @@
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -14,8 +14,8 @@
           "https",
           "grpcs"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -29,63 +29,63 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "inject_client_cert_details": {
               "default": false,
-              "description": "Enables TLS client certificate metadata values to be injected into HTTP headers.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Enables TLS client certificate metadata values to be injected into HTTP headers."
             }
           },
           {
             "client_cert_header_name": {
               "default": "X-Client-Cert",
-              "description": "Define the HTTP header name used for the PEM format URL encoded client certificate.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Define the HTTP header name used for the PEM format URL encoded client certificate."
             }
           },
           {
             "client_serial_header_name": {
               "default": "X-Client-Cert-Serial",
-              "description": "Define the HTTP header name used for the serial number of the client certificate.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Define the HTTP header name used for the serial number of the client certificate."
             }
           },
           {
             "client_cert_issuer_dn_header_name": {
               "default": "X-Client-Cert-Issuer-DN",
-              "description": "Define the HTTP header name used for the issuer DN of the client certificate.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Define the HTTP header name used for the issuer DN of the client certificate."
             }
           },
           {
             "client_cert_subject_dn_header_name": {
               "default": "X-Client-Cert-Subject-DN",
-              "description": "Define the HTTP header name used for the subject DN of the client certificate.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Define the HTTP header name used for the subject DN of the client certificate."
             }
           },
           {
             "client_cert_fingerprint_header_name": {
               "default": "X-Client-Cert-Fingerprint",
-              "description": "Define the HTTP header name used for the SHA1 fingerprint of the client certificate.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "Define the HTTP header name used for the SHA1 fingerprint of the client certificate."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/udp-log/3.4.x.json
+++ b/schemas/udp-log/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,50 +23,51 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "host": {
-              "description": "A string representing a host name, such as example.com.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
+              "description": "An integer representing a port number between 0 and 65535, inclusive.",
+              "type": "integer",
+              "required": true,
               "between": [
                 0,
                 65535
-              ],
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "type": "integer",
-              "required": true
+              ]
             }
           },
           {
             "timeout": {
               "default": 10000,
-              "description": "An optional timeout in milliseconds when sending data to the upstream server.",
-              "type": "number"
+              "type": "number",
+              "description": "An optional timeout in milliseconds when sending data to the upstream server."
             }
           },
           {
             "custom_fields_by_lua": {
-              "type": "map",
-              "description": "Lua code as a key-value map",
               "values": {
                 "len_min": 1,
                 "type": "string"
@@ -76,11 +75,12 @@
               "keys": {
                 "type": "string",
                 "len_min": 1
-              }
+              },
+              "type": "map",
+              "description": "Lua code as a key-value map"
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/upstream-timeout/3.4.x.json
+++ b/schemas/upstream-timeout/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,52 +18,53 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "read_timeout": {
+              "type": "integer",
               "between": [
                 0,
                 2147483646
               ],
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-              "type": "integer"
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
             "send_timeout": {
+              "type": "integer",
               "between": [
                 0,
                 2147483646
               ],
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-              "type": "integer"
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
             "connect_timeout": {
+              "type": "integer",
               "between": [
                 0,
                 2147483646
               ],
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
-              "type": "integer"
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/vault-auth/3.4.x.json
+++ b/schemas/vault-auth/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,65 +18,67 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
         "reference": "consumers",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "access_token_name": {
               "required": true,
               "default": "access_token",
-              "description": "Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
               "type": "string",
               "elements": {
-                "type": "string",
-                "description": "A string representing an HTTP header name."
-              }
+                "description": "A string representing an HTTP header name.",
+                "type": "string"
+              },
+              "description": "Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-]."
             }
           },
           {
             "secret_token_name": {
               "required": true,
               "default": "secret_token",
-              "description": "Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
               "type": "string",
               "elements": {
-                "type": "string",
-                "description": "A string representing an HTTP header name."
-              }
+                "description": "A string representing an HTTP header name.",
+                "type": "string"
+              },
+              "description": "Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-]."
             }
           },
           {
             "vault": {
               "reference": "vault_auth_vaults",
-              "description": "A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.",
               "type": "foreign",
-              "required": true
+              "required": true,
+              "description": "A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API."
             }
           },
           {
             "hide_credentials": {
               "default": false,
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the header or querystring containing the key) before proxying it.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the header or querystring containing the key) before proxying it."
             }
           },
           {
@@ -89,19 +90,18 @@
           {
             "tokens_in_body": {
               "default": false,
-              "description": "If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "If enabled, the plugin will read the request body (if said request has one and its MIME type is supported) and try to find the key in it. Supported MIME types are `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`."
             }
           },
           {
             "run_on_preflight": {
               "default": true,
-              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed."
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }

--- a/schemas/websocket-size-limit/3.4.x.json
+++ b/schemas/websocket-size-limit/3.4.x.json
@@ -6,8 +6,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -20,9 +20,9 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -30,27 +30,27 @@
         "fields": [
           {
             "client_max_payload": {
+              "type": "integer",
+              "required": false,
               "between": [
                 1,
                 33554432
-              ],
-              "type": "integer",
-              "required": false
+              ]
             }
           },
           {
             "upstream_max_payload": {
+              "type": "integer",
+              "required": false,
               "between": [
                 1,
                 33554432
-              ],
-              "type": "integer",
-              "required": false
+              ]
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [

--- a/schemas/websocket-validator/3.4.x.json
+++ b/schemas/websocket-validator/3.4.x.json
@@ -6,8 +6,8 @@
           "ws",
           "wss"
         ],
-        "required": true,
         "type": "set",
+        "required": true,
         "elements": {
           "type": "string",
           "one_of": [
@@ -20,9 +20,9 @@
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -31,19 +31,31 @@
           {
             "client": {
               "required": false,
-              "entity_checks": [
-                {
-                  "at_least_one_of": [
-                    "text",
-                    "binary"
-                  ]
-                }
-              ],
               "type": "record",
               "fields": [
                 {
                   "text": {
                     "required": false,
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "type": "string",
+                          "required": true,
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported."
+                        }
+                      },
+                      {
+                        "schema": {
+                          "type": "string",
+                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                        }
+                      }
+                    ],
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -51,26 +63,6 @@
                             "type",
                             "schema"
                           ]
-                        }
-                      }
-                    ],
-                    "type": "record",
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
-                          "one_of": [
-                            "draft4"
-                          ],
-                          "required": true
-                        }
-                      },
-                      {
-                        "schema": {
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
-                          "type": "string",
-                          "required": true
                         }
                       }
                     ]
@@ -79,6 +71,26 @@
                 {
                   "binary": {
                     "required": false,
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "type": "string",
+                          "required": true,
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported."
+                        }
+                      },
+                      {
+                        "schema": {
+                          "type": "string",
+                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                        }
+                      }
+                    ],
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -88,28 +100,16 @@
                           ]
                         }
                       }
-                    ],
-                    "type": "record",
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
-                          "one_of": [
-                            "draft4"
-                          ],
-                          "required": true
-                        }
-                      },
-                      {
-                        "schema": {
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
-                          "type": "string",
-                          "required": true
-                        }
-                      }
                     ]
                   }
+                }
+              ],
+              "entity_checks": [
+                {
+                  "at_least_one_of": [
+                    "text",
+                    "binary"
+                  ]
                 }
               ]
             }
@@ -117,19 +117,31 @@
           {
             "upstream": {
               "required": false,
-              "entity_checks": [
-                {
-                  "at_least_one_of": [
-                    "text",
-                    "binary"
-                  ]
-                }
-              ],
               "type": "record",
               "fields": [
                 {
                   "text": {
                     "required": false,
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "type": "string",
+                          "required": true,
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported."
+                        }
+                      },
+                      {
+                        "schema": {
+                          "type": "string",
+                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                        }
+                      }
+                    ],
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -137,26 +149,6 @@
                             "type",
                             "schema"
                           ]
-                        }
-                      }
-                    ],
-                    "type": "record",
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
-                          "one_of": [
-                            "draft4"
-                          ],
-                          "required": true
-                        }
-                      },
-                      {
-                        "schema": {
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
-                          "type": "string",
-                          "required": true
                         }
                       }
                     ]
@@ -165,6 +157,26 @@
                 {
                   "binary": {
                     "required": false,
+                    "type": "record",
+                    "fields": [
+                      {
+                        "type": {
+                          "one_of": [
+                            "draft4"
+                          ],
+                          "type": "string",
+                          "required": true,
+                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported."
+                        }
+                      },
+                      {
+                        "schema": {
+                          "type": "string",
+                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                        }
+                      }
+                    ],
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -174,35 +186,23 @@
                           ]
                         }
                       }
-                    ],
-                    "type": "record",
-                    "fields": [
-                      {
-                        "type": {
-                          "type": "string",
-                          "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
-                          "one_of": [
-                            "draft4"
-                          ],
-                          "required": true
-                        }
-                      },
-                      {
-                        "schema": {
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
-                          "type": "string",
-                          "required": true
-                        }
-                      }
                     ]
                   }
+                }
+              ],
+              "entity_checks": [
+                {
+                  "at_least_one_of": [
+                    "text",
+                    "binary"
+                  ]
                 }
               ]
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "at_least_one_of": [

--- a/schemas/xml-threat-protection/3.4.x.json
+++ b/schemas/xml-threat-protection/3.4.x.json
@@ -9,7 +9,6 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing HTTP protocols.",
         "type": "set",
         "elements": {
           "type": "string",
@@ -19,15 +18,16 @@
             "http",
             "https"
           ]
-        }
+        },
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -39,13 +39,13 @@
               "default": [
                 "application/xml"
               ],
-              "description": "A list of Content-Type values with payloads that must be validated.",
               "type": "set",
               "elements": {
+                "match": "^[^%s]+%/[^ ;]+$",
                 "required": true,
-                "type": "string",
-                "match": "^[^%s]+%/[^ ;]+$"
-              }
+                "type": "string"
+              },
+              "description": "A list of Content-Type values with payloads that must be validated."
             }
           },
           {
@@ -54,29 +54,29 @@
               "default": [
 
               ],
-              "description": "A list of Content-Type values with payloads that are allowed, but aren't validated.",
               "type": "set",
               "elements": {
+                "match": "^[^%s]+%/[^ ;]+$",
                 "required": true,
-                "type": "string",
-                "match": "^[^%s]+%/[^ ;]+$"
-              }
+                "type": "string"
+              },
+              "description": "A list of Content-Type values with payloads that are allowed, but aren't validated."
             }
           },
           {
             "allow_dtd": {
               "default": false,
-              "description": "Indicates whether an XML Document Type Definition (DTD) section is allowed.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Indicates whether an XML Document Type Definition (DTD) section is allowed."
             }
           },
           {
             "namespace_aware": {
               "default": true,
-              "description": "If not parsing namespace aware, all prefixes and namespace attributes will be counted as regular attributes and element names, and validated as such.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "If not parsing namespace aware, all prefixes and namespace attributes will be counted as regular attributes and element names, and validated as such."
             }
           },
           {
@@ -84,8 +84,8 @@
               "gt": 0,
               "required": true,
               "default": 50,
-              "description": "Maximum depth of tags. Child elements such as Text or Comments are not counted as another level.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum depth of tags. Child elements such as Text or Comments are not counted as another level."
             }
           },
           {
@@ -93,8 +93,8 @@
               "gt": 0,
               "required": true,
               "default": 100,
-              "description": "Maximum number of children allowed (Element, Text, Comment, ProcessingInstruction, CDATASection). Note: Adjacent text and CDATA sections are counted as one. For example, text-cdata-text-cdata is one child.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of children allowed (Element, Text, Comment, ProcessingInstruction, CDATASection). Note: Adjacent text and CDATA sections are counted as one. For example, text-cdata-text-cdata is one child."
             }
           },
           {
@@ -102,8 +102,8 @@
               "gt": 0,
               "required": true,
               "default": 100,
-              "description": "Maximum number of attributes allowed on a tag, including default ones. Note: If namespace-aware parsing is disabled, then the namespaces definitions are counted as attributes.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of attributes allowed on a tag, including default ones. Note: If namespace-aware parsing is disabled, then the namespaces definitions are counted as attributes."
             }
           },
           {
@@ -111,8 +111,8 @@
               "gt": 0,
               "required": false,
               "default": 20,
-              "description": "Maximum number of namespaces defined on a tag. This value is required if parsing is namespace-aware.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of namespaces defined on a tag. This value is required if parsing is namespace-aware."
             }
           },
           {
@@ -120,8 +120,8 @@
               "gt": 0,
               "required": true,
               "default": 10485760,
-              "description": "Maximum size of the entire document.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of the entire document."
             }
           },
           {
@@ -129,8 +129,8 @@
               "gt": 0,
               "required": true,
               "default": 1048576,
-              "description": "Maximum size of the unparsed buffer (see below).",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of the unparsed buffer (see below)."
             }
           },
           {
@@ -138,8 +138,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of comments.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of comments."
             }
           },
           {
@@ -147,8 +147,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of the localname. This applies to tags and attributes.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of the localname. This applies to tags and attributes."
             }
           },
           {
@@ -156,8 +156,8 @@
               "gt": 0,
               "required": false,
               "default": 1024,
-              "description": "Maximum size of the prefix. This applies to tags and attributes. This value is required if parsing is namespace-aware.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of the prefix. This applies to tags and attributes. This value is required if parsing is namespace-aware."
             }
           },
           {
@@ -165,8 +165,8 @@
               "gt": 0,
               "required": false,
               "default": 1024,
-              "description": "Maximum size of the namespace URI. This value is required if parsing is namespace-aware.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of the namespace URI. This value is required if parsing is namespace-aware."
             }
           },
           {
@@ -174,8 +174,8 @@
               "gt": 0,
               "required": true,
               "default": 1048576,
-              "description": "Maximum size of the attribute value.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of the attribute value."
             }
           },
           {
@@ -183,8 +183,8 @@
               "gt": 0,
               "required": true,
               "default": 1048576,
-              "description": "Maximum text inside tags (counted over all adjacent text/CDATA elements combined).",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum text inside tags (counted over all adjacent text/CDATA elements combined)."
             }
           },
           {
@@ -192,8 +192,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of processing instruction targets.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of processing instruction targets."
             }
           },
           {
@@ -201,8 +201,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of processing instruction data.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of processing instruction data."
             }
           },
           {
@@ -210,8 +210,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of entity names in EntityDecl.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of entity names in EntityDecl."
             }
           },
           {
@@ -219,8 +219,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of entity values in EntityDecl.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of entity values in EntityDecl."
             }
           },
           {
@@ -228,8 +228,8 @@
               "gt": 0,
               "required": true,
               "default": 1024,
-              "description": "Maximum size of systemId, publicId, or notationName in EntityDecl.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum size of systemId, publicId, or notationName in EntityDecl."
             }
           },
           {
@@ -237,8 +237,8 @@
               "gt": 1,
               "required": true,
               "default": 100,
-              "description": "Sets the maximum allowed amplification. This protects against the Billion Laughs Attack.",
-              "type": "number"
+              "type": "number",
+              "description": "Sets the maximum allowed amplification. This protects against the Billion Laughs Attack."
             }
           },
           {
@@ -246,21 +246,21 @@
               "gt": 1024,
               "required": true,
               "default": 8388608,
-              "description": "Sets the threshold after which the protection starts. This protects against the Billion Laughs Attack.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Sets the threshold after which the protection starts. This protects against the Billion Laughs Attack."
             }
           }
         ],
-        "required": true,
         "type": "record",
+        "required": true,
         "entity_checks": [
           {
             "conditional": {
-              "if_field": "namespace_aware",
+              "if_match": {
+                "eq": true
+              },
               "then_field": "max_namespaces",
-              "if_match": {
-                "eq": true
-              },
+              "if_field": "namespace_aware",
               "then_match": {
                 "required": true
               }
@@ -268,11 +268,11 @@
           },
           {
             "conditional": {
-              "if_field": "namespace_aware",
+              "if_match": {
+                "eq": true
+              },
               "then_field": "prefix",
-              "if_match": {
-                "eq": true
-              },
+              "if_field": "namespace_aware",
               "then_match": {
                 "required": true
               }
@@ -280,11 +280,11 @@
           },
           {
             "conditional": {
-              "if_field": "namespace_aware",
-              "then_field": "namespaceuri",
               "if_match": {
                 "eq": true
               },
+              "then_field": "namespaceuri",
+              "if_field": "namespace_aware",
               "then_match": {
                 "required": true
               }

--- a/schemas/zipkin/3.4.x.json
+++ b/schemas/zipkin/3.4.x.json
@@ -9,10 +9,8 @@
           "http",
           "https"
         ],
-        "description": "A set of strings representing protocols.",
         "type": "set",
         "elements": {
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
           "type": "string",
           "one_of": [
             "grpc",
@@ -25,40 +23,43 @@
             "udp",
             "ws",
             "wss"
-          ]
-        }
+          ],
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        },
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "reference": "consumer_groups",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null,
         "type": "foreign",
-        "eq": null
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
+        "type": "record",
         "fields": [
           {
             "local_service_name": {
               "default": "kong",
-              "description": "The name of the service as displayed in Zipkin.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The name of the service as displayed in Zipkin."
             }
           },
           {
             "http_endpoint": {
-              "type": "string",
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
+              "type": "string"
             }
           },
           {
             "sample_ratio": {
               "default": 0.001,
-              "description": "How often to sample requests that do not contain trace IDs. Set to `0` to turn sampling off, or to `1` to sample **all** requests. ",
               "type": "number",
+              "description": "How often to sample requests that do not contain trace IDs. Set to `0` to turn sampling off, or to `1` to sample **all** requests. ",
               "between": [
                 0,
                 1
@@ -74,28 +75,27 @@
           {
             "include_credential": {
               "default": true,
-              "description": "Specify whether the credential of the currently authenticated consumer should be included in metadata sent to the Zipkin server.",
               "type": "boolean",
-              "required": true
+              "required": true,
+              "description": "Specify whether the credential of the currently authenticated consumer should be included in metadata sent to the Zipkin server."
             }
           },
           {
             "traceid_byte_count": {
               "required": true,
               "default": 16,
-              "description": "The length in bytes of each request's Trace ID.",
               "type": "integer",
               "one_of": [
                 8,
                 16
-              ]
+              ],
+              "description": "The length in bytes of each request's Trace ID."
             }
           },
           {
             "header_type": {
               "required": true,
               "default": "preserve",
-              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests",
               "type": "string",
               "one_of": [
                 "preserve",
@@ -107,14 +107,14 @@
                 "ot",
                 "aws",
                 "datadog"
-              ]
+              ],
+              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests"
             }
           },
           {
             "default_header_type": {
               "required": true,
               "default": "b3",
-              "description": "Allows specifying the type of header to be added to requests with no pre-existing tracing headers and when `config.header_type` is set to `\"preserve\"`. When `header_type` is set to any other value, `default_header_type` is ignored.",
               "type": "string",
               "one_of": [
                 "b3",
@@ -124,28 +124,27 @@
                 "ot",
                 "aws",
                 "datadog"
-              ]
+              ],
+              "description": "Allows specifying the type of header to be added to requests with no pre-existing tracing headers and when `config.header_type` is set to `\"preserve\"`. When `header_type` is set to any other value, `default_header_type` is ignored."
             }
           },
           {
             "tags_header": {
               "default": "Zipkin-Tags",
-              "description": "The Zipkin plugin will add extra headers to the tags associated with any HTTP requests that come with a header named as configured by this property.",
               "type": "string",
-              "required": true
+              "required": true,
+              "description": "The Zipkin plugin will add extra headers to the tags associated with any HTTP requests that come with a header named as configured by this property."
             }
           },
           {
             "static_tags": {
-              "description": "The tags specified on this property will be added to the generated request traces.",
               "type": "array",
               "elements": {
-                "type": "record",
                 "fields": [
                   {
                     "name": {
-                      "required": true,
                       "type": "string",
+                      "required": true,
                       "not_one_of": [
                         "error",
                         "http.method",
@@ -165,31 +164,33 @@
                   },
                   {
                     "value": {
-                      "type": "string",
-                      "required": true
+                      "required": true,
+                      "type": "string"
                     }
                   }
-                ]
-              }
+                ],
+                "type": "record"
+              },
+              "description": "The tags specified on this property will be added to the generated request traces."
             }
           },
           {
             "http_span_name": {
               "required": true,
               "default": "method",
-              "description": "Specify whether to include the HTTP path in the span name.",
               "type": "string",
               "one_of": [
                 "method",
                 "method_path"
-              ]
+              ],
+              "description": "Specify whether to include the HTTP path in the span name."
             }
           },
           {
             "connect_timeout": {
               "default": 2000,
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
@@ -199,8 +200,8 @@
           {
             "send_timeout": {
               "default": 5000,
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
@@ -210,8 +211,8 @@
           {
             "read_timeout": {
               "default": 5000,
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
@@ -227,48 +228,49 @@
             "phase_duration_flavor": {
               "required": true,
               "default": "annotations",
-              "description": "Specify whether to include the duration of each phase as an annotation or a tag.",
               "type": "string",
               "one_of": [
                 "annotations",
                 "tags"
-              ]
+              ],
+              "description": "Specify whether to include the duration of each phase as an annotation or a tag."
             }
           },
           {
             "queue": {
+              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
                     "default": 1,
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
                     "default": 1,
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "type": "number",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
                     "default": 10000,
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "type": "integer",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
@@ -280,26 +282,26 @@
                 {
                   "max_retry_time": {
                     "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
-                    "type": "number"
+                    "type": "number",
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
                   }
                 },
                 {
                   "initial_retry_delay": {
                     "default": 0.01,
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "type": "number",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
                     "default": 60,
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
@@ -307,12 +309,10 @@
                   }
                 }
               ],
-              "type": "record",
               "required": true
             }
           }
         ],
-        "type": "record",
         "required": true
       }
     }


### PR DESCRIPTION
Pulled the latest plugin schemas and referenceable fields using the README instructions.

Running into the same issue with the app registration plugin example validation as you ran into before, @fabianrbz . I tested manually though, and the example seems to work 🤷 so I think we're good to ignore that for now.