### PR TITLE
Fix: Typo in exit transformer examples

### DIFF
--- a/examples/exit-transformer/_2.4.x.yaml
+++ b/examples/exit-transformer/_2.4.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_2.5.x.yaml
+++ b/examples/exit-transformer/_2.5.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_2.6.x.yaml
+++ b/examples/exit-transformer/_2.6.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_2.7.x.yaml
+++ b/examples/exit-transformer/_2.7.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_2.8.x.yaml
+++ b/examples/exit-transformer/_2.8.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_3.0.x.yaml
+++ b/examples/exit-transformer/_3.0.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_3.1.x.yaml
+++ b/examples/exit-transformer/_3.1.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_3.2.x.yaml
+++ b/examples/exit-transformer/_3.2.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_3.3.x.yaml
+++ b/examples/exit-transformer/_3.3.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"

--- a/examples/exit-transformer/_3.4.x.yaml
+++ b/examples/exit-transformer/_3.4.x.yaml
@@ -1,4 +1,4 @@
 name: exit-transformer
 config:
   functions:
-    - "return function(status, body, header) return status, body, headers end"
+    - "return function(status, body, headers) return status, body, headers end"


### PR DESCRIPTION
Typo `header` instead of `headers` in the examples for the Exit Transformer plugin.

From slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1696588432212259