### PR TITLE
Generate examples for the post-function plugin

### DIFF
--- a/examples/post-function/_2.6.x.yaml
+++ b/examples/post-function/_2.6.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_2.7.x.yaml
+++ b/examples/post-function/_2.7.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_2.8.x.yaml
+++ b/examples/post-function/_2.8.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_3.0.x.yaml
+++ b/examples/post-function/_3.0.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_3.1.x.yaml
+++ b/examples/post-function/_3.1.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_3.2.x.yaml
+++ b/examples/post-function/_3.2.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_3.3.x.yaml
+++ b/examples/post-function/_3.3.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)

--- a/examples/post-function/_3.4.x.yaml
+++ b/examples/post-function/_3.4.x.yaml
@@ -1,0 +1,6 @@
+name: post-function
+config:
+  access:
+    - |
+      kong.log.err("foo")
+      kong.response.exit(418)


### PR DESCRIPTION
The plugin hub current has "serverless plugins" as one plugin listing. I'm working on splitting that out into two real plugins, post-function and pre-function. To do that properly, we need to generate the examples for the plugin. 