### PR TITLE
Chore: Regenerate 3.5 schemas

### DIFF
--- a/schemas/acl/3.4.x.json
+++ b/schemas/acl/3.4.x.json
@@ -45,7 +45,8 @@
             "allow": {
               "type": "array",
               "elements": {
-                "type": "string"
+                "type": "string",
+                "description": "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified."
               }
             }
           },
@@ -53,7 +54,8 @@
             "deny": {
               "type": "array",
               "elements": {
-                "type": "string"
+                "type": "string",
+                "description": "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified."
               }
             }
           },
@@ -61,6 +63,7 @@
             "hide_groups_header": {
               "default": false,
               "type": "boolean",
+              "description": "If enabled (`true`), prevents the `X-Consumer-Groups` header from being sent in the request to the upstream service.",
               "required": true
             }
           }

--- a/schemas/acl/3.5.x.json
+++ b/schemas/acl/3.5.x.json
@@ -3,21 +3,29 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -27,46 +35,38 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "allow": {
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "deny": {
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
           },
           {
             "hide_groups_header": {
-              "required": true,
+              "default": false,
               "type": "boolean",
-              "default": false
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/acl/3.5.x.json
+++ b/schemas/acl/3.5.x.json
@@ -45,7 +45,8 @@
             "allow": {
               "type": "array",
               "elements": {
-                "type": "string"
+                "type": "string",
+                "description": "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified."
               }
             }
           },
@@ -53,7 +54,8 @@
             "deny": {
               "type": "array",
               "elements": {
-                "type": "string"
+                "type": "string",
+                "description": "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified."
               }
             }
           },
@@ -61,6 +63,7 @@
             "hide_groups_header": {
               "default": false,
               "type": "boolean",
+              "description": "If enabled (`true`), prevents the `X-Consumer-Groups` header from being sent in the request to the upstream service.",
               "required": true
             }
           }

--- a/schemas/acme/3.5.x.json
+++ b/schemas/acme/3.5.x.json
@@ -3,37 +3,45 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "service": {
         "type": "foreign",
-        "description": "A reference to the 'services' table with a null value allowed.",
         "eq": null,
-        "reference": "services"
+        "reference": "services",
+        "description": "A reference to the 'services' table with a null value allowed."
       }
     },
     {
       "route": {
         "type": "foreign",
-        "description": "A reference to the 'routes' table with a null value allowed.",
         "eq": null,
-        "reference": "routes"
+        "reference": "routes",
+        "description": "A reference to the 'routes' table with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -43,52 +51,42 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "account_email": {
-              "referenceable": true,
-              "description": "The account identifier. Can be reused in a different plugin instance.",
-              "encrypted": true,
-              "type": "string",
               "match": "%w*%p*@+%w*%.?%w*",
-              "required": true
+              "required": true,
+              "encrypted": true,
+              "referenceable": true,
+              "type": "string",
+              "description": "The account identifier. Can be reused in a different plugin instance."
             }
           },
           {
             "account_key": {
-              "required": false,
-              "type": "record",
               "description": "The private key associated with the account.",
               "fields": [
                 {
                   "key_id": {
-                    "required": true,
+                    "description": "The Key ID.",
                     "type": "string",
-                    "description": "The Key ID."
+                    "required": true
                   }
                 },
                 {
                   "key_set": {
-                    "description": "The ID of the key set to associate the Key ID with.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The ID of the key set to associate the Key ID with."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": false
             }
           },
           {
@@ -107,41 +105,41 @@
           },
           {
             "eab_kid": {
-              "encrypted": true,
-              "type": "string",
               "description": "External account binding (EAB) key id. You usually don't need to set this unless it is explicitly required by the CA.",
-              "referenceable": true
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true
             }
           },
           {
             "eab_hmac_key": {
-              "encrypted": true,
-              "type": "string",
               "description": "External account binding (EAB) base64-encoded URL string of the HMAC key. You usually don't need to set this unless it is explicitly required by the CA.",
-              "referenceable": true
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true
             }
           },
           {
             "cert_type": {
-              "default": "rsa",
-              "type": "string",
-              "description": "The certificate type to create. The possible values are `'rsa'` for RSA certificate or `'ecc'` for EC certificate.",
               "one_of": [
                 "rsa",
                 "ecc"
-              ]
+              ],
+              "default": "rsa",
+              "type": "string",
+              "description": "The certificate type to create. The possible values are `'rsa'` for RSA certificate or `'ecc'` for EC certificate."
             }
           },
           {
             "rsa_key_size": {
-              "default": 4096,
-              "type": "number",
-              "description": "RSA private key size for the certificate. The possible values are 2048, 3072, or 4096.",
               "one_of": [
                 2048,
                 3072,
                 4096
-              ]
+              ],
+              "default": 4096,
+              "type": "number",
+              "description": "RSA private key size for the certificate. The possible values are 2048, 3072, or 4096."
             }
           },
           {
@@ -190,27 +188,23 @@
           },
           {
             "storage": {
-              "default": "shm",
-              "type": "string",
-              "description": "The backend storage type to use. The possible values are `'kong'`, `'shm'`, `'redis'`, `'consul'`, or `'vault'`. In DB-less mode, `'kong'` storage is unavailable. Note that `'shm'` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `'kong'`, `'redis'`, `'consul'`, or `'vault'` in production. Please refer to the Hybrid Mode sections below as well.",
               "one_of": [
                 "kong",
                 "shm",
                 "redis",
                 "consul",
                 "vault"
-              ]
+              ],
+              "default": "shm",
+              "type": "string",
+              "description": "The backend storage type to use. The possible values are `'kong'`, `'shm'`, `'redis'`, `'consul'`, or `'vault'`. In DB-less mode, `'kong'` storage is unavailable. Note that `'shm'` storage does not persist during Kong restarts and does not work for Kong running on different machines, so consider using one of `'kong'`, `'redis'`, `'consul'`, or `'vault'` in production. Please refer to the Hybrid Mode sections below as well."
             }
           },
           {
             "storage_config": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "shm": {
-                    "required": true,
-                    "type": "record",
                     "fields": [
                       {
                         "shm_name": {
@@ -219,27 +213,27 @@
                           "description": "Name of shared memory zone used for Kong API gateway storage"
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "kong": {
-                    "required": true,
-                    "type": "record",
                     "fields": [
 
-                    ]
+                    ],
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "redis": {
-                    "required": true,
-                    "type": "record",
                     "fields": [
                       {
                         "host": {
-                          "description": "A string representing a host name, such as example.com.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "A string representing a host name, such as example.com."
                         }
                       },
                       {
@@ -254,30 +248,30 @@
                       },
                       {
                         "database": {
-                          "description": "The index of the Redis database to use.",
-                          "type": "number"
+                          "type": "number",
+                          "description": "The index of the Redis database to use."
                         }
                       },
                       {
                         "auth": {
+                          "referenceable": true,
                           "type": "string",
-                          "description": "The Redis password to use for authentication. ",
-                          "referenceable": true
+                          "description": "The Redis password to use for authentication. "
                         }
                       },
                       {
                         "ssl": {
+                          "description": "Whether to use SSL/TLS encryption when connecting to the Redis server.",
                           "default": false,
                           "type": "boolean",
-                          "description": "Whether to use SSL/TLS encryption when connecting to the Redis server.",
                           "required": true
                         }
                       },
                       {
                         "ssl_verify": {
+                          "description": "Whether to verify the SSL/TLS certificate presented by the Redis server. This should be a boolean value.",
                           "default": false,
                           "type": "boolean",
-                          "description": "Whether to verify the SSL/TLS certificate presented by the Redis server. This should be a boolean value.",
                           "required": true
                         }
                       },
@@ -290,28 +284,28 @@
                       },
                       {
                         "namespace": {
-                          "len_min": 0,
                           "type": "string",
-                          "description": "A namespace to prepend to all keys stored in Redis.",
+                          "required": true,
+                          "len_min": 0,
                           "default": "",
-                          "required": true
+                          "description": "A namespace to prepend to all keys stored in Redis."
                         }
                       },
                       {
                         "scan_count": {
+                          "description": "The number of keys to return in Redis SCAN calls.",
                           "default": 10,
                           "type": "number",
-                          "description": "The number of keys to return in Redis SCAN calls.",
                           "required": false
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "consul": {
-                    "required": true,
-                    "type": "record",
                     "fields": [
                       {
                         "https": {
@@ -322,8 +316,8 @@
                       },
                       {
                         "host": {
-                          "description": "A string representing a host name, such as example.com.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "A string representing a host name, such as example.com."
                         }
                       },
                       {
@@ -338,30 +332,30 @@
                       },
                       {
                         "kv_path": {
-                          "description": "KV prefix path.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "KV prefix path."
                         }
                       },
                       {
                         "timeout": {
-                          "description": "Timeout in milliseconds.",
-                          "type": "number"
+                          "type": "number",
+                          "description": "Timeout in milliseconds."
                         }
                       },
                       {
                         "token": {
+                          "referenceable": true,
                           "type": "string",
-                          "description": "Consul ACL token.",
-                          "referenceable": true
+                          "description": "Consul ACL token."
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": true
                   }
                 },
                 {
                   "vault": {
-                    "required": true,
-                    "type": "record",
                     "fields": [
                       {
                         "https": {
@@ -372,8 +366,8 @@
                       },
                       {
                         "host": {
-                          "description": "A string representing a host name, such as example.com.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "A string representing a host name, such as example.com."
                         }
                       },
                       {
@@ -388,21 +382,21 @@
                       },
                       {
                         "kv_path": {
-                          "description": "KV prefix path.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "KV prefix path."
                         }
                       },
                       {
                         "timeout": {
-                          "description": "Timeout in milliseconds.",
-                          "type": "number"
+                          "type": "number",
+                          "description": "Timeout in milliseconds."
                         }
                       },
                       {
                         "token": {
+                          "referenceable": true,
                           "type": "string",
-                          "description": "Consul ACL token.",
-                          "referenceable": true
+                          "description": "Consul ACL token."
                         }
                       },
                       {
@@ -414,49 +408,53 @@
                       },
                       {
                         "tls_server_name": {
-                          "description": "SNI used in request, default to host if omitted.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "SNI used in request, default to host if omitted."
                         }
                       },
                       {
                         "auth_method": {
-                          "default": "token",
-                          "type": "string",
-                          "description": "Auth Method, default to token, can be 'token' or 'kubernetes'.",
                           "one_of": [
                             "token",
                             "kubernetes"
-                          ]
+                          ],
+                          "default": "token",
+                          "type": "string",
+                          "description": "Auth Method, default to token, can be 'token' or 'kubernetes'."
                         }
                       },
                       {
                         "auth_path": {
-                          "description": "Vault's authentication path to use.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "Vault's authentication path to use."
                         }
                       },
                       {
                         "auth_role": {
-                          "description": "The role to try and assign.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "The role to try and assign."
                         }
                       },
                       {
                         "jwt_path": {
-                          "description": "The path to the JWT.",
-                          "type": "string"
+                          "type": "string",
+                          "description": "The path to the JWT."
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": true
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "preferred_chain": {
-              "description": "A string value that specifies the preferred certificate chain to use when generating certificates.",
-              "type": "string"
+              "type": "string",
+              "description": "A string value that specifies the preferred certificate chain to use when generating certificates."
             }
           },
           {
@@ -466,25 +464,27 @@
               "description": "A boolean value that controls whether to include the IPv4 address in the common name field of generated certificates."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],
   "entity_checks": [
     {
       "conditional": {
-        "then_field": "config.tos_accepted",
         "then_match": {
           "eq": true
         },
-        "then_err": "terms of service must be accepted, see https://letsencrypt.org/repository/",
+        "then_field": "config.tos_accepted",
         "if_match": {
           "one_of": [
             "https://acme-v02.api.letsencrypt.org",
             "https://acme-staging-v02.api.letsencrypt.org"
           ]
         },
-        "if_field": "config.api_uri"
+        "if_field": "config.api_uri",
+        "then_err": "terms of service must be accepted, see https://letsencrypt.org/repository/"
       }
     },
     {

--- a/schemas/application-registration/3.5.x.json
+++ b/schemas/application-registration/3.5.x.json
@@ -3,29 +3,37 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "service": {
+        "ne": null,
         "type": "foreign",
         "on_delete": "cascade",
-        "ne": null,
         "reference": "services"
       }
     },
     {
       "route": {
         "type": "foreign",
-        "description": "A reference to the 'routes' table with a null value allowed.",
         "eq": null,
-        "reference": "routes"
+        "reference": "routes",
+        "description": "A reference to the 'routes' table with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -35,62 +43,54 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "display_name": {
-              "unique": true,
-              "type": "string",
+              "required": true,
               "description": "Unique display name used for a Service in the Developer Portal.",
-              "required": true
+              "type": "string",
+              "unique": true
             }
           },
           {
             "description": {
-              "unique": true,
+              "description": "Unique description displayed in information about a Service in the Developer Portal.",
               "type": "string",
-              "description": "Unique description displayed in information about a Service in the Developer Portal."
+              "unique": true
             }
           },
           {
             "auto_approve": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "If enabled, all new Service Contracts requests are automatically approved.",
-              "required": true
+              "description": "If enabled, all new Service Contracts requests are automatically approved."
             }
           },
           {
             "show_issuer": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Displays the **Issuer URL** in the **Service Details** dialog.",
-              "required": true
+              "description": "Displays the **Issuer URL** in the **Service Details** dialog."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/aws-lambda/3.5.x.json
+++ b/schemas/aws-lambda/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,68 +19,58 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "timeout": {
               "required": true,
+              "default": 60000,
               "type": "number",
-              "description": "An optional timeout in milliseconds when invoking the function.",
-              "default": 60000
+              "description": "An optional timeout in milliseconds when invoking the function."
             }
           },
           {
             "keepalive": {
               "required": true,
+              "default": 60000,
               "type": "number",
-              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed.",
-              "default": 60000
+              "description": "An optional value in milliseconds that defines how long an idle connection lives before being closed."
             }
           },
           {
             "aws_key": {
               "encrypted": true,
               "referenceable": true,
-              "description": "The AWS key credential to be used when invoking the function.",
-              "type": "string"
+              "type": "string",
+              "description": "The AWS key credential to be used when invoking the function."
             }
           },
           {
             "aws_secret": {
               "encrypted": true,
               "referenceable": true,
-              "description": "The AWS secret credential to be used when invoking the function. ",
-              "type": "string"
+              "type": "string",
+              "description": "The AWS secret credential to be used when invoking the function. "
             }
           },
           {
             "aws_assume_role_arn": {
               "encrypted": true,
               "referenceable": true,
-              "description": "The target AWS IAM role ARN used to invoke the Lambda function.",
-              "type": "string"
+              "type": "string",
+              "description": "The target AWS IAM role ARN used to invoke the Lambda function."
             }
           },
           {
@@ -84,8 +82,8 @@
           },
           {
             "aws_region": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -97,56 +95,56 @@
           },
           {
             "qualifier": {
-              "description": "The qualifier to use when invoking the function.",
-              "type": "string"
+              "type": "string",
+              "description": "The qualifier to use when invoking the function."
             }
           },
           {
             "invocation_type": {
               "type": "string",
-              "description": "The InvocationType to use when invoking the function. Available types are RequestResponse, Event, DryRun.",
-              "default": "RequestResponse",
               "required": true,
               "one_of": [
                 "RequestResponse",
                 "Event",
                 "DryRun"
-              ]
+              ],
+              "default": "RequestResponse",
+              "description": "The InvocationType to use when invoking the function. Available types are RequestResponse, Event, DryRun."
             }
           },
           {
             "log_type": {
               "type": "string",
-              "description": "The LogType to use when invoking the function. By default, None and Tail are supported.",
-              "default": "Tail",
               "required": true,
               "one_of": [
                 "Tail",
                 "None"
-              ]
+              ],
+              "default": "Tail",
+              "description": "The LogType to use when invoking the function. By default, None and Tail are supported."
             }
           },
           {
             "host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
-              "default": 443,
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 443,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "disable_https": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
@@ -203,8 +201,8 @@
           },
           {
             "proxy_url": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
@@ -224,16 +222,18 @@
           {
             "aws_imds_protocol_version": {
               "type": "string",
-              "description": "Identifier to select the IMDS protocol version to use: `v1` or `v2`.",
-              "default": "v1",
               "required": true,
               "one_of": [
                 "v1",
                 "v2"
-              ]
+              ],
+              "default": "v1",
+              "description": "Identifier to select the IMDS protocol version to use: `v1` or `v2`."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/azure-functions/3.5.x.json
+++ b/schemas/azure-functions/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "timeout": {
@@ -72,33 +70,33 @@
           },
           {
             "apikey": {
-              "encrypted": true,
-              "type": "string",
               "description": "The apikey to access the Azure resources. If provided, it is injected as the `x-functions-key` header.",
-              "referenceable": true
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true
             }
           },
           {
             "clientid": {
-              "encrypted": true,
-              "type": "string",
               "description": "The `clientid` to access the Azure resources. If provided, it is injected as the `x-functions-clientid` header.",
-              "referenceable": true
+              "referenceable": true,
+              "type": "string",
+              "encrypted": true
             }
           },
           {
             "appname": {
-              "required": true,
+              "description": "The Azure app name.",
               "type": "string",
-              "description": "The Azure app name."
+              "required": true
             }
           },
           {
             "hostdomain": {
-              "required": true,
-              "type": "string",
               "description": "The domain where the function resides.",
-              "default": "azurewebsites.net"
+              "default": "azurewebsites.net",
+              "type": "string",
+              "required": true
             }
           },
           {
@@ -110,12 +108,14 @@
           },
           {
             "functionname": {
-              "required": true,
+              "description": "Name of the Azure function to invoke.",
               "type": "string",
-              "description": "Name of the Azure function to invoke."
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/basic-auth/3.5.x.json
+++ b/schemas/basic-auth/3.5.x.json
@@ -3,15 +3,14 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -20,6 +19,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,31 +36,31 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "anonymous": {
-              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Please note that this value must refer to the Consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "hide_credentials": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it.",
-              "required": true
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin will strip the credential from the request (i.e. the `Authorization` header) before proxying it."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/bot-detection/3.5.x.json
+++ b/schemas/bot-detection/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,57 +27,49 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "allow": {
-              "elements": {
-                "is_regex": true,
-                "type": "string"
-              },
-              "type": "array",
               "description": "An array of regular expressions that should be allowed. The regular expressions will be checked against the `User-Agent` header.",
               "default": [
 
-              ]
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "is_regex": true
+              }
             }
           },
           {
             "deny": {
-              "elements": {
-                "is_regex": true,
-                "type": "string"
-              },
-              "type": "array",
               "description": "An array of regular expressions that should be denied. The regular expressions will be checked against the `User-Agent` header.",
               "default": [
 
-              ]
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "is_regex": true
+              }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/canary/3.5.x.json
+++ b/schemas/canary/3.5.x.json
@@ -3,21 +3,29 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -27,15 +35,7 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
@@ -43,25 +43,20 @@
         "shorthand_fields": [
           {
             "hash": {
-              "description": "Hash algorithm to be used for canary release. `whitelist` is deprecated. Use `allow` instead `blacklist` is deprecated. Use `deny` instead.",
-              "type": "string"
+              "type": "string",
+              "description": "Hash algorithm to be used for canary release. `whitelist` is deprecated. Use `allow` instead `blacklist` is deprecated. Use `deny` instead."
             }
           }
         ],
-        "type": "record",
-        "required": true,
         "fields": [
           {
             "start": {
-              "description": "Future time in seconds since epoch, when the canary release will start. Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`.",
-              "type": "number"
+              "type": "number",
+              "description": "Future time in seconds since epoch, when the canary release will start. Ignored when `percentage` is set, or when using `allow` or `deny` in `hash`."
             }
           },
           {
             "hash": {
-              "default": "consumer",
-              "type": "string",
-              "description": "Hash algorithm to be used for canary release.\n\n* `consumer`: The hash will be based on the consumer.\n* `ip`: The hash will be based on the client IP address.\n* `none`: No hash will be applied.\n* `allow`: Allows the specified groups to access the canary release.\n* `deny`: Denies the specified groups from accessing the canary release.\n* `header`: The hash will be based on the specified header value.",
               "one_of": [
                 "consumer",
                 "ip",
@@ -69,29 +64,32 @@
                 "allow",
                 "deny",
                 "header"
-              ]
+              ],
+              "default": "consumer",
+              "type": "string",
+              "description": "Hash algorithm to be used for canary release.\n\n* `consumer`: The hash will be based on the consumer.\n* `ip`: The hash will be based on the client IP address.\n* `none`: No hash will be applied.\n* `allow`: Allows the specified groups to access the canary release.\n* `deny`: Denies the specified groups from accessing the canary release.\n* `header`: The hash will be based on the specified header value."
             }
           },
           {
             "hash_header": {
-              "description": "A string representing an HTTP header name.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           },
           {
             "duration": {
+              "gt": 0,
               "default": 3600,
               "type": "number",
-              "description": "The duration of the canary release in seconds.",
-              "gt": 0
+              "description": "The duration of the canary release in seconds."
             }
           },
           {
             "steps": {
+              "gt": 1,
               "default": 1000,
               "type": "number",
-              "description": "The number of steps for the canary release.",
-              "gt": 1
+              "description": "The number of steps for the canary release."
             }
           },
           {
@@ -106,8 +104,8 @@
           },
           {
             "upstream_host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -129,28 +127,30 @@
           },
           {
             "upstream_fallback": {
-              "required": true,
-              "type": "boolean",
               "description": "Specifies whether to fallback to the upstream server if the canary release fails.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "groups": {
+              "description": "The groups allowed to access the canary release.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "The groups allowed to access the canary release."
+              }
             }
           },
           {
             "canary_by_header_name": {
-              "description": "A string representing an HTTP header name.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/correlation-id/3.5.x.json
+++ b/schemas/correlation-id/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "header_name": {
@@ -44,25 +42,27 @@
           },
           {
             "generator": {
-              "default": "uuid#counter",
-              "type": "string",
-              "description": "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators).",
               "one_of": [
                 "uuid",
                 "uuid#counter",
                 "tracker"
-              ]
+              ],
+              "default": "uuid#counter",
+              "type": "string",
+              "description": "The generator to use for the correlation ID. Accepted values are `uuid`, `uuid#counter`, and `tracker`. See [Generators](#generators)."
             }
           },
           {
             "echo_downstream": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Whether to echo the header back to downstream (the client).",
-              "required": true
+              "description": "Whether to echo the header back to downstream (the client)."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/cors/3.5.x.json
+++ b/schemas/cors/3.5.x.json
@@ -3,15 +3,23 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
-          "required": true,
+          "len_min": 1,
           "one_of": [
             "grpc",
             "grpcs",
@@ -19,61 +27,52 @@
             "https"
           ],
           "type": "string",
-          "len_min": 1
+          "required": true
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "origins": {
+              "description": "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "List of allowed domains for the `Access-Control-Allow-Origin` header. If you want to allow all origins, add `*` as a single value to this configuration field. The accepted values can either be flat strings or PCRE regexes."
+              }
             }
           },
           {
             "headers": {
+              "description": "Value for the `Access-Control-Allow-Headers` header.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Value for the `Access-Control-Allow-Headers` header."
+              }
             }
           },
           {
             "exposed_headers": {
+              "description": "Value for the `Access-Control-Expose-Headers` header. If not specified, no custom headers are exposed.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Value for the `Access-Control-Expose-Headers` header. If not specified, no custom headers are exposed."
+              }
             }
           },
           {
             "methods": {
+              "description": "'Value for the `Access-Control-Allow-Methods` header. Available options include `GET`, `HEAD`, `PUT`, `PATCH`, `POST`, `DELETE`, `OPTIONS`, `TRACE`, `CONNECT`. By default, all options are allowed.'",
               "default": [
                 "GET",
                 "HEAD",
@@ -86,7 +85,6 @@
                 "CONNECT"
               ],
               "type": "array",
-              "description": "'Value for the `Access-Control-Allow-Methods` header. Available options include `GET`, `HEAD`, `PUT`, `PATCH`, `POST`, `DELETE`, `OPTIONS`, `TRACE`, `CONNECT`. By default, all options are allowed.'",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -105,35 +103,37 @@
           },
           {
             "max_age": {
-              "description": "Indicates how long the results of the preflight request can be cached, in `seconds`.",
-              "type": "number"
+              "type": "number",
+              "description": "Indicates how long the results of the preflight request can be cached, in `seconds`."
             }
           },
           {
             "credentials": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value.",
-              "default": false
+              "description": "Flag to determine whether the `Access-Control-Allow-Credentials` header should be sent with `true` as the value."
             }
           },
           {
             "private_network": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Flag to determine whether the `Access-Control-Allow-Private-Network` header should be sent with `true` as the value.",
-              "default": false
+              "description": "Flag to determine whether the `Access-Control-Allow-Private-Network` header should be sent with `true` as the value."
             }
           },
           {
             "preflight_continue": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service.",
-              "default": false
+              "description": "A boolean value that instructs the plugin to proxy the `OPTIONS` preflight request to the Upstream service."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/datadog/3.5.x.json
+++ b/schemas/datadog/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -57,19 +55,19 @@
             "host": {
               "default": "localhost",
               "referenceable": true,
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "port": {
-              "default": 8125,
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 8125,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
@@ -102,64 +100,62 @@
           },
           {
             "retry_count": {
-              "description": "Number of times to retry when sending data to the upstream server.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of times to retry when sending data to the upstream server."
             }
           },
           {
             "queue_size": {
-              "description": "Maximum number of log entries to be sent on each message to the upstream server.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of log entries to be sent on each message to the upstream server."
             }
           },
           {
             "flush_timeout": {
-              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.",
-              "type": "number"
+              "type": "number",
+              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records."
             }
           },
           {
             "queue": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "number",
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 10000,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
                   "max_bytes": {
-                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content.",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
@@ -171,32 +167,153 @@
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 0.01,
+                    "type": "number",
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 60,
+                    "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "metrics": {
+              "type": "array",
+              "required": true,
+              "default": [
+                {
+                  "sample_rate": 1,
+                  "stat_type": "counter",
+                  "name": "request_count",
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ]
+                },
+                {
+                  "name": "latency",
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "stat_type": "timer"
+                },
+                {
+                  "name": "request_size",
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "stat_type": "timer"
+                },
+                {
+                  "name": "response_size",
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "stat_type": "timer"
+                },
+                {
+                  "name": "upstream_latency",
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "stat_type": "timer"
+                },
+                {
+                  "name": "kong_latency",
+                  "consumer_identifier": "custom_id",
+                  "tags": [
+                    "app:kong"
+                  ],
+                  "stat_type": "timer"
+                }
+              ],
+              "description": "List of metrics to be logged.",
               "elements": {
+                "fields": [
+                  {
+                    "name": {
+                      "required": true,
+                      "one_of": [
+                        "kong_latency",
+                        "latency",
+                        "request_count",
+                        "request_size",
+                        "response_size",
+                        "upstream_latency"
+                      ],
+                      "type": "string",
+                      "description": "Datadog metric’s name"
+                    }
+                  },
+                  {
+                    "stat_type": {
+                      "required": true,
+                      "one_of": [
+                        "counter",
+                        "gauge",
+                        "histogram",
+                        "meter",
+                        "set",
+                        "timer",
+                        "distribution"
+                      ],
+                      "type": "string",
+                      "description": "Determines what sort of event the metric represents"
+                    }
+                  },
+                  {
+                    "tags": {
+                      "description": "List of tags",
+                      "type": "array",
+                      "elements": {
+                        "match": "^.*[^:]$",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "sample_rate": {
+                      "between": [
+                        0,
+                        1
+                      ],
+                      "type": "number",
+                      "description": "Sampling rate"
+                    }
+                  },
+                  {
+                    "consumer_identifier": {
+                      "one_of": [
+                        "consumer_id",
+                        "custom_id",
+                        "username"
+                      ],
+                      "type": "string",
+                      "description": "Authenticated user detail"
+                    }
+                  }
+                ],
+                "type": "record",
                 "entity_checks": [
                   {
                     "conditional": {
@@ -213,130 +330,13 @@
                       "if_field": "stat_type"
                     }
                   }
-                ],
-                "type": "record",
-                "fields": [
-                  {
-                    "name": {
-                      "required": true,
-                      "type": "string",
-                      "description": "Datadog metric’s name",
-                      "one_of": [
-                        "kong_latency",
-                        "latency",
-                        "request_count",
-                        "request_size",
-                        "response_size",
-                        "upstream_latency"
-                      ]
-                    }
-                  },
-                  {
-                    "stat_type": {
-                      "required": true,
-                      "type": "string",
-                      "description": "Determines what sort of event the metric represents",
-                      "one_of": [
-                        "counter",
-                        "gauge",
-                        "histogram",
-                        "meter",
-                        "set",
-                        "timer",
-                        "distribution"
-                      ]
-                    }
-                  },
-                  {
-                    "tags": {
-                      "elements": {
-                        "match": "^.*[^:]$",
-                        "type": "string"
-                      },
-                      "type": "array",
-                      "description": "List of tags"
-                    }
-                  },
-                  {
-                    "sample_rate": {
-                      "between": [
-                        0,
-                        1
-                      ],
-                      "type": "number",
-                      "description": "Sampling rate"
-                    }
-                  },
-                  {
-                    "consumer_identifier": {
-                      "type": "string",
-                      "description": "Authenticated user detail",
-                      "one_of": [
-                        "consumer_id",
-                        "custom_id",
-                        "username"
-                      ]
-                    }
-                  }
                 ]
-              },
-              "type": "array",
-              "description": "List of metrics to be logged.",
-              "required": true,
-              "default": [
-                {
-                  "sample_rate": 1,
-                  "stat_type": "counter",
-                  "name": "request_count",
-                  "consumer_identifier": "custom_id",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "name": "latency",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "name": "request_size",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "name": "response_size",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "name": "upstream_latency",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer",
-                  "tags": [
-                    "app:kong"
-                  ]
-                },
-                {
-                  "name": "kong_latency",
-                  "consumer_identifier": "custom_id",
-                  "stat_type": "timer",
-                  "tags": [
-                    "app:kong"
-                  ]
-                }
-              ]
+              }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/degraphql/3.5.x.json
+++ b/schemas/degraphql/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,35 +27,25 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "graphql_server_path": {
-              "starts_with": "/",
               "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
+              "required": true,
+              "starts_with": "/",
               "default": "/graphql",
               "match_none": [
                 {
@@ -55,10 +53,12 @@
                   "err": "must not have empty segments"
                 }
               ],
-              "required": true
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/exit-transformer/3.5.x.json
+++ b/schemas/exit-transformer/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "functions": {
@@ -58,7 +56,9 @@
               "description": "Determines whether to handle unexpected errors by transforming their responses."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/file-log/3.5.x.json
+++ b/schemas/file-log/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,65 +23,57 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "path": {
               "type": "string",
-              "description": "The file path of the output log file. The plugin creates the log file if it doesn't exist yet.",
               "required": true,
               "err": "not a valid filename",
-              "match": "^[^*&%%\\`]+$"
+              "match": "^[^*&%%\\`]+$",
+              "description": "The file path of the output log file. The plugin creates the log file if it doesn't exist yet."
             }
           },
           {
             "reopen": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Determines whether the log file is closed and reopened on every request.",
-              "default": false
+              "description": "Determines whether the log file is closed and reopened on every request."
             }
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
+              "type": "map",
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "type": "map",
-              "description": "Lua code as a key-value map",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "Lua code as a key-value map"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/forward-proxy/3.5.x.json
+++ b/schemas/forward-proxy/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,23 +19,15 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -44,25 +44,24 @@
             }
           }
         ],
-        "type": "record",
         "fields": [
           {
             "x_headers": {
               "type": "string",
-              "description": "Determines how to handle headers when forwarding the request.",
-              "default": "append",
               "required": true,
               "one_of": [
                 "append",
                 "transparent",
                 "delete"
-              ]
+              ],
+              "default": "append",
+              "description": "Determines how to handle headers when forwarding the request."
             }
           },
           {
             "http_proxy_host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -77,8 +76,8 @@
           },
           {
             "https_proxy_host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -94,39 +93,40 @@
           {
             "proxy_scheme": {
               "type": "string",
-              "description": "The proxy scheme to use when connecting. Only `http` is supported.",
-              "default": "http",
               "required": true,
               "one_of": [
                 "http"
-              ]
+              ],
+              "default": "http",
+              "description": "The proxy scheme to use when connecting. Only `http` is supported."
             }
           },
           {
             "auth_username": {
-              "required": false,
-              "type": "string",
               "description": "The username to authenticate with, if the forward proxy is protected\nby basic authentication.",
-              "referenceable": true
+              "referenceable": true,
+              "type": "string",
+              "required": false
             }
           },
           {
             "auth_password": {
-              "required": false,
-              "type": "string",
               "description": "The password to authenticate with, if the forward proxy is protected\nby basic authentication.",
-              "referenceable": true
+              "referenceable": true,
+              "type": "string",
+              "required": false
             }
           },
           {
             "https_verify": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Whether the server certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate.",
-              "default": false
+              "description": "Whether the server certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate."
             }
           }
         ],
+        "type": "record",
         "required": true,
         "entity_checks": [
           {

--- a/schemas/graphql-proxy-cache-advanced/3.5.x.json
+++ b/schemas/graphql-proxy-cache-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,75 +19,67 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "strategy": {
               "type": "string",
-              "description": "The backing data store in which to hold cached entities. Accepted value is `memory`.",
               "required": true,
-              "default": "memory",
               "one_of": [
                 "memory"
-              ]
+              ],
+              "default": "memory",
+              "description": "The backing data store in which to hold cached entities. Accepted value is `memory`."
             }
           },
           {
             "cache_ttl": {
+              "gt": 0,
               "default": 300,
               "type": "integer",
-              "description": "TTL in seconds of cache entities. Must be a value greater than 0.",
-              "gt": 0
+              "description": "TTL in seconds of cache entities. Must be a value greater than 0."
             }
           },
           {
             "memory": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "dictionary_name": {
-                    "required": true,
-                    "type": "string",
                     "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. This dictionary currently must be defined manually in the Kong Nginx template.",
-                    "default": "kong_db_cache"
+                    "default": "kong_db_cache",
+                    "type": "string",
+                    "required": true
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "vary_headers": {
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration."
+              }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/graphql-rate-limiting-advanced/3.5.x.json
+++ b/schemas/graphql-rate-limiting-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,106 +19,96 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "identifier": {
               "type": "string",
-              "description": "How to define the rate limit key. Can be `ip`, `credential`, `consumer`.",
               "required": true,
-              "default": "consumer",
               "one_of": [
                 "ip",
                 "credential",
                 "consumer"
-              ]
+              ],
+              "default": "consumer",
+              "description": "How to define the rate limit key. Can be `ip`, `credential`, `consumer`."
             }
           },
           {
             "window_size": {
-              "required": true,
-              "type": "array",
               "description": "One or more window sizes to apply a limit to (defined in seconds).",
               "elements": {
                 "type": "number"
-              }
+              },
+              "type": "array",
+              "required": true
             }
           },
           {
             "window_type": {
-              "default": "sliding",
-              "type": "string",
-              "description": "Sets the time window to either `sliding` or `fixed`.",
               "one_of": [
                 "fixed",
                 "sliding"
-              ]
+              ],
+              "default": "sliding",
+              "type": "string",
+              "description": "Sets the time window to either `sliding` or `fixed`."
             }
           },
           {
             "limit": {
-              "required": true,
-              "type": "array",
               "description": "One or more requests-per-window limits to apply.",
               "elements": {
                 "type": "number"
-              }
+              },
+              "type": "array",
+              "required": true
             }
           },
           {
             "sync_rate": {
-              "required": true,
+              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 syncs the counters in that many number of seconds.",
               "type": "number",
-              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 syncs the counters in that many number of seconds."
+              "required": true
             }
           },
           {
             "namespace": {
-              "type": "string",
               "auto": true,
+              "type": "string",
               "description": "The rate limiting library namespace to use for this plugin instance. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `window_size`, `dictionary_name`, need to be the same."
             }
           },
           {
             "strategy": {
               "type": "string",
-              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits.",
               "required": true,
-              "default": "cluster",
               "one_of": [
                 "cluster",
                 "redis"
-              ]
+              ],
+              "default": "cluster",
+              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits."
             }
           },
           {
             "dictionary_name": {
-              "required": true,
-              "type": "string",
               "description": "The shared dictionary where counters will be stored until the next sync cycle.",
-              "default": "kong_rate_limiting_counters"
+              "default": "kong_rate_limiting_counters",
+              "type": "string",
+              "required": true
             }
           },
           {
@@ -122,36 +120,34 @@
           },
           {
             "cost_strategy": {
-              "default": "default",
-              "type": "string",
-              "description": "Strategy to use to evaluate query costs. Either `default` or `node_quantifier`.",
               "one_of": [
                 "default",
                 "node_quantifier"
-              ]
+              ],
+              "default": "default",
+              "type": "string",
+              "description": "Strategy to use to evaluate query costs. Either `default` or `node_quantifier`."
             }
           },
           {
             "score_factor": {
-              "type": "number",
-              "description": "A scoring factor to multiply (or divide) the cost. The `score_factor` must always be greater than 0.",
-              "required": false,
               "gt": 0,
-              "default": 1
+              "type": "number",
+              "required": false,
+              "default": 1,
+              "description": "A scoring factor to multiply (or divide) the cost. The `score_factor` must always be greater than 0."
             }
           },
           {
             "max_cost": {
-              "required": false,
-              "type": "number",
               "description": "A defined maximum cost per query. 0 means unlimited.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "redis": {
-              "required": true,
-              "type": "record",
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -213,8 +209,8 @@
               "fields": [
                 {
                   "host": {
-                    "description": "A string representing a host name, such as example.com.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "A string representing a host name, such as example.com."
                   }
                 },
                 {
@@ -229,13 +225,13 @@
                 },
                 {
                   "timeout": {
-                    "default": 2000,
-                    "type": "integer",
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "between": [
                       0,
                       2147483646
-                    ]
+                    ],
+                    "default": 2000,
+                    "type": "integer",
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
@@ -271,31 +267,31 @@
                 {
                   "username": {
                     "referenceable": true,
-                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
-                    "referenceable": true,
                     "description": "Password to use for Redis connections. If undefined, no AUTH commands are sent to Redis.",
-                    "type": "string"
+                    "referenceable": true,
+                    "type": "string",
+                    "encrypted": true
                   }
                 },
                 {
                   "sentinel_username": {
                     "referenceable": true,
-                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+."
                   }
                 },
                 {
                   "sentinel_password": {
-                    "encrypted": true,
-                    "referenceable": true,
                     "description": "Sentinel password to authenticate with a Redis Sentinel instance. If undefined, no AUTH commands are sent to Redis Sentinels.",
-                    "type": "string"
+                    "referenceable": true,
+                    "type": "string",
+                    "encrypted": true
                   }
                 },
                 {
@@ -307,13 +303,13 @@
                 },
                 {
                   "keepalive_pool_size": {
-                    "default": 256,
-                    "type": "integer",
-                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low.",
                     "between": [
                       1,
                       2147483646
-                    ]
+                    ],
+                    "default": 256,
+                    "type": "integer",
+                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low."
                   }
                 },
                 {
@@ -328,55 +324,55 @@
                 },
                 {
                   "sentinel_master": {
-                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_role": {
-                    "type": "string",
-                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel.",
                     "one_of": [
                       "master",
                       "slave",
                       "any"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_addresses": {
                     "len_min": 1,
-                    "type": "array",
-                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "array",
+                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element."
                   }
                 },
                 {
                   "cluster_addresses": {
                     "len_min": 1,
-                    "type": "array",
-                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "array",
+                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element."
                   }
                 },
                 {
                   "ssl": {
-                    "required": false,
-                    "type": "boolean",
                     "description": "If set to true, uses SSL to connect to Redis.",
-                    "default": false
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
                   "ssl_verify": {
-                    "required": false,
-                    "type": "boolean",
                     "description": "If set to true, verifies the validity of the server SSL certificate. If setting this parameter, also configure `lua_ssl_trusted_certificate` in `kong.conf` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
-                    "default": false
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
@@ -386,10 +382,14 @@
                     "description": "A string representing an SNI (server name indication) value for TLS."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/grpc-gateway/3.5.x.json
+++ b/schemas/grpc-gateway/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,41 +23,33 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "proto": {
-              "required": false,
+              "description": "Describes the gRPC types and methods.",
               "type": "string",
-              "description": "Describes the gRPC types and methods."
+              "required": false
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/grpc-web/3.5.x.json
+++ b/schemas/grpc-web/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "proto": {
@@ -58,13 +56,15 @@
           },
           {
             "allow_origin_header": {
+              "required": false,
               "default": "*",
               "type": "string",
-              "description": "The value of the `Access-Control-Allow-Origin` header in the response to the gRPC-Web client.",
-              "required": false
+              "description": "The value of the `Access-Control-Allow-Origin` header in the response to the gRPC-Web client."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/hmac-auth/3.5.x.json
+++ b/schemas/hmac-auth/3.5.x.json
@@ -3,15 +3,14 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -20,6 +19,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,60 +36,66 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "hide_credentials": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service.",
-              "required": true
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service."
             }
           },
           {
             "clock_skew": {
-              "default": 300,
               "gt": 0,
-              "description": "Clock skew in seconds to prevent replay attacks.",
-              "type": "number"
+              "default": 300,
+              "type": "number",
+              "description": "Clock skew in seconds to prevent replay attacks."
             }
           },
           {
             "anonymous": {
-              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (Consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
             }
           },
           {
             "validate_request_body": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "A boolean value telling the plugin to enable body validation.",
-              "required": true
+              "description": "A boolean value telling the plugin to enable body validation."
             }
           },
           {
             "enforce_headers": {
-              "elements": {
-                "type": "string"
-              },
-              "type": "array",
               "description": "A list of headers that the client should at least use for HTTP signature creation.",
               "default": [
 
-              ]
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "algorithms": {
+              "description": "A list of HMAC digest algorithms that the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`",
+              "default": [
+                "hmac-sha1",
+                "hmac-sha256",
+                "hmac-sha384",
+                "hmac-sha512"
+              ],
+              "type": "array",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -98,18 +104,12 @@
                   "hmac-sha384",
                   "hmac-sha512"
                 ]
-              },
-              "type": "array",
-              "description": "A list of HMAC digest algorithms that the user wants to support. Allowed values are `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, and `hmac-sha512`",
-              "default": [
-                "hmac-sha1",
-                "hmac-sha256",
-                "hmac-sha384",
-                "hmac-sha512"
-              ]
+              }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/http-log/3.5.x.json
+++ b/schemas/http-log/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,31 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -51,38 +50,37 @@
             }
           }
         ],
-        "type": "record",
         "fields": [
           {
             "http_endpoint": {
-              "referenceable": true,
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "encrypted": true,
               "type": "string",
-              "required": true
+              "encrypted": true,
+              "referenceable": true,
+              "required": true,
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "method": {
-              "default": "POST",
-              "type": "string",
-              "description": "An optional method used to send data to the HTTP server. Supported values are `POST` (default), `PUT`, and `PATCH`.",
               "one_of": [
                 "POST",
                 "PUT",
                 "PATCH"
-              ]
+              ],
+              "default": "POST",
+              "type": "string",
+              "description": "An optional method used to send data to the HTTP server. Supported values are `POST` (default), `PUT`, and `PATCH`."
             }
           },
           {
             "content_type": {
-              "default": "application/json",
-              "type": "string",
-              "description": "Indicates the type of data sent. The only available option is `application/json`.",
               "one_of": [
                 "application/json",
                 "application/json; charset=utf-8"
-              ]
+              ],
+              "default": "application/json",
+              "type": "string",
+              "description": "Indicates the type of data sent. The only available option is `application/json`."
             }
           },
           {
@@ -101,33 +99,25 @@
           },
           {
             "retry_count": {
-              "description": "Number of times to retry when sending data to the upstream server.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of times to retry when sending data to the upstream server."
             }
           },
           {
             "queue_size": {
-              "description": "Maximum number of log entries to be sent on each message to the upstream server.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Maximum number of log entries to be sent on each message to the upstream server."
             }
           },
           {
             "flush_timeout": {
-              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records.",
-              "type": "number"
+              "type": "number",
+              "description": "Optional time in seconds. If `queue_size` > 1, this is the max idle time before sending a log with less than `queue_size` records."
             }
           },
           {
             "headers": {
-              "values": {
-                "referenceable": true,
-                "type": "string"
-              },
-              "type": "map",
-              "description": "An optional table of headers included in the HTTP message to the upstream server. Values are indexed by header name, and each header name accepts a single string.",
               "keys": {
-                "type": "string",
-                "description": "A string representing an HTTP header name.",
                 "match_none": [
                   {
                     "pattern": "^[Hh][Oo][Ss][Tt]$",
@@ -141,52 +131,58 @@
                     "pattern": "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Tt][Yy][Pp][Ee]$",
                     "err": "cannot contain 'Content-Type' header"
                   }
-                ]
-              }
+                ],
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              },
+              "type": "map",
+              "values": {
+                "type": "string",
+                "referenceable": true
+              },
+              "description": "An optional table of headers included in the HTTP message to the upstream server. Values are indexed by header name, and each header name accepts a single string."
             }
           },
           {
             "queue": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "number",
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 10000,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
                   "max_bytes": {
-                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content.",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
@@ -198,44 +194,48 @@
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 0.01,
+                    "type": "number",
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 60,
+                    "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
+              "type": "map",
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "type": "map",
-              "description": "Lua code as a key-value map",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "Lua code as a key-value map"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/ip-restriction/3.5.x.json
+++ b/schemas/ip-restriction/3.5.x.json
@@ -2,6 +2,17 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "http",
+          "https",
+          "tcp",
+          "tls",
+          "grpc",
+          "grpcs"
+        ],
+        "description": "A set of strings representing protocols.",
         "elements": {
           "one_of": [
             "grpc",
@@ -15,53 +26,40 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
-        },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "default": [
-          "http",
-          "https",
-          "tcp",
-          "tls",
-          "grpc",
-          "grpcs"
-        ],
-        "required": true
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
+        }
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "allow": {
-              "elements": {
-                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16.",
-                "type": "string"
-              },
+              "description": "List of IPs or CIDR ranges to allow. One of `config.allow` or `config.deny` must be specified.",
               "type": "array",
-              "description": "List of IPs or CIDR ranges to allow. One of `config.allow` or `config.deny` must be specified."
+              "elements": {
+                "type": "string",
+                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16."
+              }
             }
           },
           {
             "deny": {
-              "elements": {
-                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16.",
-                "type": "string"
-              },
+              "description": "List of IPs or CIDR ranges to deny. One of `config.allow` or `config.deny` must be specified.",
               "type": "array",
-              "description": "List of IPs or CIDR ranges to deny. One of `config.allow` or `config.deny` must be specified."
+              "elements": {
+                "type": "string",
+                "description": "A string representing an IP address or CIDR block, such as 192.168.1.1 or 192.168.0.0/16."
+              }
             }
           },
           {
@@ -78,7 +76,9 @@
               "description": "The message to send as a response body to rejected requests."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/jq/3.5.x.json
+++ b/schemas/jq/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,21 +27,11 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -45,149 +43,151 @@
         "fields": [
           {
             "request_jq_program": {
-              "required": false,
-              "type": "string"
+              "type": "string",
+              "required": false
             }
           },
           {
             "request_jq_program_options": {
-              "required": false,
-              "type": "record",
-              "default": [
-
-              ],
               "fields": [
                 {
                   "compact_output": {
-                    "required": true,
+                    "default": true,
                     "type": "boolean",
-                    "default": true
+                    "required": true
                   }
                 },
                 {
                   "raw_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "join_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "ascii_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "sort_keys": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 }
-              ]
+              ],
+              "default": [
+
+              ],
+              "type": "record",
+              "required": false
             }
           },
           {
             "request_if_media_type": {
               "required": false,
+              "default": [
+                "application/json"
+              ],
               "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "default": [
-                "application/json"
-              ]
+              }
             }
           },
           {
             "response_jq_program": {
-              "required": false,
-              "type": "string"
+              "type": "string",
+              "required": false
             }
           },
           {
             "response_jq_program_options": {
-              "required": false,
-              "type": "record",
-              "default": [
-
-              ],
               "fields": [
                 {
                   "compact_output": {
-                    "required": true,
+                    "default": true,
                     "type": "boolean",
-                    "default": true
+                    "required": true
                   }
                 },
                 {
                   "raw_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "join_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "ascii_output": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 },
                 {
                   "sort_keys": {
-                    "required": true,
+                    "default": false,
                     "type": "boolean",
-                    "default": false
+                    "required": true
                   }
                 }
-              ]
+              ],
+              "default": [
+
+              ],
+              "type": "record",
+              "required": false
             }
           },
           {
             "response_if_media_type": {
               "required": false,
+              "default": [
+                "application/json"
+              ],
               "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "default": [
-                "application/json"
-              ]
+              }
             }
           },
           {
             "response_if_status_code": {
               "required": false,
+              "default": [
+                200
+              ],
               "type": "array",
               "elements": {
+                "type": "integer",
                 "between": [
                   100,
                   599
-                ],
-                "type": "integer"
-              },
-              "default": [
-                200
-              ]
+                ]
+              }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/jwe-decrypt/3.5.x.json
+++ b/schemas/jwe-decrypt/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,62 +19,52 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "lookup_header_name": {
+              "description": "The name of the header to look for the JWE token.",
               "default": "Authorization",
               "type": "string",
-              "description": "The name of the header to look for the JWE token.",
               "required": true
             }
           },
           {
             "forward_header_name": {
+              "description": "The name of the header that is used to set the decrypted value.",
               "default": "Authorization",
               "type": "string",
-              "description": "The name of the header that is used to set the decrypted value.",
               "required": true
             }
           },
           {
             "key_sets": {
-              "required": true,
-              "type": "array",
               "description": "Denote the name or names of all Key Sets that should be inspected when trying to find a suitable key to decrypt the JWE token.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": true
             }
           },
           {
@@ -76,7 +74,9 @@
               "description": "Defines how the plugin behaves in cases where no token was found in the request. When using `strict` mode, the request requires a token to be present and subsequently raise an error if none could be found."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/jwt-signer/3.5.x.json
+++ b/schemas/jwt-signer/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,127 +27,123 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "realm": {
-              "required": false,
+              "description": "When authentication or authorization fails, or there is an unexpected error, the plugin sends an `WWW-Authenticate` header with the `realm` attribute value.",
               "type": "string",
-              "description": "When authentication or authorization fails, or there is an unexpected error, the plugin sends an `WWW-Authenticate` header with the `realm` attribute value."
+              "required": false
             }
           },
           {
             "enable_hs_signatures": {
-              "required": false,
-              "type": "boolean",
               "description": "Tokens signed with HMAC algorithms such as `HS256`, `HS384`, or `HS512` are not accepted by default. If you need to accept such tokens for verification, enable this setting.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "enable_instrumentation": {
-              "required": false,
-              "type": "boolean",
               "description": "Writes log entries with some added information using `ngx.CRIT` (CRITICAL) level.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "access_token_issuer": {
-              "required": false,
-              "type": "string",
               "description": "The `iss` claim of a signed or re-signed access token is set to this value. Original `iss` claim of the incoming token (possibly introspected) is stored in `original_iss` claim of the newly signed access token.",
-              "default": "kong"
+              "default": "kong",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_keyset": {
-              "required": false,
-              "type": "string",
               "description": "The name of the keyset containing signing keys.",
-              "default": "kong"
+              "default": "kong",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_jwks_uri": {
-              "required": false,
+              "description": "Specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the access token.",
               "type": "string",
-              "description": "Specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the access token."
+              "required": false
             }
           },
           {
             "access_token_request_header": {
-              "required": false,
-              "type": "string",
               "description": "This parameter tells the name of the header where to look for the access token.",
-              "default": "Authorization"
+              "default": "Authorization",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_leeway": {
-              "required": false,
-              "type": "number",
               "description": "Adjusts clock skew between the token issuer and Kong. The value is added to the token's `exp` claim before checking token expiry against Kong servers' current time in seconds. You can disable access token `expiry` verification altogether with `config.verify_access_token_expiry`.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "access_token_scopes_required": {
-              "required": false,
-              "type": "array",
               "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.access_token_scopes_claim`.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "access_token_scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "Specify the claim in an access token to verify against values of `config.access_token_scopes_required`.",
               "required": false,
               "default": [
                 "scope"
-              ]
+              ],
+              "elements": {
+                "type": "string"
+              },
+              "description": "Specify the claim in an access token to verify against values of `config.access_token_scopes_required`."
             }
           },
           {
             "access_token_consumer_claim": {
-              "required": false,
-              "type": "array",
               "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (for example, `sub` or `username`) in an access token to Kong consumer entity.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "access_token_consumer_by": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -148,105 +152,105 @@
                   "custom_id"
                 ]
               },
-              "type": "array",
-              "description": "When the plugin tries to apply an access token to a Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of alues. Valid values are `id`, `username`, and `custom_id`.",
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ]
+              "description": "When the plugin tries to apply an access token to a Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of alues. Valid values are `id`, `username`, and `custom_id`."
             }
           },
           {
             "access_token_upstream_header": {
-              "required": false,
-              "type": "string",
               "description": "Removes the `config.access_token_request_header` from the request after reading its value. With `config.access_token_upstream_header`, you can specify the upstream header where the plugin adds the Kong signed token. If you don't specify a value, such as use `null` or `\"\"` (empty string), the plugin does not even try to sign or re-sign the token.",
-              "default": "Authorization:Bearer"
+              "default": "Authorization:Bearer",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_upstream_leeway": {
-              "required": false,
-              "type": "number",
               "description": "If you want to add or subtract (using a negative value) expiry time (in seconds) of the original access token, you can specify a value that is added to the original access token's `exp` claim.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "access_token_introspection_endpoint": {
-              "required": false,
+              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter.",
               "type": "string",
-              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter."
+              "required": false
             }
           },
           {
             "access_token_introspection_authorization": {
-              "required": false,
+              "description": "If the introspection endpoint requires client authentication (client being the JWT Signer plugin), you can specify the `Authorization` header's value with this configuration parameter.",
               "type": "string",
-              "description": "If the introspection endpoint requires client authentication (client being the JWT Signer plugin), you can specify the `Authorization` header's value with this configuration parameter."
+              "required": false
             }
           },
           {
             "access_token_introspection_body_args": {
-              "required": false,
+              "description": "This parameter allows you to pass URL encoded request body arguments. For example: `resource=` or `a=1&b=&c`.",
               "type": "string",
-              "description": "This parameter allows you to pass URL encoded request body arguments. For example: `resource=` or `a=1&b=&c`."
+              "required": false
             }
           },
           {
             "access_token_introspection_hint": {
-              "required": false,
-              "type": "string",
               "description": "If you need to give `hint` parameter when introspecting an access token, use this parameter to specify the value. By default, the plugin sends `hint=access_token`.",
-              "default": "access_token"
+              "default": "access_token",
+              "type": "string",
+              "required": false
             }
           },
           {
             "access_token_introspection_jwt_claim": {
-              "required": false,
-              "type": "array",
               "description": "If your introspection endpoint returns an access token in one of the keys (or claims) within the introspection results (`JSON`). If the key cannot be found, the plugin responds with `401 Unauthorized`. Also if the key is found but cannot be decoded as JWT, it also responds with `401 Unauthorized`.",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "access_token_introspection_scopes_required": {
-              "required": false,
-              "type": "array",
-              "description": "Specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.access_token_introspection_scopes_claim`.",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "access_token_introspection_scopes_claim": {
               "elements": {
                 "type": "string"
               },
               "type": "array",
-              "description": "Specify the claim/property in access token introspection results (`JSON`) to be verified against values of `config.access_token_introspection_scopes_required`. This supports nested claims. For example, with Keycloak you could use `[ \"realm_access\", \"roles\" ]`, hich can be given as `realm_access,roles` (form post). If the claim is not found in access token introspection results, and you have specified `config.access_token_introspection_scopes_required`, the plugin responds with `403 Forbidden`.",
+              "required": false
+            }
+          },
+          {
+            "access_token_introspection_scopes_required": {
+              "description": "Specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.access_token_introspection_scopes_claim`.",
+              "elements": {
+                "type": "string"
+              },
+              "type": "array",
+              "required": false
+            }
+          },
+          {
+            "access_token_introspection_scopes_claim": {
+              "type": "array",
               "required": true,
               "default": [
                 "scope"
-              ]
+              ],
+              "elements": {
+                "type": "string"
+              },
+              "description": "Specify the claim/property in access token introspection results (`JSON`) to be verified against values of `config.access_token_introspection_scopes_required`. This supports nested claims. For example, with Keycloak you could use `[ \"realm_access\", \"roles\" ]`, hich can be given as `realm_access,roles` (form post). If the claim is not found in access token introspection results, and you have specified `config.access_token_introspection_scopes_required`, the plugin responds with `403 Forbidden`."
             }
           },
           {
             "access_token_introspection_consumer_claim": {
-              "required": false,
-              "type": "array",
               "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in access token introspection results to the Kong consumer entity.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "access_token_introspection_consumer_by": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -255,35 +259,27 @@
                   "custom_id"
                 ]
               },
-              "type": "array",
-              "description": "When the plugin tries to do access token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values.",
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ]
+              "description": "When the plugin tries to do access token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values."
             }
           },
           {
             "access_token_introspection_leeway": {
-              "required": false,
-              "type": "number",
               "description": "Adjusts clock skew between the token issuer introspection results and Kong. The value is added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time in seconds. You can disable access token introspection `expiry` verification altogether with `config.verify_access_token_introspection_expiry`.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "access_token_introspection_timeout": {
-              "required": false,
+              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on access token introspection.",
               "type": "number",
-              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on access token introspection."
+              "required": false
             }
           },
           {
             "access_token_signing_algorithm": {
               "type": "string",
-              "description": "When this plugin sets the upstream header as specified with `config.access_token_upstream_header`, re-signs the original access token using the private keys of the JWT Signer plugin. Specify the algorithm that is used to sign the token. The `config.access_token_issuer` specifies which `keyset` is used to sign the new token issued by Kong using the specified signing algorithm.",
-              "default": "RS256",
               "required": true,
               "one_of": [
                 "HS256",
@@ -298,267 +294,275 @@
                 "PS384",
                 "PS512",
                 "EdDSA"
-              ]
+              ],
+              "default": "RS256",
+              "description": "When this plugin sets the upstream header as specified with `config.access_token_upstream_header`, re-signs the original access token using the private keys of the JWT Signer plugin. Specify the algorithm that is used to sign the token. The `config.access_token_issuer` specifies which `keyset` is used to sign the new token issued by Kong using the specified signing algorithm."
             }
           },
           {
             "access_token_optional": {
-              "required": false,
-              "type": "boolean",
               "description": "If an access token is not provided or no `config.access_token_request_header` is specified, the plugin cannot verify the access token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Use this parameter to allow the request to proceed even when there is no token to check. If the token is provided, then this parameter has no effect",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_signature": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn access token signature verification off and on as needed.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_expiry": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn access token expiry verification off and on as needed.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_scopes": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn off and on the access token required scopes verification, specified with `config.access_token_scopes_required`.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_introspection_expiry": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn access token introspection expiry verification off and on as needed.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_access_token_introspection_scopes": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn off and on the access token introspection scopes verification, specified with `config.access_token_introspection_scopes_required`.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "cache_access_token_introspection": {
-              "required": false,
-              "type": "boolean",
               "description": "Whether to cache access token introspection results.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "trust_access_token_introspection": {
-              "required": false,
-              "type": "boolean",
               "description": "Use this parameter to enable and disable further checks on a payload before the new token is signed. If you set this to `true`, the expiry or scopes are not checked on a payload.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "enable_access_token_introspection": {
-              "required": false,
-              "type": "boolean",
               "description": "If you don't want to support opaque access tokens, change this configuration parameter to `false` to disable introspection.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "channel_token_issuer": {
-              "required": false,
-              "type": "string",
               "description": "The `iss` claim of the re-signed channel token is set to this value, which is `kong` by default. The original `iss` claim of the incoming token (possibly introspected) is stored in the `original_iss` claim of the newly signed channel token.",
-              "default": "kong"
+              "default": "kong",
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_keyset": {
-              "required": false,
-              "type": "string",
               "description": "The name of the keyset containing signing keys.",
-              "default": "kong"
+              "default": "kong",
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_jwks_uri": {
-              "required": false,
+              "description": "If you want to use `config.verify_channel_token_signature`, you must specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the channel token. If you don't specify a URI and you pass a JWT token to the plugin, then the plugin responds with `401 Unauthorized`.",
               "type": "string",
-              "description": "If you want to use `config.verify_channel_token_signature`, you must specify the URI where the plugin can fetch the public keys (JWKS) to verify the signature of the channel token. If you don't specify a URI and you pass a JWT token to the plugin, then the plugin responds with `401 Unauthorized`."
+              "required": false
             }
           },
           {
             "channel_token_request_header": {
-              "required": false,
+              "description": "This parameter tells the name of the header where to look for the channel token. If you don't want to do anything with the channel token, then you can set this to `null` or `\"\"` (empty string).",
               "type": "string",
-              "description": "This parameter tells the name of the header where to look for the channel token. If you don't want to do anything with the channel token, then you can set this to `null` or `\"\"` (empty string)."
+              "required": false
             }
           },
           {
             "channel_token_leeway": {
-              "required": false,
-              "type": "number",
               "description": "Adjusts clock skew between the token issuer and Kong. The value will be added to token's `exp` claim before checking token expiry against Kong servers current time in seconds. You can disable channel token `expiry` verification altogether with `config.verify_channel_token_expiry`.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "channel_token_scopes_required": {
-              "required": false,
-              "type": "array",
               "description": "Specify the required values (or scopes) that are checked by a claim specified by `config.channel_token_scopes_claim`.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "channel_token_scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "Specify the claim in a channel token to verify against values of `config.channel_token_scopes_required`. This supports nested claims.",
               "required": false,
               "default": [
                 "scope"
-              ]
+              ],
+              "elements": {
+                "type": "string"
+              },
+              "description": "Specify the claim in a channel token to verify against values of `config.channel_token_scopes_required`. This supports nested claims."
             }
           },
           {
             "channel_token_consumer_claim": {
-              "required": false,
-              "type": "array",
               "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter. Kong consumers have an `id`, a `username`, and a `custom_id`. If this parameter is enabled but the mapping fails, such as when there's a non-existent Kong consumer, the plugin responds with `403 Forbidden`.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "channel_token_consumer_by": {
-              "elements": {
-                "type": "string",
-                "one_of": [
-                  "id",
-                  "username",
-                  "custom_id"
-                ]
-              },
-              "type": "array",
               "description": "When the plugin tries to do channel token to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of valid values: `id`, `username`, and `custom_id`.",
               "default": [
                 "username",
                 "custom_id"
-              ]
+              ],
+              "type": "array",
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "id",
+                  "username",
+                  "custom_id"
+                ]
+              }
             }
           },
           {
             "channel_token_upstream_header": {
-              "required": false,
+              "description": "This plugin removes the `config.channel_token_request_header` from the request after reading its value.",
               "type": "string",
-              "description": "This plugin removes the `config.channel_token_request_header` from the request after reading its value."
+              "required": false
             }
           },
           {
             "channel_token_upstream_leeway": {
-              "required": false,
-              "type": "number",
               "description": "If you want to add or perhaps subtract (using negative value) expiry time of the original channel token, you can specify a value that is added to the original channel token's `exp` claim.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "channel_token_introspection_endpoint": {
-              "required": false,
+              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise, the plugin does not try introspection and returns `401 Unauthorized` instead.",
               "type": "string",
-              "description": "When you use `opaque` access tokens and you want to turn on access token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise, the plugin does not try introspection and returns `401 Unauthorized` instead."
+              "required": false
             }
           },
           {
             "channel_token_introspection_authorization": {
-              "required": false,
-              "type": "string",
               "description": "When using `opaque` channel tokens, and you want to turn on channel token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise the plugin will not try introspection, and instead returns `401 Unauthorized` when using opaque channel tokens.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_introspection_body_args": {
-              "required": false,
-              "type": "string",
               "description": "If you need to pass additional body arguments to introspection endpoint when the plugin introspects the opaque channel token, you can use this config parameter to specify them. You should URL encode the value. For example: `resource=` or `a=1&b=&c`.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_introspection_hint": {
-              "required": false,
-              "type": "string",
               "description": "If you need to give `hint` parameter when introspecting a channel token, you can use this parameter to specify the value of such parameter. By default, a `hint` isn't sent with channel token introspection.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "string",
+              "required": false
             }
           },
           {
             "channel_token_introspection_jwt_claim": {
-              "required": false,
-              "type": "array",
               "description": "If your introspection endpoint returns a channel token in one of the keys (or claims) in the introspection results (`JSON`), the plugin can use that value instead of the introspection results when doing expiry verification and signing of the new token issued by Kong.",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "channel_token_introspection_scopes_required": {
-              "required": false,
-              "type": "array",
-              "description": "Use this parameter to specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.channel_token_introspection_scopes_claim`.",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "channel_token_introspection_scopes_claim": {
               "elements": {
                 "type": "string"
               },
               "type": "array",
-              "description": "Use this parameter to specify the claim/property in channel token introspection results (`JSON`) to be verified against values of `config.channel_token_introspection_scopes_required`. This supports nested claims.",
+              "required": false
+            }
+          },
+          {
+            "channel_token_introspection_scopes_required": {
+              "description": "Use this parameter to specify the required values (or scopes) that are checked by an introspection claim/property specified by `config.channel_token_introspection_scopes_claim`.",
+              "elements": {
+                "type": "string"
+              },
+              "type": "array",
+              "required": false
+            }
+          },
+          {
+            "channel_token_introspection_scopes_claim": {
+              "type": "array",
               "required": false,
               "default": [
                 "scope"
-              ]
+              ],
+              "elements": {
+                "type": "string"
+              },
+              "description": "Use this parameter to specify the claim/property in channel token introspection results (`JSON`) to be verified against values of `config.channel_token_introspection_scopes_required`. This supports nested claims."
             }
           },
           {
             "channel_token_introspection_consumer_claim": {
-              "required": false,
-              "type": "array",
               "description": "When you set a value for this parameter, the plugin tries to map an arbitrary claim specified with this configuration parameter (such as `sub` or `username`) in channel token introspection results to Kong consumer entity",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "channel_token_introspection_consumer_by": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -567,35 +571,27 @@
                   "custom_id"
                 ]
               },
-              "type": "array",
-              "description": "When the plugin tries to do channel token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values. Valid values are `id`, `username` and `custom_id`.",
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ]
+              "description": "When the plugin tries to do channel token introspection results to Kong consumer mapping, it tries to find a matching Kong consumer from properties defined using this configuration parameter. The parameter can take an array of values. Valid values are `id`, `username` and `custom_id`."
             }
           },
           {
             "channel_token_introspection_leeway": {
-              "required": false,
-              "type": "number",
               "description": "You can use this parameter to adjust clock skew between the token issuer introspection results and Kong. The value will be added to introspection results (`JSON`) `exp` claim/property before checking token expiry against Kong servers current time (in seconds). You can disable channel token introspection `expiry` verification altogether with `config.verify_channel_token_introspection_expiry`.",
-              "default": 0
+              "default": 0,
+              "type": "number",
+              "required": false
             }
           },
           {
             "channel_token_introspection_timeout": {
-              "required": false,
+              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on channel token introspection.",
               "type": "number",
-              "description": "Timeout in milliseconds for an introspection request. The plugin tries to introspect twice if the first request fails for some reason. If both requests timeout, then the plugin runs two times the `config.access_token_introspection_timeout` on channel token introspection."
+              "required": false
             }
           },
           {
             "channel_token_signing_algorithm": {
               "type": "string",
-              "description": "When this plugin sets the upstream header as specified with `config.channel_token_upstream_header`, it also re-signs the original channel token using private keys of this plugin. Specify the algorithm that is used to sign the token.",
-              "default": "RS256",
               "required": true,
               "one_of": [
                 "HS256",
@@ -610,113 +606,117 @@
                 "PS384",
                 "PS512",
                 "EdDSA"
-              ]
+              ],
+              "default": "RS256",
+              "description": "When this plugin sets the upstream header as specified with `config.channel_token_upstream_header`, it also re-signs the original channel token using private keys of this plugin. Specify the algorithm that is used to sign the token."
             }
           },
           {
             "channel_token_optional": {
-              "required": false,
-              "type": "boolean",
               "description": "If a channel token is not provided or no `config.channel_token_request_header` is specified, the plugin cannot verify the channel token. In that case, the plugin normally responds with `401 Unauthorized` (client didn't send a token) or `500 Unexpected` (a configuration error). Enable this parameter to allow the request to proceed even when there is no channel token to check. If the channel token is provided, then this parameter has no effect",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_signature": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn on/off the channel token signature verification.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_expiry": {
-              "required": false,
+              "default": true,
               "type": "boolean",
-              "default": true
+              "required": false
             }
           },
           {
             "verify_channel_token_scopes": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn on/off the channel token required scopes verification specified with `config.channel_token_scopes_required`.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_introspection_expiry": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn on/off the channel token introspection expiry verification.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "verify_channel_token_introspection_scopes": {
-              "required": false,
-              "type": "boolean",
               "description": "Quickly turn on/off the channel token introspection scopes verification specified with `config.channel_token_introspection_scopes_required`.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "cache_channel_token_introspection": {
-              "required": false,
-              "type": "boolean",
               "description": "Whether to cache channel token introspection results.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "trust_channel_token_introspection": {
-              "required": false,
-              "type": "boolean",
               "description": "Providing an opaque channel token for plugin introspection, and verifying expiry and scopes on introspection results may make further payload checks unnecessary before the plugin signs a new token. This also applies when using a JWT token with introspection JSON as per config.channel_token_introspection_jwt_claim. Use this parameter to manage additional payload checks before signing a new token. With true (default), payload's expiry or scopes aren't checked.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "enable_channel_token_introspection": {
-              "required": false,
-              "type": "boolean",
               "description": "If you don't want to support opaque channel tokens, disable introspection by changing this configuration parameter to `false`.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "add_claims": {
-              "type": "map",
-              "description": "Add customized claims if they are not present yet.",
               "keys": {
                 "type": "string"
               },
+              "type": "map",
               "required": false,
+              "default": [
+
+              ],
               "values": {
                 "type": "string"
               },
-              "default": [
-
-              ]
+              "description": "Add customized claims if they are not present yet."
             }
           },
           {
             "set_claims": {
-              "type": "map",
-              "description": "Set customized claims. If a claim is already present, it will be overwritten.",
               "keys": {
                 "type": "string"
               },
+              "type": "map",
               "required": false,
+              "default": [
+
+              ],
               "values": {
                 "type": "string"
               },
-              "default": [
-
-              ]
+              "description": "Set customized claims. If a claim is already present, it will be overwritten."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/jwt/3.5.x.json
+++ b/schemas/jwt/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,52 +27,42 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "uri_param_names": {
-              "elements": {
-                "type": "string"
-              },
-              "type": "set",
               "description": "A list of querystring parameters that Kong will inspect to retrieve JWTs.",
               "default": [
                 "jwt"
-              ]
+              ],
+              "type": "set",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "cookie_names": {
-              "elements": {
-                "type": "string"
-              },
-              "type": "set",
               "description": "A list of cookie names that Kong will inspect to retrieve JWTs.",
               "default": [
 
-              ]
+              ],
+              "type": "set",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
@@ -77,62 +75,64 @@
           {
             "secret_is_base64": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "If true, the plugin assumes the credential’s secret to be base64 encoded. You will need to create a base64-encoded secret for your Consumer, and sign your JWT with the original secret.",
-              "default": false
+              "description": "If true, the plugin assumes the credential’s secret to be base64 encoded. You will need to create a base64-encoded secret for your Consumer, and sign your JWT with the original secret."
             }
           },
           {
             "claims_to_verify": {
+              "description": "A list of registered claims (according to RFC 7519) that Kong can verify as well. Accepted values: one of exp or nbf.",
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
                   "exp",
                   "nbf"
                 ]
-              },
-              "type": "set",
-              "description": "A list of registered claims (according to RFC 7519) that Kong can verify as well. Accepted values: one of exp or nbf."
+              }
             }
           },
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
             }
           },
           {
             "run_on_preflight": {
               "required": true,
+              "default": true,
               "type": "boolean",
-              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed.",
-              "default": true
+              "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on OPTIONS preflight requests. If set to false, then OPTIONS requests will always be allowed."
             }
           },
           {
             "maximum_expiration": {
-              "default": 0,
-              "type": "number",
-              "description": "A value between 0 and 31536000 (365 days) limiting the lifetime of the JWT to maximum_expiration seconds in the future.",
               "between": [
                 0,
                 31536000
-              ]
+              ],
+              "default": 0,
+              "type": "number",
+              "description": "A value between 0 and 31536000 (365 days) limiting the lifetime of the JWT to maximum_expiration seconds in the future."
             }
           },
           {
             "header_names": {
-              "elements": {
-                "type": "string"
-              },
-              "type": "set",
               "description": "A list of HTTP header names that Kong will inspect to retrieve JWTs.",
               "default": [
                 "authorization"
-              ]
+              ],
+              "type": "set",
+              "elements": {
+                "type": "string"
+              }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/kafka-log/3.5.x.json
+++ b/schemas/kafka-log/3.5.x.json
@@ -3,7 +3,6 @@
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -12,6 +11,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -28,15 +28,13 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -49,6 +47,8 @@
         "fields": [
           {
             "bootstrap_servers": {
+              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format.",
+              "type": "set",
               "elements": {
                 "type": "record",
                 "fields": [
@@ -61,19 +61,17 @@
                   },
                   {
                     "port": {
-                      "required": true,
-                      "type": "integer",
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
                       "between": [
                         0,
                         65535
-                      ]
+                      ],
+                      "required": true,
+                      "type": "integer",
+                      "description": "An integer representing a port number between 0 and 65535, inclusive."
                     }
                   }
                 ]
-              },
-              "type": "set",
-              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format."
+              }
             }
           },
           {
@@ -92,41 +90,39 @@
           },
           {
             "keepalive": {
-              "default": 60000,
-              "type": "integer"
+              "type": "integer",
+              "default": 60000
             }
           },
           {
             "keepalive_enabled": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "authentication": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "strategy": {
                     "required": false,
-                    "type": "string",
-                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`.",
                     "one_of": [
                       "sasl"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`."
                   }
                 },
                 {
                   "mechanism": {
                     "required": false,
-                    "type": "string",
-                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN` or `SCRAM-SHA-256`.",
                     "one_of": [
                       "PLAIN",
                       "SCRAM-SHA-256",
                       "SCRAM-SHA-512"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN` or `SCRAM-SHA-256`."
                   }
                 },
                 {
@@ -138,36 +134,36 @@
                 },
                 {
                   "user": {
-                    "referenceable": true,
-                    "description": "Username for SASL authentication.",
+                    "type": "string",
                     "required": false,
+                    "referenceable": true,
                     "encrypted": true,
-                    "type": "string"
+                    "description": "Username for SASL authentication."
                   }
                 },
                 {
                   "password": {
-                    "referenceable": true,
-                    "description": "Password for SASL authentication.",
+                    "type": "string",
                     "required": false,
+                    "referenceable": true,
                     "encrypted": true,
-                    "type": "string"
+                    "description": "Password for SASL authentication."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "security": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "certificate_id": {
-                    "required": false,
-                    "type": "string",
+                    "uuid": true,
                     "description": "UUID of certificate entity for mTLS authentication.",
-                    "uuid": true
+                    "type": "string",
+                    "required": false
                   }
                 },
                 {
@@ -177,27 +173,29 @@
                     "description": "Enables TLS."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "cluster_name": {
               "required": false,
               "type": "string",
-              "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster.",
-              "auto": true
+              "auto": true,
+              "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster."
             }
           },
           {
             "producer_request_acks": {
-              "default": 1,
-              "type": "integer",
-              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set).",
               "one_of": [
                 -1,
                 0,
                 1
-              ]
+              ],
+              "default": 1,
+              "type": "integer",
+              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set)."
             }
           },
           {
@@ -258,19 +256,21 @@
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
+              "type": "map",
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "type": "map",
-              "description": "Lua code as a key-value map",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "Lua code as a key-value map"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/kafka-upstream/3.5.x.json
+++ b/schemas/kafka-upstream/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -56,6 +54,8 @@
         "fields": [
           {
             "bootstrap_servers": {
+              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format.",
+              "type": "set",
               "elements": {
                 "type": "record",
                 "fields": [
@@ -68,19 +68,17 @@
                   },
                   {
                     "port": {
-                      "required": true,
-                      "type": "integer",
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
                       "between": [
                         0,
                         65535
-                      ]
+                      ],
+                      "required": true,
+                      "type": "integer",
+                      "description": "An integer representing a port number between 0 and 65535, inclusive."
                     }
                   }
                 ]
-              },
-              "type": "set",
-              "description": "Set of bootstrap brokers in a `{host: host, port: port}` list format."
+              }
             }
           },
           {
@@ -106,35 +104,33 @@
           },
           {
             "keepalive_enabled": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "authentication": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "strategy": {
                     "required": false,
-                    "type": "string",
-                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`.",
                     "one_of": [
                       "sasl"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "The authentication strategy for the plugin, the only option for the value is `sasl`."
                   }
                 },
                 {
                   "mechanism": {
                     "required": false,
-                    "type": "string",
-                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.",
                     "one_of": [
                       "PLAIN",
                       "SCRAM-SHA-256",
                       "SCRAM-SHA-512"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "The SASL authentication mechanism.  Supported options: `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`."
                   }
                 },
                 {
@@ -146,36 +142,36 @@
                 },
                 {
                   "user": {
-                    "referenceable": true,
-                    "description": "Username for SASL authentication.",
-                    "encrypted": true,
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "referenceable": true,
+                    "encrypted": true,
+                    "description": "Username for SASL authentication."
                   }
                 },
                 {
                   "password": {
-                    "referenceable": true,
-                    "description": "Password for SASL authentication.",
-                    "encrypted": true,
                     "type": "string",
-                    "required": false
+                    "required": false,
+                    "referenceable": true,
+                    "encrypted": true,
+                    "description": "Password for SASL authentication."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "security": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "certificate_id": {
                     "uuid": true,
+                    "required": false,
                     "type": "string",
-                    "description": "UUID of certificate entity for mTLS authentication.",
-                    "required": false
+                    "description": "UUID of certificate entity for mTLS authentication."
                   }
                 },
                 {
@@ -185,7 +181,9 @@
                     "description": "Enables TLS."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
@@ -219,21 +217,21 @@
           {
             "cluster_name": {
               "required": false,
-              "type": "string",
               "auto": true,
+              "type": "string",
               "description": "An identifier for the Kafka cluster. By default, this field generates a random string. You can also set your own custom cluster identifier.  If more than one Kafka plugin is configured without a `cluster_name` (that is, if the default autogenerated value is removed), these plugins will use the same producer, and by extension, the same cluster. Logs will be sent to the leader of the cluster."
             }
           },
           {
             "producer_request_acks": {
-              "default": 1,
-              "type": "integer",
-              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set).",
               "one_of": [
                 -1,
                 0,
                 1
-              ]
+              ],
+              "default": 1,
+              "type": "integer",
+              "description": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments; 1 for only the leader; and -1 for the full ISR (In-Sync Replica set)."
             }
           },
           {
@@ -292,7 +290,9 @@
               "description": "Maximum number of messages that can be buffered in memory in asynchronous mode."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/key-auth-enc/3.5.x.json
+++ b/schemas/key-auth-enc/3.5.x.json
@@ -3,15 +3,14 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -20,6 +19,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,28 +36,26 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "key_names": {
-              "elements": {
-                "description": "A string representing an HTTP header name.",
-                "type": "string"
-              },
               "type": "array",
-              "description": "Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name.  Key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.",
               "required": true,
               "default": [
                 "apikey"
-              ]
+              ],
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              },
+              "description": "Describes an array of parameter names where the plugin will look for a key. The client must send the authentication key in one of those key names, and the plugin will try to read the credential from a header, request body, or query string parameter with the same name.  Key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen."
             }
           },
           {
@@ -69,8 +67,8 @@
           },
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
@@ -101,7 +99,9 @@
               "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/key-auth/3.5.x.json
+++ b/schemas/key-auth/3.5.x.json
@@ -3,15 +3,14 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -20,6 +19,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,77 +36,77 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "key_names": {
-              "elements": {
-                "description": "A string representing an HTTP header name.",
-                "type": "string"
-              },
               "type": "array",
-              "description": "Describes an array of parameter names where the plugin will look for a key. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen.",
               "required": true,
               "default": [
                 "apikey"
-              ]
+              ],
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              },
+              "description": "Describes an array of parameter names where the plugin will look for a key. The key names may only contain [a-z], [A-Z], [0-9], [_] underscore, and [-] hyphen."
             }
           },
           {
             "hide_credentials": {
-              "required": true,
-              "type": "boolean",
               "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service. If `true`, the plugin strips the credential from the request.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`."
             }
           },
           {
             "key_in_header": {
-              "required": true,
-              "type": "boolean",
               "description": "If enabled (default), the plugin reads the request header and tries to find the key in it.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "key_in_query": {
-              "required": true,
-              "type": "boolean",
               "description": "If enabled (default), the plugin reads the query parameter in the request and tries to find the key in it.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "key_in_body": {
-              "required": true,
-              "type": "boolean",
               "description": "If enabled, the plugin reads the request body. Supported MIME types: `application/www-form-urlencoded`, `application/json`, and `multipart/form-data`.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "run_on_preflight": {
-              "required": true,
-              "type": "boolean",
               "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests are always allowed.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/konnect-application-auth/3.5.x.json
+++ b/schemas/konnect-application-auth/3.5.x.json
@@ -3,21 +3,29 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "route": {
         "type": "foreign",
-        "description": "A reference to the 'routes' table with a null value allowed.",
         "eq": null,
-        "reference": "routes"
+        "reference": "routes",
+        "description": "A reference to the 'routes' table with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -27,68 +35,60 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
 
         ],
         "fields": [
           {
             "key_names": {
-              "elements": {
-                "description": "A string representing an HTTP header name.",
-                "type": "string"
-              },
               "type": "array",
-              "description": "The names of the headers containing the API key. You can specify multiple header names.",
               "required": true,
               "default": [
                 "apikey"
-              ]
+              ],
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              },
+              "description": "The names of the headers containing the API key. You can specify multiple header names."
             }
           },
           {
             "auth_type": {
               "type": "string",
-              "description": "The type of authentication to be performed. Possible values are: 'openid-connect', 'key-auth'.",
               "required": true,
-              "default": "openid-connect",
               "one_of": [
                 "openid-connect",
                 "key-auth"
-              ]
+              ],
+              "default": "openid-connect",
+              "description": "The type of authentication to be performed. Possible values are: 'openid-connect', 'key-auth'."
             }
           },
           {
             "scope": {
-              "required": true,
-              "type": "string",
               "description": "The unique scope identifier for the plugin configuration.",
-              "unique": true
+              "unique": true,
+              "type": "string",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/ldap-auth-advanced/3.5.x.json
+++ b/schemas/ldap-auth-advanced/3.5.x.json
@@ -3,7 +3,6 @@
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -12,6 +11,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -28,23 +28,21 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "ldap_host": {
@@ -57,8 +55,8 @@
             "ldap_password": {
               "encrypted": true,
               "referenceable": true,
-              "description": "The password to the LDAP server.",
-              "type": "string"
+              "type": "string",
+              "description": "The password to the LDAP server."
             }
           },
           {
@@ -71,32 +69,32 @@
           {
             "bind_dn": {
               "referenceable": true,
-              "description": "The DN to bind to. Used to perform LDAP search of user. This `bind_dn` should have permissions to search for the user being authenticated.",
-              "type": "string"
+              "type": "string",
+              "description": "The DN to bind to. Used to perform LDAP search of user. This `bind_dn` should have permissions to search for the user being authenticated."
             }
           },
           {
             "ldaps": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
-              "required": true
+              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled."
             }
           },
           {
             "start_tls": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
-              "required": true
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled."
             }
           },
           {
             "verify_ldap_host": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
-              "required": true
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive."
             }
           },
           {
@@ -115,10 +113,10 @@
           },
           {
             "cache_ttl": {
+              "required": true,
               "default": 60,
               "type": "number",
-              "description": "Cache expiry time in seconds.",
-              "required": true
+              "description": "Cache expiry time in seconds."
             }
           },
           {
@@ -144,10 +142,10 @@
           },
           {
             "anonymous": {
+              "len_min": 0,
               "default": "",
               "type": "string",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "len_min": 0
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
@@ -159,14 +157,20 @@
           },
           {
             "consumer_optional": {
+              "required": false,
               "default": false,
               "type": "boolean",
-              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user.",
-              "required": false
+              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user."
             }
           },
           {
             "consumer_by": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -174,25 +178,19 @@
                   "custom_id"
                 ]
               },
-              "type": "array",
-              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both.",
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ]
+              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both."
             }
           },
           {
             "group_base_dn": {
-              "description": "Sets a distinguished name (DN) for the entry where LDAP searches for groups begin. This field is case-insensitive.',dc=com'.",
-              "type": "string"
+              "type": "string",
+              "description": "Sets a distinguished name (DN) for the entry where LDAP searches for groups begin. This field is case-insensitive.',dc=com'."
             }
           },
           {
             "group_name_attribute": {
-              "description": "Sets the attribute holding the name of a group, typically called `name` (in Active Directory) or `cn` (in OpenLDAP). This field is case-insensitive.",
-              "type": "string"
+              "type": "string",
+              "description": "Sets the attribute holding the name of a group, typically called `name` (in Active Directory) or `cn` (in OpenLDAP). This field is case-insensitive."
             }
           },
           {
@@ -204,23 +202,25 @@
           },
           {
             "log_search_results": {
+              "required": false,
               "default": false,
               "type": "boolean",
-              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment.",
-              "required": false
+              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment."
             }
           },
           {
             "groups_required": {
               "required": false,
-              "type": "array",
-              "description": "The groups required to be present in the LDAP search result for successful authorization. This config parameter works in both **AND** / **OR** cases. - When `[\"group1 group2\"]` are in the same array indices, both `group1` AND `group2` need to be present in the LDAP search result. - When `[\"group1\", \"group2\"]` are in different array indices, either `group1` OR `group2` need to be present in the LDAP search result.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "description": "The groups required to be present in the LDAP search result for successful authorization. This config parameter works in both **AND** / **OR** cases. - When `[\"group1 group2\"]` are in the same array indices, both `group1` AND `group2` need to be present in the LDAP search result. - When `[\"group1\", \"group2\"]` are in different array indices, either `group1` OR `group2` need to be present in the LDAP search result."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/ldap-auth/3.5.x.json
+++ b/schemas/ldap-auth/3.5.x.json
@@ -3,15 +3,14 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -20,6 +19,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,27 +36,25 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "conditional": {
-              "then_field": "start_tls",
               "then_match": {
                 "eq": false
               },
-              "then_err": "'ldaps' and 'start_tls' cannot be enabled simultaneously",
+              "then_field": "start_tls",
               "if_match": {
                 "eq": true
               },
-              "if_field": "ldaps"
+              "if_field": "ldaps",
+              "then_err": "'ldaps' and 'start_tls' cannot be enabled simultaneously"
             }
           }
         ],
@@ -70,67 +68,67 @@
           },
           {
             "ldap_port": {
+              "type": "integer",
+              "required": true,
               "between": [
                 0,
                 65535
               ],
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "default": 389,
-              "required": true
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "ldaps": {
+              "description": "Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
               "default": false,
               "type": "boolean",
-              "description": "Set to `true` to connect using the LDAPS protocol (LDAP over TLS).  When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
               "required": true
             }
           },
           {
             "start_tls": {
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
               "default": false,
               "type": "boolean",
-              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
               "required": true
             }
           },
           {
             "verify_ldap_host": {
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
               "default": false,
               "type": "boolean",
-              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
               "required": true
             }
           },
           {
             "base_dn": {
-              "required": true,
+              "description": "Base DN as the starting point for the search; e.g., dc=example,dc=com",
               "type": "string",
-              "description": "Base DN as the starting point for the search; e.g., dc=example,dc=com"
+              "required": true
             }
           },
           {
             "attribute": {
-              "required": true,
+              "description": "Attribute to be used to search the user; e.g. cn",
               "type": "string",
-              "description": "Attribute to be used to search the user; e.g. cn"
+              "required": true
             }
           },
           {
             "cache_ttl": {
+              "description": "Cache expiry time in seconds.",
               "default": 60,
               "type": "number",
-              "description": "Cache expiry time in seconds.",
               "required": true
             }
           },
           {
             "hide_credentials": {
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
               "required": true
             }
           },
@@ -150,8 +148,8 @@
           },
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`."
             }
           },
           {
@@ -161,7 +159,9 @@
               "description": "An optional string to use as part of the Authorization header"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/loggly/3.5.x.json
+++ b/schemas/loggly/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "host": {
@@ -51,21 +49,21 @@
           },
           {
             "port": {
-              "default": 514,
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 514,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "key": {
               "encrypted": true,
+              "referenceable": true,
               "type": "string",
-              "required": true,
-              "referenceable": true
+              "required": true
             }
           },
           {
@@ -145,25 +143,27 @@
           },
           {
             "timeout": {
-              "default": 10000,
-              "type": "number"
+              "type": "number",
+              "default": 10000
             }
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
+              "type": "map",
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "type": "map",
-              "description": "Lua code as a key-value map",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "Lua code as a key-value map"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/mocking/3.5.x.json
+++ b/schemas/mocking/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "api_specification_filename": {
@@ -79,30 +77,32 @@
           },
           {
             "included_status_codes": {
+              "description": "A global list of the HTTP status codes that can only be selected and returned.",
+              "type": "array",
               "elements": {
                 "type": "integer"
-              },
-              "type": "array",
-              "description": "A global list of the HTTP status codes that can only be selected and returned."
+              }
             }
           },
           {
             "random_status_code": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Determines whether to randomly select an HTTP status code from the responses of the corresponding API method. The default value is `false`, which means the minimum HTTP status code is always selected and returned.",
-              "default": false
+              "description": "Determines whether to randomly select an HTTP status code from the responses of the corresponding API method. The default value is `false`, which means the minimum HTTP status code is always selected and returned."
             }
           },
           {
             "include_base_path": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Indicates whether to include the base path when performing path match evaluation.",
-              "default": false
+              "description": "Indicates whether to include the base path when performing path match evaluation."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/mtls-auth/3.5.x.json
+++ b/schemas/mtls-auth/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,29 +27,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "mutually_required": [
@@ -59,12 +57,18 @@
         "fields": [
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "consumer_by": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -72,73 +76,67 @@
                   "custom_id"
                 ]
               },
-              "type": "array",
-              "description": "Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array), then auto-matching is disabled.",
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ]
+              "description": "Whether to match the subject name of the client-supplied certificate against consumer's `username` and/or `custom_id` attribute. If set to `[]` (the empty array), then auto-matching is disabled."
             }
           },
           {
             "ca_certificates": {
               "required": true,
-              "type": "array",
-              "description": "List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`).",
               "elements": {
                 "uuid": true,
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "description": "List of CA Certificates strings to use as Certificate Authorities (CA) when validating a client certificate. At least one is required but you can specify as many as needed. The value of this array is comprised of primary keys (`id`)."
             }
           },
           {
             "cache_ttl": {
               "required": true,
+              "default": 60,
               "type": "number",
-              "description": "Cache expiry time in seconds.",
-              "default": 60
+              "description": "Cache expiry time in seconds."
             }
           },
           {
             "skip_consumer_lookup": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Skip consumer lookup once certificate is trusted against the configured CA list.",
-              "default": false
+              "description": "Skip consumer lookup once certificate is trusted against the configured CA list."
             }
           },
           {
             "allow_partial_chain": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Allow certificate verification with only an intermediate certificate. When this is enabled, you don't need to upload the full chain to Kong Certificates.",
-              "default": false
+              "description": "Allow certificate verification with only an intermediate certificate. When this is enabled, you don't need to upload the full chain to Kong Certificates."
             }
           },
           {
             "authenticated_group_by": {
               "type": "string",
-              "description": "Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API. To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users.",
               "required": false,
-              "default": "CN",
               "one_of": [
                 "CN",
                 "DN"
-              ]
+              ],
+              "default": "CN",
+              "description": "Certificate property to use as the authenticated group. Valid values are `CN` (Common Name) or `DN` (Distinguished Name). Once `skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API. To restrict usage to only some of the authenticated users, also add the ACL plugin (not covered here) and create allowed or denied groups of users."
             }
           },
           {
             "revocation_check_mode": {
               "type": "string",
-              "description": "Controls client certificate revocation check behavior. If set to `SKIP`, no revocation check is performed. If set to `IGNORE_CA_ERROR`, the plugin respects the revocation status when either OCSP or CRL URL is set, and doesn't fail on network issues. If set to `STRICT`, the plugin only treats the certificate as valid when it's able to verify the revocation status.",
               "required": false,
-              "default": "IGNORE_CA_ERROR",
               "one_of": [
                 "SKIP",
                 "IGNORE_CA_ERROR",
                 "STRICT"
-              ]
+              ],
+              "default": "IGNORE_CA_ERROR",
+              "description": "Controls client certificate revocation check behavior. If set to `SKIP`, no revocation check is performed. If set to `IGNORE_CA_ERROR`, the plugin respects the revocation status when either OCSP or CRL URL is set, and doesn't fail on network issues. If set to `STRICT`, the plugin only treats the certificate as valid when it's able to verify the revocation status."
             }
           },
           {
@@ -164,8 +162,8 @@
           },
           {
             "http_proxy_host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -180,8 +178,8 @@
           },
           {
             "https_proxy_host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
@@ -194,7 +192,9 @@
               "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/oas-validation/3.5.x.json
+++ b/schemas/oas-validation/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "api_spec": {
@@ -44,101 +42,103 @@
           },
           {
             "verbose_response": {
+              "required": false,
               "default": false,
               "type": "boolean",
-              "description": "If set to true, returns a detailed error message for invalid requests & responses. This is useful while testing.",
-              "required": false
+              "description": "If set to true, returns a detailed error message for invalid requests & responses. This is useful while testing."
             }
           },
           {
             "validate_request_body": {
+              "required": false,
               "default": true,
               "type": "boolean",
-              "description": "If set to true, validates the request body content against the API specification.",
-              "required": false
+              "description": "If set to true, validates the request body content against the API specification."
             }
           },
           {
             "notify_only_request_validation_failure": {
+              "required": false,
               "default": false,
               "type": "boolean",
-              "description": "If set to true, notifications via event hooks are enabled, but request based validation failures don't affect the request flow.",
-              "required": false
+              "description": "If set to true, notifications via event hooks are enabled, but request based validation failures don't affect the request flow."
             }
           },
           {
             "validate_request_header_params": {
+              "required": false,
               "default": true,
               "type": "boolean",
-              "description": "If set to true, validates HTTP header parameters against the API specification.",
-              "required": false
+              "description": "If set to true, validates HTTP header parameters against the API specification."
             }
           },
           {
             "validate_request_query_params": {
+              "required": false,
               "default": true,
               "type": "boolean",
-              "description": "If set to true, validates query parameters against the API specification.",
-              "required": false
+              "description": "If set to true, validates query parameters against the API specification."
             }
           },
           {
             "validate_request_uri_params": {
+              "required": false,
               "default": true,
               "type": "boolean",
-              "description": "If set to true, validates URI parameters in the request against the API specification.",
-              "required": false
+              "description": "If set to true, validates URI parameters in the request against the API specification."
             }
           },
           {
             "validate_response_body": {
+              "required": false,
               "default": false,
               "type": "boolean",
-              "description": "If set to true, validates the response from the upstream services against the API specification. If validation fails, it results in an `HTTP 406 Not Acceptable` status code.",
-              "required": false
+              "description": "If set to true, validates the response from the upstream services against the API specification. If validation fails, it results in an `HTTP 406 Not Acceptable` status code."
             }
           },
           {
             "notify_only_response_body_validation_failure": {
+              "required": false,
               "default": false,
               "type": "boolean",
-              "description": "If set to true, notifications via event hooks are enabled, but response validation failures don't affect the response flow.",
-              "required": false
+              "description": "If set to true, notifications via event hooks are enabled, but response validation failures don't affect the response flow."
             }
           },
           {
             "query_parameter_check": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "If set to true, checks if query parameters in the request exist in the API specification.",
-              "required": true
+              "description": "If set to true, checks if query parameters in the request exist in the API specification."
             }
           },
           {
             "header_parameter_check": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "If set to true, checks if HTTP header parameters in the request exist in the API specification.",
-              "required": true
+              "description": "If set to true, checks if HTTP header parameters in the request exist in the API specification."
             }
           },
           {
             "allowed_header_parameters": {
+              "required": false,
               "default": "Host,Content-Type,User-Agent,Accept,Content-Length",
               "type": "string",
-              "description": "List of header parameters in the request that will be ignored when performing HTTP header validation. These are additional headers added to an API request beyond those defined in the API specification.  For example, you might include the HTTP header `User-Agent`, which lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent.",
-              "required": false
+              "description": "List of header parameters in the request that will be ignored when performing HTTP header validation. These are additional headers added to an API request beyond those defined in the API specification.  For example, you might include the HTTP header `User-Agent`, which lets servers and network peers identify the application, operating system, vendor, and/or version of the requesting user agent."
             }
           },
           {
             "include_base_path": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Indicates whether to include the base path when performing path match evaluation.",
-              "required": true
+              "description": "Indicates whether to include the base path when performing path match evaluation."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/oauth2-introspection/3.5.x.json
+++ b/schemas/oauth2-introspection/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,29 +27,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "introspection_url": {
@@ -59,15 +57,15 @@
           },
           {
             "token_type_hint": {
-              "description": "The `token_type_hint` value to associate to introspection requests.",
-              "type": "string"
+              "type": "string",
+              "description": "The `token_type_hint` value to associate to introspection requests."
             }
           },
           {
             "authorization_value": {
-              "required": true,
+              "description": "The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`).",
               "type": "string",
-              "description": "The value to set as the `Authorization` header when querying the introspection endpoint. This depends on the OAuth 2.0 server, but usually is the `client_id` and `client_secret` as a Base64-encoded Basic Auth string (`Basic MG9hNWl...`)."
+              "required": true
             }
           },
           {
@@ -86,9 +84,9 @@
           },
           {
             "introspect_request": {
+              "description": "A boolean indicating whether to forward information about the current downstream request to the introspect endpoint. If true, headers `X-Request-Path` and `X-Request-Http-Method` will be inserted into the introspect request.",
               "default": false,
               "type": "boolean",
-              "description": "A boolean indicating whether to forward information about the current downstream request to the introspect endpoint. If true, headers `X-Request-Path` and `X-Request-Http-Method` will be inserted into the introspect request.",
               "required": true
             }
           },
@@ -109,53 +107,55 @@
           {
             "anonymous": {
               "len_min": 0,
+              "default": "",
               "type": "string",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "default": ""
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "consumer_by": {
               "type": "string",
-              "description": "A string indicating whether to associate OAuth2 `username` or `client_id` with the consumer's username. OAuth2 `username` is mapped to a consumer's `username` field, while an OAuth2 `client_id` maps to a consumer's `custom_id`.",
               "required": true,
-              "default": "username",
               "one_of": [
                 "username",
                 "client_id"
-              ]
+              ],
+              "default": "username",
+              "description": "A string indicating whether to associate OAuth2 `username` or `client_id` with the consumer's username. OAuth2 `username` is mapped to a consumer's `username` field, while an OAuth2 `client_id` maps to a consumer's `custom_id`."
             }
           },
           {
             "custom_introspection_headers": {
-              "type": "map",
-              "description": "A list of custom headers to be added in the introspection request.",
               "keys": {
                 "type": "string"
               },
+              "type": "map",
               "required": true,
+              "default": [
+
+              ],
               "values": {
                 "type": "string"
               },
-              "default": [
-
-              ]
+              "description": "A list of custom headers to be added in the introspection request."
             }
           },
           {
             "custom_claims_forward": {
-              "elements": {
-                "type": "string"
-              },
               "type": "set",
-              "description": "A list of custom claims to be forwarded from the introspection response to the upstream request. Claims are forwarded in headers with prefix `X-Credential-{claim-name}`.",
               "required": true,
               "default": [
 
-              ]
+              ],
+              "elements": {
+                "type": "string"
+              },
+              "description": "A list of custom claims to be forwarded from the introspection response to the upstream request. Claims are forwarded in headers with prefix `X-Credential-{claim-name}`."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/oauth2/3.5.x.json
+++ b/schemas/oauth2/3.5.x.json
@@ -3,15 +3,14 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "grpc",
           "grpcs",
@@ -20,6 +19,7 @@
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -36,14 +36,13 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
         "entity_checks": [
           {
             "conditional": {
@@ -58,103 +57,102 @@
             }
           }
         ],
-        "type": "record",
         "fields": [
           {
             "scopes": {
+              "description": "Describes an array of scope names that will be available to the end user. If `mandatory_scope` is set to `true`, then `scopes` are required.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Describes an array of scope names that will be available to the end user. If `mandatory_scope` is set to `true`, then `scopes` are required."
+              }
             }
           },
           {
             "mandatory_scope": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value telling the plugin to require at least one `scope` to be authorized by the end user.",
-              "required": true
+              "description": "An optional boolean value telling the plugin to require at least one `scope` to be authorized by the end user."
             }
           },
           {
             "provision_key": {
               "type": "string",
-              "description": "The unique key the plugin has generated when it has been added to the Service.",
               "unique": true,
-              "required": true,
               "encrypted": true,
-              "auto": true
+              "required": true,
+              "auto": true,
+              "description": "The unique key the plugin has generated when it has been added to the Service."
             }
           },
           {
             "token_expiration": {
+              "required": true,
               "default": 7200,
               "type": "number",
-              "description": "An optional integer value telling the plugin how many seconds a token should last, after which the client will need to refresh the token. Set to `0` to disable the expiration.",
-              "required": true
+              "description": "An optional integer value telling the plugin how many seconds a token should last, after which the client will need to refresh the token. Set to `0` to disable the expiration."
             }
           },
           {
             "enable_authorization_code": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value to enable the three-legged Authorization Code flow (RFC 6742 Section 4.1).",
-              "required": true
+              "description": "An optional boolean value to enable the three-legged Authorization Code flow (RFC 6742 Section 4.1)."
             }
           },
           {
             "enable_implicit_grant": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value to enable the Implicit Grant flow which allows to provision a token as a result of the authorization process (RFC 6742 Section 4.2).",
-              "required": true
+              "description": "An optional boolean value to enable the Implicit Grant flow which allows to provision a token as a result of the authorization process (RFC 6742 Section 4.2)."
             }
           },
           {
             "enable_client_credentials": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value to enable the Client Credentials Grant flow (RFC 6742 Section 4.4).",
-              "required": true
+              "description": "An optional boolean value to enable the Client Credentials Grant flow (RFC 6742 Section 4.4)."
             }
           },
           {
             "enable_password_grant": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value to enable the Resource Owner Password Credentials Grant flow (RFC 6742 Section 4.3).",
-              "required": true
+              "description": "An optional boolean value to enable the Resource Owner Password Credentials Grant flow (RFC 6742 Section 4.3)."
             }
           },
           {
             "hide_credentials": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service.",
-              "required": true
+              "description": "An optional boolean value telling the plugin to show or hide the credential from the upstream service."
             }
           },
           {
             "accept_http_if_already_terminated": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Accepts HTTPs requests that have already been terminated by a proxy or load balancer.",
-              "required": true
+              "description": "Accepts HTTPs requests that have already been terminated by a proxy or load balancer."
             }
           },
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails."
             }
           },
           {
             "global_credentials": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value that allows using the same OAuth credentials generated by the plugin with any other service whose OAuth 2.0 plugin configuration also has `config.global_credentials=true`.",
-              "required": true
+              "description": "An optional boolean value that allows using the same OAuth credentials generated by the plugin with any other service whose OAuth 2.0 plugin configuration also has `config.global_credentials=true`."
             }
           },
           {
@@ -166,22 +164,22 @@
           },
           {
             "refresh_token_ttl": {
+              "type": "number",
+              "required": true,
               "between": [
                 0,
                 100000000
               ],
-              "type": "number",
-              "description": "Time-to-live value for data",
               "default": 1209600,
-              "required": true
+              "description": "Time-to-live value for data"
             }
           },
           {
             "reuse_refresh_token": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "An optional boolean value that indicates whether an OAuth refresh token is reused when refreshing an access token.",
-              "required": true
+              "description": "An optional boolean value that indicates whether an OAuth refresh token is reused when refreshing an access token."
             }
           },
           {
@@ -194,17 +192,19 @@
           {
             "pkce": {
               "type": "string",
-              "description": "Specifies a mode of how the Proof Key for Code Exchange (PKCE) should be handled by the plugin.",
               "required": false,
-              "default": "lax",
               "one_of": [
                 "none",
                 "lax",
                 "strict"
-              ]
+              ],
+              "default": "lax",
+              "description": "Specifies a mode of how the Proof Key for Code Exchange (PKCE) should be handled by the plugin."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/opa/3.5.x.json
+++ b/schemas/opa/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,73 +27,63 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "opa_protocol": {
-              "default": "http",
-              "type": "string",
-              "description": "The protocol to use when talking to Open Policy Agent (OPA) server. Allowed protocols are `http` and `https`.",
               "one_of": [
                 "http",
                 "https"
-              ]
+              ],
+              "default": "http",
+              "type": "string",
+              "description": "The protocol to use when talking to Open Policy Agent (OPA) server. Allowed protocols are `http` and `https`."
             }
           },
           {
             "opa_host": {
+              "description": "A string representing a host name, such as example.com.",
               "default": "localhost",
               "type": "string",
-              "description": "A string representing a host name, such as example.com.",
               "required": true
             }
           },
           {
             "opa_port": {
+              "type": "integer",
+              "required": true,
               "between": [
                 0,
                 65535
               ],
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "default": 8181,
-              "required": true
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "opa_path": {
-              "starts_with": "/",
               "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "required": true,
+              "starts_with": "/",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
-              ]
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
@@ -111,8 +109,8 @@
           },
           {
             "include_body_in_opa_input": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
@@ -132,12 +130,14 @@
           {
             "ssl_verify": {
               "required": true,
+              "default": true,
               "type": "boolean",
-              "description": "If set to true, the OPA certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate.",
-              "default": true
+              "description": "If set to true, the OPA certificate will be verified according to the CA certificates specified in lua_ssl_trusted_certificate."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/openid-connect/3.5.x.json
+++ b/schemas/openid-connect/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,23 +27,15 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -122,8 +122,6 @@
             }
           }
         ],
-        "type": "record",
-        "required": true,
         "fields": [
           {
             "issuer": {
@@ -134,45 +132,59 @@
           },
           {
             "discovery_headers_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra header names passed to the discovery endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "discovery_headers_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra header values passed to the discovery endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "extra_jwks_uris": {
-              "required": false,
-              "type": "set",
               "description": "JWKS URIs whose public keys are trusted (in addition to the keys found with the discovery).",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "set",
+              "required": false
             }
           },
           {
             "rediscovery_lifetime": {
+              "description": "Specifies how long (in seconds) the plugin waits between discovery attempts. Discovery is still triggered on an as-needed basis.",
               "default": 30,
               "type": "number",
-              "description": "Specifies how long (in seconds) the plugin waits between discovery attempts. Discovery is still triggered on an as-needed basis.",
               "required": false
             }
           },
           {
             "auth_methods": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "password",
+                "client_credentials",
+                "authorization_code",
+                "bearer",
+                "introspection",
+                "userinfo",
+                "kong_oauth2",
+                "refresh_token",
+                "session"
+              ],
+              "description": "Types of credentials/grants to enable.",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -186,51 +198,35 @@
                   "refresh_token",
                   "session"
                 ]
-              },
-              "type": "array",
-              "description": "Types of credentials/grants to enable.",
-              "required": false,
-              "default": [
-                "password",
-                "client_credentials",
-                "authorization_code",
-                "bearer",
-                "introspection",
-                "userinfo",
-                "kong_oauth2",
-                "refresh_token",
-                "session"
-              ]
+              }
             }
           },
           {
             "client_id": {
-              "elements": {
-                "referenceable": true,
-                "type": "string"
-              },
               "type": "array",
-              "description": "The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.",
               "encrypted": true,
-              "required": false
+              "description": "The client id(s) that the plugin uses when it calls authenticated endpoints on the identity provider.",
+              "required": false,
+              "elements": {
+                "type": "string",
+                "referenceable": true
+              }
             }
           },
           {
             "client_secret": {
-              "elements": {
-                "referenceable": true,
-                "type": "string"
-              },
               "type": "array",
-              "description": "The client secret.",
               "encrypted": true,
-              "required": false
+              "description": "The client secret.",
+              "required": false,
+              "elements": {
+                "type": "string",
+                "referenceable": true
+              }
             }
           },
           {
             "client_auth": {
-              "required": false,
-              "type": "array",
               "description": "The authentication method used by the client (plugin) when calling the endpoint.",
               "elements": {
                 "type": "string",
@@ -241,7 +237,9 @@
                   "private_key_jwt",
                   "none"
                 ]
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
@@ -249,25 +247,23 @@
               "required": false,
               "type": "array",
               "elements": {
-                "required": false,
-                "type": "record",
                 "fields": [
                   {
                     "issuer": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "kty": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "use": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
@@ -275,27 +271,27 @@
                       "required": false,
                       "type": "array",
                       "elements": {
-                        "required": false,
-                        "type": "string"
+                        "type": "string",
+                        "required": false
                       }
                     }
                   },
                   {
                     "alg": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "kid": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "x5u": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
@@ -303,134 +299,136 @@
                       "required": false,
                       "type": "array",
                       "elements": {
-                        "required": false,
-                        "type": "string"
+                        "type": "string",
+                        "required": false
                       }
                     }
                   },
                   {
                     "x5t": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "x5t#S256": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "k": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "x": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "y": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "crv": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "n": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "e": {
-                      "required": false,
-                      "type": "string"
+                      "type": "string",
+                      "required": false
                     }
                   },
                   {
                     "d": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "p": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "q": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "dp": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "dq": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "qi": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "oth": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "r": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   },
                   {
                     "t": {
                       "encrypted": true,
-                      "type": "string",
                       "referenceable": true,
+                      "type": "string",
                       "required": false
                     }
                   }
-                ]
+                ],
+                "type": "record",
+                "required": false
               }
             }
           },
@@ -460,286 +458,286 @@
           },
           {
             "client_arg": {
+              "description": "The client to use for this request (the selection is made with a request parameter with the same name).",
               "default": "client_id",
               "type": "string",
-              "description": "The client to use for this request (the selection is made with a request parameter with the same name).",
               "required": false
             }
           },
           {
             "redirect_uri": {
-              "required": false,
-              "type": "array",
               "description": "The redirect URI passed to the authorization and token endpoints.",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "login_redirect_uri": {
-              "required": false,
-              "type": "array",
               "description": "Where to redirect the client when `login_action` is set to `redirect`.",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "logout_redirect_uri": {
-              "required": false,
-              "type": "array",
               "description": "Where to redirect the client after the logout.",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "forbidden_redirect_uri": {
-              "required": false,
-              "type": "array",
               "description": "Where to redirect the client on forbidden requests.",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "forbidden_error_message": {
+              "description": "The error message for the forbidden requests (when not using the redirection).",
               "default": "Forbidden",
               "type": "string",
-              "description": "The error message for the forbidden requests (when not using the redirection).",
               "required": false
             }
           },
           {
             "forbidden_destroy_session": {
+              "description": "Destroy any active session for the forbidden requests.",
               "default": true,
               "type": "boolean",
-              "description": "Destroy any active session for the forbidden requests.",
               "required": false
             }
           },
           {
             "unauthorized_destroy_session": {
+              "description": "Destroy any active session for the unauthorized requests.",
               "default": true,
               "type": "boolean",
-              "description": "Destroy any active session for the unauthorized requests.",
               "required": false
             }
           },
           {
             "unauthorized_redirect_uri": {
-              "required": false,
-              "type": "array",
               "description": "Where to redirect the client on unauthorized requests.",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "unauthorized_error_message": {
+              "description": "The error message for the unauthorized requests (when not using the redirection).",
               "default": "Unauthorized",
               "type": "string",
-              "description": "The error message for the unauthorized requests (when not using the redirection).",
               "required": false
             }
           },
           {
             "unexpected_redirect_uri": {
-              "required": false,
-              "type": "array",
               "description": "Where to redirect the client when unexpected errors happen with the requests.",
               "elements": {
-                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "response_mode": {
               "type": "string",
-              "description": "The response mode passed to the authorization endpoint: - `query`: Instructs the identity provider to pass parameters in query string - `form_post`: Instructs the identity provider to pass parameters in request body - `fragment`: Instructs the identity provider to pass parameters in uri fragment (rarely useful as the plugin itself cannot read it)",
-              "default": "query",
               "required": false,
               "one_of": [
                 "query",
                 "form_post",
                 "fragment"
-              ]
+              ],
+              "default": "query",
+              "description": "The response mode passed to the authorization endpoint: - `query`: Instructs the identity provider to pass parameters in query string - `form_post`: Instructs the identity provider to pass parameters in request body - `fragment`: Instructs the identity provider to pass parameters in uri fragment (rarely useful as the plugin itself cannot read it)"
             }
           },
           {
             "response_type": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "The response type passed to the authorization endpoint.",
               "required": false,
               "default": [
                 "code"
-              ]
+              ],
+              "description": "The response type passed to the authorization endpoint.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "scopes": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "The scopes passed to the authorization and token endpoints.",
               "required": false,
               "default": [
                 "openid"
-              ]
+              ],
+              "description": "The scopes passed to the authorization and token endpoints.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "audience": {
-              "required": false,
-              "type": "array",
               "description": "The audience passed to the authorization endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "issuers_allowed": {
-              "required": false,
-              "type": "array",
               "description": "The issuers allowed to be present in the tokens (`iss` claim).",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "scopes_required": {
-              "required": false,
-              "type": "array",
               "description": "The scopes (`scopes_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "scopes_claim": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "The claim that contains the scopes. If multiple values are set, it means the claim is inside a nested object of the token payload.",
               "required": false,
               "default": [
                 "scope"
-              ]
+              ],
+              "description": "The claim that contains the scopes.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "audience_required": {
-              "required": false,
-              "type": "array",
               "description": "The audiences (`audience_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "audience_claim": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "The claim that contains the audience. If multiple values are set, it means the claim is inside a nested object of the token payload.",
               "required": false,
               "default": [
                 "aud"
-              ]
+              ],
+              "description": "The claim that contains the audience.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "groups_required": {
-              "required": false,
-              "type": "array",
               "description": "The groups (`groups_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "groups_claim": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "The claim that contains the groups. If multiple values are set, it means the claim is inside a nested object of the token payload.",
               "required": false,
               "default": [
                 "groups"
-              ]
+              ],
+              "description": "The claim that contains the groups.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "roles_required": {
-              "required": false,
-              "type": "array",
               "description": "The roles (`roles_claim` claim) required to be present in the access token (or introspection results) for successful authorization. This config parameter works in both **AND** / **OR** cases.",
-              "elements": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "roles_claim": {
               "elements": {
                 "type": "string"
               },
               "type": "array",
-              "description": "The claim that contains the roles. If multiple values are set, it means the claim is inside a nested object of the token payload.",
+              "required": false
+            }
+          },
+          {
+            "roles_claim": {
+              "type": "array",
               "required": false,
               "default": [
                 "roles"
-              ]
+              ],
+              "description": "The claim that contains the roles.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "domains": {
-              "required": false,
-              "type": "array",
               "description": "The allowed values for the `hd` claim.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "max_age": {
-              "required": false,
+              "description": "The maximum age (in seconds) compared to the `auth_time` claim.",
               "type": "number",
-              "description": "The maximum age (in seconds) compared to the `auth_time` claim."
+              "required": false
             }
           },
           {
             "authenticated_groups_claim": {
-              "required": false,
-              "type": "array",
-              "description": "The claim that contains authenticated groups. This setting can be used together with ACL plugin, but it also enables IdP managed groups with other applications and integrations. If multiple values are set, it means the claim is inside a nested object of the token payload.",
+              "description": "The claim that contains authenticated groups. This setting can be used together with ACL plugin, but it also enables IdP managed groups with other applications and integrations.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
@@ -751,106 +749,106 @@
           },
           {
             "authorization_query_args_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra query argument names passed to the authorization endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "authorization_query_args_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra query argument values passed to the authorization endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "authorization_query_args_client": {
-              "required": false,
-              "type": "array",
               "description": "Extra query arguments passed from the client to the authorization endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "authorization_rolling_timeout": {
+              "description": "Specifies how long the session used for the authorization code flow can be used in seconds until it needs to be renewed. 0 disables the checks and rolling.",
               "default": 600,
               "type": "number",
-              "description": "Specifies how long the session used for the authorization code flow can be used in seconds until it needs to be renewed. 0 disables the checks and rolling.",
               "required": false
             }
           },
           {
             "authorization_cookie_name": {
+              "description": "The authorization cookie name.",
               "default": "authorization",
               "type": "string",
-              "description": "The authorization cookie name.",
               "required": false
             }
           },
           {
             "authorization_cookie_path": {
-              "starts_with": "/",
               "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "required": false,
+              "starts_with": "/",
+              "default": "/",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
-              "default": "/"
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "authorization_cookie_domain": {
-              "required": false,
+              "description": "The authorization cookie Domain flag.",
               "type": "string",
-              "description": "The authorization cookie Domain flag."
+              "required": false
             }
           },
           {
             "authorization_cookie_same_site": {
               "type": "string",
-              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
-              "default": "Default",
               "required": false,
               "one_of": [
                 "Strict",
                 "Lax",
                 "None",
                 "Default"
-              ]
+              ],
+              "default": "Default",
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks."
             }
           },
           {
             "authorization_cookie_http_only": {
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
               "default": true,
               "type": "boolean",
-              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
               "required": false
             }
           },
           {
             "authorization_cookie_secure": {
-              "required": false,
+              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
               "type": "boolean",
-              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks."
+              "required": false
             }
           },
           {
             "preserve_query_args": {
+              "description": "With this parameter, you can preserve request query arguments even when doing authorization code flow.",
               "default": false,
               "type": "boolean",
-              "description": "With this parameter, you can preserve request query arguments even when doing authorization code flow.",
               "required": false
             }
           },
@@ -863,8 +861,6 @@
           },
           {
             "token_endpoint_auth_method": {
-              "required": false,
-              "type": "string",
               "description": "The token endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
               "one_of": [
                 "client_secret_basic",
@@ -872,60 +868,60 @@
                 "client_secret_jwt",
                 "private_key_jwt",
                 "none"
-              ]
+              ],
+              "type": "string",
+              "required": false
             }
           },
           {
             "token_headers_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra header names passed to the token endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_headers_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra header values passed to the token endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_headers_client": {
-              "required": false,
-              "type": "array",
               "description": "Extra headers passed from the client to the token endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_headers_replay": {
-              "required": false,
-              "type": "array",
               "description": "The names of token endpoint response headers to forward to the downstream client.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_headers_prefix": {
-              "required": false,
+              "description": "Add a prefix to the token endpoint response headers before forwarding them to the downstream client.",
               "type": "string",
-              "description": "Add a prefix to the token endpoint response headers before forwarding them to the downstream client."
+              "required": false
             }
           },
           {
             "token_headers_grants": {
-              "required": false,
-              "type": "array",
               "description": "Enable the sending of the token endpoint response headers only with certain grants: - `password`: with OAuth password grant - `client_credentials`: with OAuth client credentials grant - `authorization_code`: with authorization code flow - `refresh_token` with refresh token grant",
               "elements": {
                 "type": "string",
@@ -935,37 +931,39 @@
                   "authorization_code",
                   "refresh_token"
                 ]
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_post_args_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra post argument names passed to the token endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_post_args_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra post argument values passed to the token endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "token_post_args_client": {
-              "required": false,
-              "type": "array",
               "description": "Pass extra arguments from the client to the OpenID-Connect plugin. If arguments exist, the client can pass them using: - Request Body - Query parameters  This parameter can be used with `scope` values, like this:  `config.token_post_args_client=scope`  In this case, the token would take the `scope` value from the query parameter or from the request body and send it to the token endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
@@ -977,8 +975,6 @@
           },
           {
             "introspection_endpoint_auth_method": {
-              "required": false,
-              "type": "string",
               "description": "The introspection endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
               "one_of": [
                 "client_secret_basic",
@@ -986,103 +982,105 @@
                 "client_secret_jwt",
                 "private_key_jwt",
                 "none"
-              ]
+              ],
+              "type": "string",
+              "required": false
             }
           },
           {
             "introspection_hint": {
+              "description": "Introspection hint parameter value passed to the introspection endpoint.",
               "default": "access_token",
               "type": "string",
-              "description": "Introspection hint parameter value passed to the introspection endpoint.",
               "required": false
             }
           },
           {
             "introspection_check_active": {
+              "description": "Check that the introspection response has an `active` claim with a value of `true`.",
               "default": true,
               "type": "boolean",
-              "description": "Check that the introspection response has an `active` claim with a value of `true`.",
               "required": false
             }
           },
           {
             "introspection_accept": {
               "type": "string",
-              "description": "The value of `Accept` header for introspection requests: - `application/json`: introspection response as JSON - `application/token-introspection+jwt`: introspection response as JWT (from the current IETF draft document) - `application/jwt`: introspection response as JWT (from the obsolete IETF draft document)",
-              "default": "application/json",
               "required": false,
               "one_of": [
                 "application/json",
                 "application/token-introspection+jwt",
                 "application/jwt"
-              ]
+              ],
+              "default": "application/json",
+              "description": "The value of `Accept` header for introspection requests: - `application/json`: introspection response as JSON - `application/token-introspection+jwt`: introspection response as JWT (from the current IETF draft document) - `application/jwt`: introspection response as JWT (from the obsolete IETF draft document)"
             }
           },
           {
             "introspection_headers_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra header names passed to the introspection endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "introspection_headers_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra header values passed to the introspection endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "introspection_headers_client": {
-              "required": false,
-              "type": "array",
               "description": "Extra headers passed from the client to the introspection endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "introspection_post_args_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra post argument names passed to the introspection endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "introspection_post_args_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra post argument values passed to the introspection endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "introspection_post_args_client": {
-              "required": false,
-              "type": "array",
               "description": "Extra post arguments passed from the client to the introspection endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "introspect_jwt_tokens": {
+              "description": "Specifies whether to introspect the JWT access tokens (can be used to check for revocations).",
               "default": false,
               "type": "boolean",
-              "description": "Specifies whether to introspect the JWT access tokens (can be used to check for revocations).",
               "required": false
             }
           },
@@ -1095,8 +1093,6 @@
           },
           {
             "revocation_endpoint_auth_method": {
-              "required": false,
-              "type": "string",
               "description": "The revocation endpoint authentication method: - `client_secret_basic`: send `client_id` and `client_secret` in `Authorization: Basic` header - `client_secret_post`: send `client_id` and `client_secret` as part of the body - `client_secret_jwt`: send client assertion signed with the `client_secret` as part of the body - `private_key_jwt`:  send client assertion signed with the `private key` as part of the body - `none`: do not authenticate",
               "one_of": [
                 "client_secret_basic",
@@ -1104,7 +1100,9 @@
                 "client_secret_jwt",
                 "private_key_jwt",
                 "none"
-              ]
+              ],
+              "type": "string",
+              "required": false
             }
           },
           {
@@ -1124,73 +1122,73 @@
           {
             "userinfo_accept": {
               "type": "string",
-              "description": "The value of `Accept` header for user info requests: - `application/json`: user info response as JSON - `application/jwt`: user info response as JWT (from the obsolete IETF draft document)",
-              "default": "application/json",
               "required": false,
               "one_of": [
                 "application/json",
                 "application/jwt"
-              ]
+              ],
+              "default": "application/json",
+              "description": "The value of `Accept` header for user info requests: - `application/json`: user info response as JSON - `application/jwt`: user info response as JWT (from the obsolete IETF draft document)"
             }
           },
           {
             "userinfo_headers_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra header names passed to the user info endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "userinfo_headers_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra header values passed to the user info endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "userinfo_headers_client": {
-              "required": false,
-              "type": "array",
               "description": "Extra headers passed from the client to the user info endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "userinfo_query_args_names": {
-              "required": false,
-              "type": "array",
               "description": "Extra query argument names passed to the user info endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "userinfo_query_args_values": {
-              "required": false,
-              "type": "array",
               "description": "Extra query argument values passed to the user info endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "userinfo_query_args_client": {
-              "required": false,
-              "type": "array",
               "description": "Extra query arguments passed from the client to the user info endpoint.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
@@ -1202,138 +1200,139 @@
           },
           {
             "session_secret": {
-              "referenceable": true,
-              "description": "The session secret.",
-              "encrypted": true,
               "type": "string",
-              "required": false
+              "required": false,
+              "referenceable": true,
+              "encrypted": true,
+              "description": "The session secret."
             }
           },
           {
             "session_audience": {
+              "description": "The session audience, which is the intended target application. For example `\"my-application\"`.",
               "default": "default",
               "type": "string",
-              "description": "The session audience, which is the intended target application. For example `\"my-application\"`.",
               "required": false
             }
           },
           {
             "session_cookie_name": {
+              "description": "The session cookie name.",
               "default": "session",
               "type": "string",
-              "description": "The session cookie name.",
               "required": false
             }
           },
           {
             "session_remember": {
+              "description": "Enables or disables persistent sessions.",
               "default": false,
               "type": "boolean",
-              "description": "Enables or disables persistent sessions.",
               "required": false
             }
           },
           {
             "session_remember_cookie_name": {
+              "description": "Persistent session cookie name. Use with the `remember` configuration parameter.",
               "default": "remember",
               "type": "string",
-              "description": "Persistent session cookie name. Use with the `remember` configuration parameter.",
               "required": false
             }
           },
           {
             "session_remember_rolling_timeout": {
+              "description": "Specifies how long the persistent session is considered valid in seconds. 0 disables the checks and rolling.",
               "default": 604800,
               "type": "number",
-              "description": "Specifies how long the persistent session is considered valid in seconds. 0 disables the checks and rolling.",
               "required": false
             }
           },
           {
             "session_remember_absolute_timeout": {
+              "description": "Limits how long the persistent session can be renewed in seconds, until re-authentication is required. 0 disables the checks.",
               "default": 2592000,
               "type": "number",
-              "description": "Limits how long the persistent session can be renewed in seconds, until re-authentication is required. 0 disables the checks.",
               "required": false
             }
           },
           {
             "session_idling_timeout": {
+              "description": "Specifies how long the session can be inactive until it is considered invalid in seconds. 0 disables the checks and touching.",
               "default": 900,
               "type": "number",
-              "description": "Specifies how long the session can be inactive until it is considered invalid in seconds. 0 disables the checks and touching.",
               "required": false
             }
           },
           {
             "session_rolling_timeout": {
+              "description": "Specifies how long the session can be used in seconds until it needs to be renewed. 0 disables the checks and rolling.",
               "default": 3600,
               "type": "number",
-              "description": "Specifies how long the session can be used in seconds until it needs to be renewed. 0 disables the checks and rolling.",
               "required": false
             }
           },
           {
             "session_absolute_timeout": {
+              "description": "Limits how long the session can be renewed in seconds, until re-authentication is required. 0 disables the checks.",
               "default": 86400,
               "type": "number",
-              "description": "Limits how long the session can be renewed in seconds, until re-authentication is required. 0 disables the checks.",
               "required": false
             }
           },
           {
             "session_cookie_path": {
-              "starts_with": "/",
               "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "required": false,
+              "starts_with": "/",
+              "default": "/",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
-              "default": "/"
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "session_cookie_domain": {
-              "required": false,
+              "description": "The session cookie Domain flag.",
               "type": "string",
-              "description": "The session cookie Domain flag."
+              "required": false
             }
           },
           {
             "session_cookie_same_site": {
               "type": "string",
-              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
-              "default": "Lax",
               "required": false,
               "one_of": [
                 "Strict",
                 "Lax",
                 "None",
                 "Default"
-              ]
+              ],
+              "default": "Lax",
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks."
             }
           },
           {
             "session_cookie_http_only": {
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
               "default": true,
               "type": "boolean",
-              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
               "required": false
             }
           },
           {
             "session_cookie_secure": {
-              "required": false,
+              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
               "type": "boolean",
-              "description": "Cookie is only sent to the server when a request is made with the https: scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks."
+              "required": false
             }
           },
           {
             "session_request_headers": {
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1345,12 +1344,12 @@
                   "rolling-timeout",
                   "absolute-timeout"
                 ]
-              },
-              "type": "set"
+              }
             }
           },
           {
             "session_response_headers": {
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1362,248 +1361,255 @@
                   "rolling-timeout",
                   "absolute-timeout"
                 ]
-              },
-              "type": "set"
+              }
             }
           },
           {
             "session_storage": {
               "type": "string",
-              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie (the session cannot be invalidated or revoked without changing session secret, but is stateless, and doesn't require a database) - `memcache`: stores session data in memcached - `redis`: stores session data in Redis",
-              "default": "cookie",
               "required": false,
               "one_of": [
                 "cookie",
                 "memcache",
                 "memcached",
                 "redis"
-              ]
+              ],
+              "default": "cookie",
+              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie (the session cannot be invalidated or revoked without changing session secret, but is stateless, and doesn't require a database) - `memcache`: stores session data in memcached - `redis`: stores session data in Redis"
             }
           },
           {
             "session_store_metadata": {
+              "description": "Configures whether or not session metadata should be stored. This metadata includes information about the active sessions for a specific audience belonging to a specific subject.",
               "default": false,
               "type": "boolean",
-              "description": "Configures whether or not session metadata should be stored. This metadata includes information about the active sessions for a specific audience belonging to a specific subject.",
               "required": false
             }
           },
           {
             "session_enforce_same_subject": {
+              "description": "When set to `true`, audiences are forced to share the same subject.",
               "default": false,
               "type": "boolean",
-              "description": "When set to `true`, audiences are forced to share the same subject.",
               "required": false
             }
           },
           {
             "session_hash_subject": {
+              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
               "default": false,
               "type": "boolean",
-              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
               "required": false
             }
           },
           {
             "session_hash_storage_key": {
+              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
               "default": false,
               "type": "boolean",
-              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
               "required": false
             }
           },
           {
             "session_memcached_prefix": {
-              "required": false,
+              "description": "The memcached session key prefix.",
               "type": "string",
-              "description": "The memcached session key prefix."
+              "required": false
             }
           },
           {
             "session_memcached_socket": {
-              "required": false,
+              "description": "The memcached unix socket path.",
               "type": "string",
-              "description": "The memcached unix socket path."
+              "required": false
             }
           },
           {
             "session_memcached_host": {
+              "description": "The memcached host.",
               "default": "127.0.0.1",
               "type": "string",
-              "description": "The memcached host.",
               "required": false
             }
           },
           {
             "session_memcached_port": {
+              "type": "integer",
+              "required": false,
               "between": [
                 0,
                 65535
               ],
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "required": false,
-              "default": 11211
+              "default": 11211,
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "session_redis_prefix": {
-              "required": false,
+              "description": "The Redis session key prefix.",
               "type": "string",
-              "description": "The Redis session key prefix."
+              "required": false
             }
           },
           {
             "session_redis_socket": {
-              "required": false,
+              "description": "The Redis unix socket path.",
               "type": "string",
-              "description": "The Redis unix socket path."
+              "required": false
             }
           },
           {
             "session_redis_host": {
+              "description": "The Redis host",
               "default": "127.0.0.1",
               "type": "string",
-              "description": "The Redis host",
               "required": false
             }
           },
           {
             "session_redis_port": {
+              "type": "integer",
+              "required": false,
               "between": [
                 0,
                 65535
               ],
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "required": false,
-              "default": 6379
+              "default": 6379,
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "session_redis_username": {
-              "required": false,
-              "referenceable": true,
               "description": "Username to use for Redis connection when the `redis` session storage is defined and ACL authentication is desired. If undefined, ACL authentication will not be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-              "type": "string"
-            }
-          },
-          {
-            "session_redis_password": {
               "referenceable": true,
-              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no AUTH commands are sent to Redis.",
-              "encrypted": true,
               "type": "string",
               "required": false
             }
           },
           {
-            "session_redis_connect_timeout": {
+            "session_redis_password": {
+              "type": "string",
               "required": false,
+              "referenceable": true,
+              "encrypted": true,
+              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no AUTH commands are sent to Redis."
+            }
+          },
+          {
+            "session_redis_connect_timeout": {
+              "description": "Session redis connection timeout in milliseconds.",
               "type": "integer",
-              "description": "Session redis connection timeout in milliseconds."
+              "required": false
             }
           },
           {
             "session_redis_read_timeout": {
-              "required": false,
+              "description": "Session redis read timeout in milliseconds.",
               "type": "integer",
-              "description": "Session redis read timeout in milliseconds."
+              "required": false
             }
           },
           {
             "session_redis_send_timeout": {
-              "required": false,
+              "description": "Session redis send timeout in milliseconds.",
               "type": "integer",
-              "description": "Session redis send timeout in milliseconds."
+              "required": false
             }
           },
           {
             "session_redis_ssl": {
+              "description": "Use SSL/TLS for Redis connection.",
               "default": false,
               "type": "boolean",
-              "description": "Use SSL/TLS for Redis connection.",
               "required": false
             }
           },
           {
             "session_redis_ssl_verify": {
+              "description": "Verify identity provider server certificate.",
               "default": false,
               "type": "boolean",
-              "description": "Verify identity provider server certificate.",
               "required": false
             }
           },
           {
             "session_redis_server_name": {
-              "required": false,
+              "description": "The SNI used for connecting the Redis server.",
               "type": "string",
-              "description": "The SNI used for connecting the Redis server."
+              "required": false
             }
           },
           {
             "session_redis_cluster_nodes": {
-              "required": false,
-              "type": "array",
               "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values.",
               "elements": {
                 "type": "record",
                 "fields": [
                   {
                     "ip": {
-                      "required": true,
-                      "type": "string",
                       "description": "A string representing a host name, such as example.com.",
-                      "default": "127.0.0.1"
+                      "default": "127.0.0.1",
+                      "type": "string",
+                      "required": true
                     }
                   },
                   {
                     "port": {
-                      "default": 6379,
-                      "type": "integer",
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
                       "between": [
                         0,
                         65535
-                      ]
+                      ],
+                      "default": 6379,
+                      "type": "integer",
+                      "description": "An integer representing a port number between 0 and 65535, inclusive."
                     }
                   }
                 ]
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "session_redis_cluster_max_redirections": {
-              "required": false,
+              "description": "The Redis cluster maximum redirects.",
               "type": "integer",
-              "description": "The Redis cluster maximum redirects."
+              "required": false
             }
           },
           {
             "reverify": {
+              "description": "Specifies whether to always verify tokens stored in the session.",
               "default": false,
               "type": "boolean",
-              "description": "Specifies whether to always verify tokens stored in the session.",
               "required": false
             }
           },
           {
             "jwt_session_claim": {
+              "description": "The claim to match against the JWT session cookie.",
               "default": "sid",
               "type": "string",
-              "description": "The claim to match against the JWT session cookie.",
               "required": false
             }
           },
           {
             "jwt_session_cookie": {
-              "required": false,
+              "description": "The name of the JWT session cookie.",
               "type": "string",
-              "description": "The name of the JWT session cookie."
+              "required": false
             }
           },
           {
             "bearer_token_param_type": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the bearer token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body - `cookie`: search the HTTP request cookies specified with `config.bearer_token_cookie_name`",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1612,26 +1618,26 @@
                   "query",
                   "body"
                 ]
-              },
-              "type": "array",
-              "description": "Where to look for the bearer token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body - `cookie`: search the HTTP request cookies specified with `config.bearer_token_cookie_name`",
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ]
+              }
             }
           },
           {
             "bearer_token_cookie_name": {
-              "required": false,
+              "description": "The name of the cookie in which the bearer token is passed.",
               "type": "string",
-              "description": "The name of the cookie in which the bearer token is passed."
+              "required": false
             }
           },
           {
             "client_credentials_param_type": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the client credentials: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search from the HTTP request body",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1639,19 +1645,19 @@
                   "query",
                   "body"
                 ]
-              },
-              "type": "array",
-              "description": "Where to look for the client credentials: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search from the HTTP request body",
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ]
+              }
             }
           },
           {
             "password_param_type": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the username and password: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1659,19 +1665,19 @@
                   "query",
                   "body"
                 ]
-              },
-              "type": "array",
-              "description": "Where to look for the username and password: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ]
+              }
             }
           },
           {
             "id_token_param_type": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the id token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1679,26 +1685,26 @@
                   "query",
                   "body"
                 ]
-              },
-              "type": "array",
-              "description": "Where to look for the id token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ]
+              }
             }
           },
           {
             "id_token_param_name": {
-              "required": false,
+              "description": "The name of the parameter used to pass the id token.",
               "type": "string",
-              "description": "The name of the parameter used to pass the id token."
+              "required": false
             }
           },
           {
             "refresh_token_param_type": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "header",
+                "query",
+                "body"
+              ],
+              "description": "Where to look for the refresh token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1706,213 +1712,211 @@
                   "query",
                   "body"
                 ]
-              },
-              "type": "array",
-              "description": "Where to look for the refresh token: - `header`: search the HTTP headers - `query`: search the URL's query string - `body`: search the HTTP request body",
-              "required": false,
-              "default": [
-                "header",
-                "query",
-                "body"
-              ]
+              }
             }
           },
           {
             "refresh_token_param_name": {
-              "required": false,
+              "description": "The name of the parameter used to pass the refresh token.",
               "type": "string",
-              "description": "The name of the parameter used to pass the refresh token."
+              "required": false
             }
           },
           {
             "refresh_tokens": {
+              "description": "Specifies whether the plugin should try to refresh (soon to be) expired access tokens if the plugin has a `refresh_token` available.",
               "default": true,
               "type": "boolean",
-              "description": "Specifies whether the plugin should try to refresh (soon to be) expired access tokens if the plugin has a `refresh_token` available.",
               "required": false
             }
           },
           {
             "upstream_headers_claims": {
-              "required": false,
-              "type": "array",
-              "description": "The upstream header claims. If multiple values are set, it means the claim is inside a nested object of the token payload.",
+              "description": "The upstream header claims.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "upstream_headers_names": {
-              "required": false,
-              "type": "array",
               "description": "The upstream header names for the claim values.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "upstream_access_token_header": {
+              "description": "The upstream access token header.",
               "default": "authorization:bearer",
               "type": "string",
-              "description": "The upstream access token header.",
               "required": false
             }
           },
           {
             "upstream_access_token_jwk_header": {
-              "required": false,
+              "description": "The upstream access token JWK header.",
               "type": "string",
-              "description": "The upstream access token JWK header."
+              "required": false
             }
           },
           {
             "upstream_id_token_header": {
-              "required": false,
+              "description": "The upstream id token header.",
               "type": "string",
-              "description": "The upstream id token header."
+              "required": false
             }
           },
           {
             "upstream_id_token_jwk_header": {
-              "required": false,
+              "description": "The upstream id token JWK header.",
               "type": "string",
-              "description": "The upstream id token JWK header."
+              "required": false
             }
           },
           {
             "upstream_refresh_token_header": {
-              "required": false,
+              "description": "The upstream refresh token header.",
               "type": "string",
-              "description": "The upstream refresh token header."
+              "required": false
             }
           },
           {
             "upstream_user_info_header": {
-              "required": false,
+              "description": "The upstream user info header.",
               "type": "string",
-              "description": "The upstream user info header."
+              "required": false
             }
           },
           {
             "upstream_user_info_jwt_header": {
-              "required": false,
+              "description": "The upstream user info JWT header (in case the user info returns a JWT response).",
               "type": "string",
-              "description": "The upstream user info JWT header (in case the user info returns a JWT response)."
+              "required": false
             }
           },
           {
             "upstream_introspection_header": {
-              "required": false,
+              "description": "The upstream introspection header.",
               "type": "string",
-              "description": "The upstream introspection header."
+              "required": false
             }
           },
           {
             "upstream_introspection_jwt_header": {
-              "required": false,
-              "type": "string"
+              "type": "string",
+              "required": false
             }
           },
           {
             "upstream_session_id_header": {
-              "required": false,
+              "description": "The upstream session id header.",
               "type": "string",
-              "description": "The upstream session id header."
+              "required": false
             }
           },
           {
             "downstream_headers_claims": {
-              "required": false,
-              "type": "array",
-              "description": "The downstream header claims. If multiple values are set, it means the claim is inside a nested object of the token payload.",
+              "description": "The downstream header claims.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "downstream_headers_names": {
-              "required": false,
-              "type": "array",
               "description": "The downstream header names for the claim values.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "downstream_access_token_header": {
-              "required": false,
+              "description": "The downstream access token header.",
               "type": "string",
-              "description": "The downstream access token header."
+              "required": false
             }
           },
           {
             "downstream_access_token_jwk_header": {
-              "required": false,
+              "description": "The downstream access token JWK header.",
               "type": "string",
-              "description": "The downstream access token JWK header."
+              "required": false
             }
           },
           {
             "downstream_id_token_header": {
-              "required": false,
+              "description": "The downstream id token header.",
               "type": "string",
-              "description": "The downstream id token header."
+              "required": false
             }
           },
           {
             "downstream_id_token_jwk_header": {
-              "required": false,
+              "description": "The downstream id token JWK header.",
               "type": "string",
-              "description": "The downstream id token JWK header."
+              "required": false
             }
           },
           {
             "downstream_refresh_token_header": {
-              "required": false,
+              "description": "The downstream refresh token header.",
               "type": "string",
-              "description": "The downstream refresh token header."
+              "required": false
             }
           },
           {
             "downstream_user_info_header": {
-              "required": false,
+              "description": "The downstream user info header.",
               "type": "string",
-              "description": "The downstream user info header."
+              "required": false
             }
           },
           {
             "downstream_user_info_jwt_header": {
-              "required": false,
+              "description": "The downstream user info JWT header (in case the user info returns a JWT response).",
               "type": "string",
-              "description": "The downstream user info JWT header (in case the user info returns a JWT response)."
+              "required": false
             }
           },
           {
             "downstream_introspection_header": {
-              "required": false,
+              "description": "The downstream introspection header.",
               "type": "string",
-              "description": "The downstream introspection header."
+              "required": false
             }
           },
           {
             "downstream_introspection_jwt_header": {
-              "required": false,
-              "type": "string"
+              "type": "string",
+              "required": false
             }
           },
           {
             "downstream_session_id_header": {
-              "required": false,
+              "description": "The downstream session id header.",
               "type": "string",
-              "description": "The downstream session id header."
+              "required": false
             }
           },
           {
             "login_methods": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "authorization_code"
+              ],
+              "description": "Enable login functionality with specified grants.",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1926,30 +1930,30 @@
                   "refresh_token",
                   "session"
                 ]
-              },
-              "type": "array",
-              "description": "Enable login functionality with specified grants.",
-              "required": false,
-              "default": [
-                "authorization_code"
-              ]
+              }
             }
           },
           {
             "login_action": {
               "type": "string",
-              "description": "What to do after successful login: - `upstream`: proxy request to upstream service - `response`: terminate request with a response - `redirect`: redirect to a different location",
-              "default": "upstream",
               "required": false,
               "one_of": [
                 "upstream",
                 "response",
                 "redirect"
-              ]
+              ],
+              "default": "upstream",
+              "description": "What to do after successful login: - `upstream`: proxy request to upstream service - `response`: terminate request with a response - `redirect`: redirect to a different location"
             }
           },
           {
             "login_tokens": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "id_token"
+              ],
+              "description": "What tokens to include in `response` body or `redirect` query string or fragment: - `id_token`: include id token - `access_token`: include access token - `refresh_token`: include refresh token - `tokens`: include the full token endpoint response - `introspection`: include introspection response",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -1959,50 +1963,51 @@
                   "tokens",
                   "introspection"
                 ]
-              },
-              "type": "array",
-              "description": "What tokens to include in `response` body or `redirect` query string or fragment: - `id_token`: include id token - `access_token`: include access token - `refresh_token`: include refresh token - `tokens`: include the full token endpoint response - `introspection`: include introspection response",
-              "required": false,
-              "default": [
-                "id_token"
-              ]
+              }
             }
           },
           {
             "login_redirect_mode": {
               "type": "string",
-              "description": "Where to place `login_tokens` when using `redirect` `login_action`: - `query`: place tokens in query string - `fragment`: place tokens in url fragment (not readable by servers)",
-              "default": "fragment",
               "required": false,
               "one_of": [
                 "query",
                 "fragment"
-              ]
+              ],
+              "default": "fragment",
+              "description": "Where to place `login_tokens` when using `redirect` `login_action`: - `query`: place tokens in query string - `fragment`: place tokens in url fragment (not readable by servers)"
             }
           },
           {
             "logout_query_arg": {
-              "required": false,
+              "description": "The request query argument that activates the logout.",
               "type": "string",
-              "description": "The request query argument that activates the logout."
+              "required": false
             }
           },
           {
             "logout_post_arg": {
-              "required": false,
+              "description": "The request body argument that activates the logout.",
               "type": "string",
-              "description": "The request body argument that activates the logout."
+              "required": false
             }
           },
           {
             "logout_uri_suffix": {
-              "required": false,
+              "description": "The request URI suffix that activates the logout.",
               "type": "string",
-              "description": "The request URI suffix that activates the logout."
+              "required": false
             }
           },
           {
             "logout_methods": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "POST",
+                "DELETE"
+              ],
+              "description": "The request methods that can activate the logout: - `POST`: HTTP POST method - `GET`: HTTP GET method - `DELETE`: HTTP DELETE method",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -2010,52 +2015,52 @@
                   "GET",
                   "DELETE"
                 ]
-              },
-              "type": "array",
-              "description": "The request methods that can activate the logout: - `POST`: HTTP POST method - `GET`: HTTP GET method - `DELETE`: HTTP DELETE method",
-              "required": false,
-              "default": [
-                "POST",
-                "DELETE"
-              ]
+              }
             }
           },
           {
             "logout_revoke": {
+              "description": "Revoke tokens as part of the logout.",
               "default": false,
               "type": "boolean",
-              "description": "Revoke tokens as part of the logout.",
               "required": false
             }
           },
           {
             "logout_revoke_access_token": {
+              "description": "Revoke the access token as part of the logout.",
               "default": true,
               "type": "boolean",
-              "description": "Revoke the access token as part of the logout.",
               "required": false
             }
           },
           {
             "logout_revoke_refresh_token": {
+              "description": "Revoke the refresh token as part of the logout.",
               "default": true,
               "type": "boolean",
-              "description": "Revoke the refresh token as part of the logout.",
               "required": false
             }
           },
           {
             "consumer_claim": {
-              "required": false,
-              "type": "array",
-              "description": "The claim used for consumer mapping. If multiple values are set, it means the claim is inside a nested object of the token payload.",
+              "description": "The claim used for consumer mapping.",
               "elements": {
                 "type": "string"
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "consumer_by": {
+              "type": "array",
+              "required": false,
+              "default": [
+                "username",
+                "custom_id"
+              ],
+              "description": "Consumer fields used for mapping: - `id`: try to find the matching Consumer by `id` - `username`: try to find the matching Consumer by `username` - `custom_id`: try to find the matching Consumer by `custom_id`",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -2063,94 +2068,93 @@
                   "username",
                   "custom_id"
                 ]
-              },
-              "type": "array",
-              "description": "Consumer fields used for mapping: - `id`: try to find the matching Consumer by `id` - `username`: try to find the matching Consumer by `username` - `custom_id`: try to find the matching Consumer by `custom_id`",
-              "required": false,
-              "default": [
-                "username",
-                "custom_id"
-              ]
+              }
             }
           },
           {
             "consumer_optional": {
+              "description": "Do not terminate the request if consumer mapping fails.",
               "default": false,
               "type": "boolean",
-              "description": "Do not terminate the request if consumer mapping fails.",
               "required": false
             }
           },
           {
             "credential_claim": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "The claim used to derive virtual credentials (e.g. to be consumed by the rate-limiting plugin), in case the consumer mapping is not used. If multiple values are set, it means the claim is inside a nested object of the token payload.",
               "required": false,
               "default": [
                 "sub"
-              ]
+              ],
+              "description": "The claim used to derive virtual credentials (e.g. to be consumed by the rate-limiting plugin), in case the consumer mapping is not used.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "anonymous": {
-              "required": false,
+              "description": "An optional string (consumer UUID or username) value that functions as an “anonymous” consumer if authentication fails. If empty (default null), requests that fail authentication will return a `4xx` HTTP status code. This value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
               "type": "string",
-              "description": "An optional string (consumer UUID or username) value that functions as an “anonymous” consumer if authentication fails. If empty (default null), requests that fail authentication will return a `4xx` HTTP status code. This value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
+              "required": false
             }
           },
           {
             "run_on_preflight": {
+              "description": "Specifies whether to run this plugin on pre-flight (`OPTIONS`) requests.",
               "default": true,
               "type": "boolean",
-              "description": "Specifies whether to run this plugin on pre-flight (`OPTIONS`) requests.",
               "required": false
             }
           },
           {
             "leeway": {
+              "description": "Allow some leeway (in seconds) on the iat claim and ttl / expiry verification.",
               "default": 0,
               "type": "number",
-              "description": "Allow some leeway (in seconds) on the iat claim and ttl / expiry verification.",
               "required": false
             }
           },
           {
             "verify_parameters": {
+              "description": "Verify plugin configuration against discovery.",
               "default": false,
               "type": "boolean",
-              "description": "Verify plugin configuration against discovery.",
               "required": false
             }
           },
           {
             "verify_nonce": {
+              "description": "Verify nonce on authorization code flow.",
               "default": true,
               "type": "boolean",
-              "description": "Verify nonce on authorization code flow.",
               "required": false
             }
           },
           {
             "verify_claims": {
+              "description": "Verify tokens for standard claims.",
               "default": true,
               "type": "boolean",
-              "description": "Verify tokens for standard claims.",
               "required": false
             }
           },
           {
             "verify_signature": {
+              "description": "Verify signature of tokens.",
               "default": true,
               "type": "boolean",
-              "description": "Verify signature of tokens.",
               "required": false
             }
           },
           {
             "ignore_signature": {
+              "type": "array",
+              "required": false,
+              "default": [
+
+              ],
+              "description": "Skip the token signature verification on certain grants: - `password`: OAuth password grant - `client_credentials`: OAuth client credentials grant - `authorization_code`: authorization code flow - `refresh_token`: OAuth refresh token grant - `session`: session cookie authentication - `introspection`: OAuth introspection - `userinfo`: OpenID Connect user info endpoint authentication",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -2162,27 +2166,19 @@
                   "introspection",
                   "userinfo"
                 ]
-              },
-              "type": "array",
-              "description": "Skip the token signature verification on certain grants: - `password`: OAuth password grant - `client_credentials`: OAuth client credentials grant - `authorization_code`: authorization code flow - `refresh_token`: OAuth refresh token grant - `session`: session cookie authentication - `introspection`: OAuth introspection - `userinfo`: OpenID Connect user info endpoint authentication",
-              "required": false,
-              "default": [
-
-              ]
+              }
             }
           },
           {
             "enable_hs_signatures": {
+              "description": "Enable shared secret, for example, HS256, signatures (when disabled they will not be accepted).",
               "default": false,
               "type": "boolean",
-              "description": "Enable shared secret, for example, HS256, signatures (when disabled they will not be accepted).",
               "required": false
             }
           },
           {
             "disable_session": {
-              "required": false,
-              "type": "array",
               "description": "Disable issuing the session cookie with the specified grants.",
               "elements": {
                 "type": "string",
@@ -2197,106 +2193,108 @@
                   "refresh_token",
                   "session"
                 ]
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "cache_ttl": {
+              "description": "The default cache ttl in seconds that is used in case the cached object does not specify the expiry.",
               "default": 3600,
               "type": "number",
-              "description": "The default cache ttl in seconds that is used in case the cached object does not specify the expiry.",
               "required": false
             }
           },
           {
             "cache_ttl_max": {
-              "required": false,
+              "description": "The maximum cache ttl in seconds (enforced).",
               "type": "number",
-              "description": "The maximum cache ttl in seconds (enforced)."
+              "required": false
             }
           },
           {
             "cache_ttl_min": {
-              "required": false,
+              "description": "The minimum cache ttl in seconds (enforced).",
               "type": "number",
-              "description": "The minimum cache ttl in seconds (enforced)."
+              "required": false
             }
           },
           {
             "cache_ttl_neg": {
-              "required": false,
+              "description": "The negative cache ttl in seconds.",
               "type": "number",
-              "description": "The negative cache ttl in seconds."
+              "required": false
             }
           },
           {
             "cache_ttl_resurrect": {
-              "required": false,
+              "description": "The resurrection ttl in seconds.",
               "type": "number",
-              "description": "The resurrection ttl in seconds."
+              "required": false
             }
           },
           {
             "cache_tokens": {
+              "description": "Cache the token endpoint requests.",
               "default": true,
               "type": "boolean",
-              "description": "Cache the token endpoint requests.",
               "required": false
             }
           },
           {
             "cache_tokens_salt": {
-              "required": false,
+              "description": "Salt used for generating the cache key that is used for caching the token endpoint requests.",
               "type": "string",
               "auto": true,
-              "description": "Salt used for generating the cache key that is used for caching the token endpoint requests."
+              "required": false
             }
           },
           {
             "cache_introspection": {
+              "description": "Cache the introspection endpoint requests.",
               "default": true,
               "type": "boolean",
-              "description": "Cache the introspection endpoint requests.",
               "required": false
             }
           },
           {
             "cache_token_exchange": {
+              "description": "Cache the token exchange endpoint requests.",
               "default": true,
               "type": "boolean",
-              "description": "Cache the token exchange endpoint requests.",
               "required": false
             }
           },
           {
             "cache_user_info": {
+              "description": "Cache the user info requests.",
               "default": true,
               "type": "boolean",
-              "description": "Cache the user info requests.",
               "required": false
             }
           },
           {
             "search_user_info": {
+              "description": "Specify whether to use the user info endpoint to get additional claims for consumer mapping, credential mapping, authenticated groups, and upstream and downstream headers.",
               "default": false,
               "type": "boolean",
-              "description": "Specify whether to use the user info endpoint to get additional claims for consumer mapping, credential mapping, authenticated groups, and upstream and downstream headers.",
               "required": false
             }
           },
           {
             "hide_credentials": {
+              "description": "Remove the credentials used for authentication from the request. If multiple credentials are sent with the same request, the plugin will remove those that were used for successful authentication.",
               "default": false,
               "type": "boolean",
-              "description": "Remove the credentials used for authentication from the request. If multiple credentials are sent with the same request, the plugin will remove those that were used for successful authentication.",
               "required": false
             }
           },
           {
             "http_version": {
+              "description": "The HTTP version used for the requests by this plugin: - `1.1`: HTTP 1.1 (the default) - `1.0`: HTTP 1.0",
               "default": 1.1,
               "type": "number",
-              "description": "The HTTP version used for the requests by this plugin: - `1.1`: HTTP 1.1 (the default) - `1.0`: HTTP 1.0",
               "required": false
             }
           },
@@ -2309,9 +2307,9 @@
           },
           {
             "http_proxy_authorization": {
-              "required": false,
+              "description": "The HTTP proxy authorization.",
               "type": "string",
-              "description": "The HTTP proxy authorization."
+              "required": false
             }
           },
           {
@@ -2323,63 +2321,63 @@
           },
           {
             "https_proxy_authorization": {
-              "required": false,
+              "description": "The HTTPS proxy authorization.",
               "type": "string",
-              "description": "The HTTPS proxy authorization."
+              "required": false
             }
           },
           {
             "no_proxy": {
-              "required": false,
+              "description": "Do not use proxy with these hosts.",
               "type": "string",
-              "description": "Do not use proxy with these hosts."
+              "required": false
             }
           },
           {
             "keepalive": {
+              "description": "Use keepalive with the HTTP client.",
               "default": true,
               "type": "boolean",
-              "description": "Use keepalive with the HTTP client.",
               "required": false
             }
           },
           {
             "ssl_verify": {
+              "description": "Verify identity provider server certificate.",
               "default": false,
               "type": "boolean",
-              "description": "Verify identity provider server certificate.",
               "required": false
             }
           },
           {
             "timeout": {
+              "description": "Network IO timeout in milliseconds.",
               "default": 10000,
               "type": "number",
-              "description": "Network IO timeout in milliseconds.",
               "required": false
             }
           },
           {
             "display_errors": {
+              "description": "Display errors on failure responses.",
               "default": false,
               "type": "boolean",
-              "description": "Display errors on failure responses.",
               "required": false
             }
           },
           {
             "by_username_ignore_case": {
+              "description": "If `consumer_by` is set to `username`, specify whether `username` can match consumers case-insensitively.",
               "default": false,
               "type": "boolean",
-              "description": "If `consumer_by` is set to `username`, specify whether `username` can match consumers case-insensitively.",
               "required": false
             }
           },
           {
             "resolve_distributed_claims": {
+              "description": "Distributed claims are represented by the `_claim_names` and `_claim_sources` members of the JSON object containing the claims. If this parameter is set to `true`, the plugin explicitly resolves these distributed claims.",
               "default": false,
               "type": "boolean",
-              "description": "Distributed claims are represented by the `_claim_names` and `_claim_sources` members of the JSON object containing the claims. If this parameter is set to `true`, the plugin explicitly resolves these distributed claims.",
               "required": false
             }
           },
@@ -2399,9 +2397,9 @@
           },
           {
             "introspection_token_param_name": {
+              "description": "Designate token's parameter name for introspection.",
               "default": "token",
               "type": "string",
-              "description": "Designate token's parameter name for introspection.",
               "required": false
             }
           },
@@ -2414,22 +2412,22 @@
           },
           {
             "revocation_token_param_name": {
+              "description": "Designate token's parameter name for revocation.",
               "default": "token",
               "type": "string",
-              "description": "Designate token's parameter name for revocation.",
               "required": false
             }
           },
           {
             "proof_of_possession_mtls": {
-              "default": "off",
-              "type": "string",
-              "description": "Enable mtls proof of possession. If set to strict, all tokens (from supported auth_methods: bearer, introspection, and session granted with bearer or introspection) are verified, if set to optional, only tokens that contain the certificate hash claim are verified. If the verification fails, the request will be rejected with 401.",
               "one_of": [
                 "off",
                 "strict",
                 "optional"
-              ]
+              ],
+              "default": "off",
+              "type": "string",
+              "description": "Enable mtls proof of possession. If set to strict, all tokens (from supported auth_methods: bearer, introspection, and session granted with bearer or introspection) are verified, if set to optional, only tokens that contain the certificate hash claim are verified. If the verification fails, the request will be rejected with 401."
             }
           },
           {
@@ -2439,7 +2437,9 @@
               "description": "If set to true, only the auth_methods that are compatible with Proof of Possession (PoP) can be configured when PoP is enabled. If set to false, all auth_methods will be configurable and PoP checks will be silently skipped for those auth_methods that are not compatible with PoP."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/opentelemetry/3.4.x.json
+++ b/schemas/opentelemetry/3.4.x.json
@@ -59,6 +59,7 @@
             "resource_attributes": {
               "values": {
                 "type": "string",
+                "description": "Attributes to add to the OpenTelemetry resource object, following the spec for Semantic Attributes. \nThe following attributes are automatically added:\n- `service.name`: The name of the service (default: `kong`).\n- `service.version`: The version of Kong Gateway.\n- `service.instance.id`: The node ID of Kong Gateway.\n\nYou can use this property to override default attribute values. For example, to override the default for `service.name`, you can specify `{ \"service.name\": \"my-service\" }`.",
                 "required": true
               },
               "keys": {
@@ -191,6 +192,7 @@
           },
           {
             "http_response_header_for_traceid": {
+              "description": "Specifies a custom header for the `trace_id`. If set, the plugin sets the corresponding header in the response.",
               "type": "string"
             }
           },
@@ -209,6 +211,7 @@
                 "datadog"
               ],
               "type": "string",
+              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests.",
               "required": false
             }
           }

--- a/schemas/opentelemetry/3.5.x.json
+++ b/schemas/opentelemetry/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -47,81 +45,79 @@
         "fields": [
           {
             "endpoint": {
-              "required": true,
-              "referenceable": true,
               "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string"
+              "referenceable": true,
+              "type": "string",
+              "required": true
             }
           },
           {
             "headers": {
+              "keys": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              },
+              "type": "map",
               "values": {
                 "type": "string",
                 "referenceable": true
               },
-              "type": "map",
-              "description": "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend.",
-              "keys": {
-                "description": "A string representing an HTTP header name.",
-                "type": "string"
-              }
+              "description": "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend."
             }
           },
           {
             "resource_attributes": {
-              "values": {
-                "required": true,
-                "type": "string"
+              "keys": {
+                "type": "string",
+                "required": true
               },
               "type": "map",
-              "keys": {
-                "required": true,
-                "type": "string"
+              "values": {
+                "type": "string",
+                "required": true
               }
             }
           },
           {
             "queue": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "number",
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 10000,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
                   "max_bytes": {
-                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content.",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
@@ -133,72 +129,74 @@
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 0.01,
+                    "type": "number",
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 60,
+                    "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "batch_span_count": {
-              "description": "The number of spans to be sent in a single batch.",
-              "type": "integer"
+              "type": "integer",
+              "description": "The number of spans to be sent in a single batch."
             }
           },
           {
             "batch_flush_delay": {
-              "description": "The delay, in seconds, between two consecutive batches.",
-              "type": "integer"
+              "type": "integer",
+              "description": "The delay, in seconds, between two consecutive batches."
             }
           },
           {
             "connect_timeout": {
-              "default": 1000,
-              "type": "integer",
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
-              ]
+              ],
+              "default": 1000,
+              "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
             "send_timeout": {
-              "default": 5000,
-              "type": "integer",
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
-              ]
+              ],
+              "default": 5000,
+              "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
             "read_timeout": {
-              "default": 5000,
-              "type": "integer",
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
-              ]
+              ],
+              "default": 5000,
+              "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
@@ -208,9 +206,6 @@
           },
           {
             "header_type": {
-              "required": false,
-              "type": "string",
-              "default": "preserve",
               "one_of": [
                 "preserve",
                 "ignore",
@@ -222,10 +217,15 @@
                 "aws",
                 "gcp",
                 "datadog"
-              ]
+              ],
+              "default": "preserve",
+              "type": "string",
+              "required": false
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/opentelemetry/3.5.x.json
+++ b/schemas/opentelemetry/3.5.x.json
@@ -69,6 +69,7 @@
             "resource_attributes": {
               "keys": {
                 "type": "string",
+                "description": "Attributes to add to the OpenTelemetry resource object, following the spec for Semantic Attributes. \nThe following attributes are automatically added:\n- `service.name`: The name of the service (default: `kong`).\n- `service.version`: The version of Kong Gateway.\n- `service.instance.id`: The node ID of Kong Gateway.\n\nYou can use this property to override default attribute values. For example, to override the default for `service.name`, you can specify `{ \"service.name\": \"my-service\" }`.",
                 "required": true
               },
               "type": "map",
@@ -201,6 +202,7 @@
           },
           {
             "http_response_header_for_traceid": {
+              "description": "Specifies a custom header for the `trace_id`. If set, the plugin sets the corresponding header in the response.",
               "type": "string"
             }
           },
@@ -219,6 +221,7 @@
                 "datadog"
               ],
               "default": "preserve",
+              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests.",
               "type": "string",
               "required": false
             }

--- a/schemas/post-function/3.5.x.json
+++ b/schemas/post-function/3.5.x.json
@@ -2,8 +2,6 @@
   "fields": [
     {
       "protocols": {
-        "required": false,
-        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -22,27 +20,37 @@
           "https",
           "ws",
           "wss"
-        ]
+        ],
+        "type": "set",
+        "required": false
       }
     },
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -56,156 +64,158 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "certificate": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "rewrite": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "access": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "header_filter": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "body_filter": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "log": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_handshake": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_client_frame": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_upstream_frame": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_close": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/pre-function/3.5.x.json
+++ b/schemas/pre-function/3.5.x.json
@@ -2,8 +2,6 @@
   "fields": [
     {
       "protocols": {
-        "required": false,
-        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -22,27 +20,37 @@
           "https",
           "ws",
           "wss"
-        ]
+        ],
+        "type": "set",
+        "required": false
       }
     },
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -56,156 +64,158 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "certificate": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "rewrite": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "access": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "header_filter": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "body_filter": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "log": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_handshake": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_client_frame": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_upstream_frame": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           },
           {
             "ws_close": {
-              "required": true,
               "type": "array",
+              "required": true,
               "default": [
 
               ],
+              "description": "Custom functions, which can be user-defined, are cached and executed sequentially during specific phases: `certificate`, `rewrite`, `access`, `header_filter`, `body_filter`, and `log`.",
               "elements": {
-                "required": false,
-                "type": "string"
+                "type": "string",
+                "required": false
               }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/prometheus/3.5.x.json
+++ b/schemas/prometheus/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "per_consumer": {
@@ -77,7 +75,9 @@
               "description": "A boolean value that determines if status code metrics should be collected. If enabled, `upstream_target_health` metric will be exported."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/proxy-cache-advanced/3.5.x.json
+++ b/schemas/proxy-cache-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,52 +19,49 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "response_code": {
-              "len_min": 1,
               "type": "array",
-              "description": "Upstream response status code considered cacheable. The integers must be a value between 100 and 900.",
               "required": true,
+              "len_min": 1,
               "default": [
                 200,
                 301,
                 404
               ],
+              "description": "Upstream response status code considered cacheable. The integers must be a value between 100 and 900.",
               "elements": {
+                "type": "integer",
                 "between": [
                   100,
                   900
-                ],
-                "type": "integer"
+                ]
               }
             }
           },
           {
             "request_method": {
+              "type": "array",
+              "required": true,
+              "default": [
+                "GET",
+                "HEAD"
+              ],
+              "description": "Downstream request methods considered cacheable. Available options: `HEAD`, `GET`, `POST`, `PATCH`, `PUT`.",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -66,136 +71,127 @@
                   "PATCH",
                   "PUT"
                 ]
-              },
-              "type": "array",
-              "description": "Downstream request methods considered cacheable. Available options: `HEAD`, `GET`, `POST`, `PATCH`, `PUT`.",
-              "required": true,
-              "default": [
-                "GET",
-                "HEAD"
-              ]
+              }
             }
           },
           {
             "content_type": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned.",
               "required": true,
               "default": [
                 "text/plain",
                 "application/json"
-              ]
+              ],
+              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value; for example, if the upstream is expected to respond with a `application/json; charset=utf-8` content-type, the plugin configuration must contain said value or a `Bypass` cache status is returned.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "cache_ttl": {
-              "default": 300,
               "gt": 0,
-              "description": "TTL in seconds of cache entities.",
-              "type": "integer"
+              "default": 300,
+              "type": "integer",
+              "description": "TTL in seconds of cache entities."
             }
           },
           {
             "strategy": {
-              "required": true,
-              "type": "string",
               "description": "The backing data store in which to hold cache entities. Accepted values are: `memory` and `redis`.",
               "one_of": [
                 "memory",
                 "redis"
-              ]
+              ],
+              "type": "string",
+              "required": true
             }
           },
           {
             "cache_control": {
+              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "default": false,
               "type": "boolean",
-              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "required": true
             }
           },
           {
             "ignore_uri_case": {
+              "description": "Determines whether to treat URIs as case sensitive. By default, case sensitivity is enabled. If set to true, requests are cached while ignoring case sensitivity in the URI.",
               "default": false,
               "type": "boolean",
-              "description": "Determines whether to treat URIs as case sensitive. By default, case sensitivity is enabled. If set to true, requests are cached while ignoring case sensitivity in the URI.",
               "required": false
             }
           },
           {
             "storage_ttl": {
-              "description": "Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors."
             }
           },
           {
             "memory": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "dictionary_name": {
-                    "required": true,
-                    "type": "string",
                     "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
-                    "default": "kong_db_cache"
+                    "default": "kong_db_cache",
+                    "type": "string",
+                    "required": true
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "vary_query_params": {
+              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration."
+              }
             }
           },
           {
             "vary_headers": {
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration."
+              }
             }
           },
           {
             "response_headers": {
-              "required": true,
-              "type": "record",
               "description": "Caching related diagnostic headers that should be included in cached responses",
               "fields": [
                 {
                   "age": {
-                    "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                   }
                 },
                 {
                   "X-Cache-Status": {
-                    "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                   }
                 },
                 {
                   "X-Cache-Key": {
-                    "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "redis": {
-              "required": true,
-              "type": "record",
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -257,8 +253,8 @@
               "fields": [
                 {
                   "host": {
-                    "description": "A string representing a host name, such as example.com.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "A string representing a host name, such as example.com."
                   }
                 },
                 {
@@ -273,13 +269,13 @@
                 },
                 {
                   "timeout": {
-                    "default": 2000,
-                    "type": "integer",
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "between": [
                       0,
                       2147483646
-                    ]
+                    ],
+                    "default": 2000,
+                    "type": "integer",
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
@@ -315,31 +311,31 @@
                 {
                   "username": {
                     "referenceable": true,
-                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
-                    "referenceable": true,
                     "description": "Password to use for Redis connections. If undefined, no AUTH commands are sent to Redis.",
-                    "type": "string"
+                    "referenceable": true,
+                    "type": "string",
+                    "encrypted": true
                   }
                 },
                 {
                   "sentinel_username": {
                     "referenceable": true,
-                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+."
                   }
                 },
                 {
                   "sentinel_password": {
-                    "encrypted": true,
-                    "referenceable": true,
                     "description": "Sentinel password to authenticate with a Redis Sentinel instance. If undefined, no AUTH commands are sent to Redis Sentinels.",
-                    "type": "string"
+                    "referenceable": true,
+                    "type": "string",
+                    "encrypted": true
                   }
                 },
                 {
@@ -351,13 +347,13 @@
                 },
                 {
                   "keepalive_pool_size": {
-                    "default": 256,
-                    "type": "integer",
-                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low.",
                     "between": [
                       1,
                       2147483646
-                    ]
+                    ],
+                    "default": 256,
+                    "type": "integer",
+                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low."
                   }
                 },
                 {
@@ -372,55 +368,55 @@
                 },
                 {
                   "sentinel_master": {
-                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_role": {
-                    "type": "string",
-                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel.",
                     "one_of": [
                       "master",
                       "slave",
                       "any"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_addresses": {
                     "len_min": 1,
-                    "type": "array",
-                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "array",
+                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element."
                   }
                 },
                 {
                   "cluster_addresses": {
                     "len_min": 1,
-                    "type": "array",
-                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "array",
+                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element."
                   }
                 },
                 {
                   "ssl": {
-                    "required": false,
-                    "type": "boolean",
                     "description": "If set to true, uses SSL to connect to Redis.",
-                    "default": false
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
                   "ssl_verify": {
-                    "required": false,
-                    "type": "boolean",
                     "description": "If set to true, verifies the validity of the server SSL certificate. If setting this parameter, also configure `lua_ssl_trusted_certificate` in `kong.conf` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
-                    "default": false
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
@@ -430,7 +426,9 @@
                     "description": "A string representing an SNI (server name indication) value for TLS."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
@@ -440,7 +438,9 @@
               "description": "Unhandled errors while trying to retrieve a cache entry (such as redis down) are resolved with `Bypass`, with the request going upstream."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/proxy-cache/3.5.x.json
+++ b/schemas/proxy-cache/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,55 +23,52 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "response_code": {
-              "len_min": 1,
               "type": "array",
-              "description": "Upstream response status code considered cacheable.",
               "required": true,
+              "len_min": 1,
               "default": [
                 200,
                 301,
                 404
               ],
+              "description": "Upstream response status code considered cacheable.",
               "elements": {
+                "type": "integer",
                 "between": [
                   100,
                   900
-                ],
-                "type": "integer"
+                ]
               }
             }
           },
           {
             "request_method": {
+              "type": "array",
+              "required": true,
+              "default": [
+                "GET",
+                "HEAD"
+              ],
+              "description": "Downstream request methods considered cacheable.",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -73,53 +78,46 @@
                   "PATCH",
                   "PUT"
                 ]
-              },
-              "type": "array",
-              "description": "Downstream request methods considered cacheable.",
-              "required": true,
-              "default": [
-                "GET",
-                "HEAD"
-              ]
+              }
             }
           },
           {
             "content_type": {
-              "elements": {
-                "type": "string"
-              },
               "type": "array",
-              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value.",
               "required": true,
               "default": [
                 "text/plain",
                 "application/json"
-              ]
+              ],
+              "description": "Upstream response content types considered cacheable. The plugin performs an **exact match** against each specified value.",
+              "elements": {
+                "type": "string"
+              }
             }
           },
           {
             "cache_ttl": {
+              "gt": 0,
               "default": 300,
               "type": "integer",
-              "description": "TTL, in seconds, of cache entities.",
-              "gt": 0
+              "description": "TTL, in seconds, of cache entities."
             }
           },
           {
             "strategy": {
-              "required": true,
-              "type": "string",
               "description": "The backing data store in which to hold cache entities.",
               "one_of": [
                 "memory"
-              ]
+              ],
+              "type": "string",
+              "required": true
             }
           },
           {
             "cache_control": {
+              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "default": false,
               "type": "boolean",
-              "description": "When enabled, respect the Cache-Control behaviors defined in RFC7234.",
               "required": true
             }
           },
@@ -132,72 +130,74 @@
           },
           {
             "storage_ttl": {
-              "description": "Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors.",
-              "type": "integer"
+              "type": "integer",
+              "description": "Number of seconds to keep resources in the storage backend. This value is independent of `cache_ttl` or resource TTLs defined by Cache-Control behaviors."
             }
           },
           {
             "memory": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "dictionary_name": {
+                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
                     "default": "kong_db_cache",
                     "type": "string",
-                    "description": "The name of the shared dictionary in which to hold cache entities when the memory strategy is selected. Note that this dictionary currently must be defined manually in the Kong Nginx template.",
                     "required": true
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "vary_query_params": {
+              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Relevant query parameters considered for the cache key. If undefined, all params are taken into consideration."
+              }
             }
           },
           {
             "vary_headers": {
+              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "Relevant headers considered for the cache key. If undefined, none of the headers are taken into consideration."
+              }
             }
           },
           {
             "response_headers": {
-              "required": true,
-              "type": "record",
               "description": "Caching related diagnostic headers that should be included in cached responses",
               "fields": [
                 {
                   "age": {
-                    "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                   }
                 },
                 {
                   "X-Cache-Status": {
-                    "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                   }
                 },
                 {
                   "X-Cache-Key": {
-                    "default": true,
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/rate-limiting-advanced/3.5.x.json
+++ b/schemas/rate-limiting-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,28 +19,16 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "identifier": {
               "type": "string",
-              "description": "The type of identifier used to generate the rate limit key. Defines the scope used to increment the rate limiting counters. Can be `ip`, `credential`, `consumer`, `service`, `header`, or `path`.",
               "required": true,
-              "default": "consumer",
               "one_of": [
                 "ip",
                 "credential",
@@ -40,73 +36,75 @@
                 "service",
                 "header",
                 "path"
-              ]
+              ],
+              "default": "consumer",
+              "description": "The type of identifier used to generate the rate limit key. Defines the scope used to increment the rate limiting counters. Can be `ip`, `credential`, `consumer`, `service`, `header`, or `path`."
             }
           },
           {
             "window_size": {
               "required": true,
-              "type": "array",
-              "description": "One or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.",
               "elements": {
                 "type": "number"
-              }
+              },
+              "type": "array",
+              "description": "One or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified."
             }
           },
           {
             "window_type": {
-              "default": "sliding",
-              "type": "string",
-              "description": "Sets the time window type to either `sliding` (default) or `fixed`. Sliding windows apply the rate limiting logic while taking into account previous hit rates (from the window that immediately precedes the current) using a dynamic weight. Fixed windows consist of buckets that are statically assigned to a definitive time range, each request is mapped to only one fixed window based on its timestamp and will affect only that window's counters.",
               "one_of": [
                 "fixed",
                 "sliding"
-              ]
+              ],
+              "default": "sliding",
+              "type": "string",
+              "description": "Sets the time window type to either `sliding` (default) or `fixed`. Sliding windows apply the rate limiting logic while taking into account previous hit rates (from the window that immediately precedes the current) using a dynamic weight. Fixed windows consist of buckets that are statically assigned to a definitive time range, each request is mapped to only one fixed window based on its timestamp and will affect only that window's counters."
             }
           },
           {
             "limit": {
               "required": true,
-              "type": "array",
-              "description": "One or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.",
               "elements": {
                 "type": "number"
-              }
+              },
+              "type": "array",
+              "description": "One or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified."
             }
           },
           {
             "sync_rate": {
-              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 will sync the counters in the specified number of seconds. The minimum allowed interval is 0.02 seconds (20ms).",
-              "type": "number"
+              "type": "number",
+              "description": "How often to sync counter data to the central data store. A value of 0 results in synchronous behavior; a value of -1 ignores sync behavior entirely and only stores counters in node memory. A value greater than 0 will sync the counters in the specified number of seconds. The minimum allowed interval is 0.02 seconds (20ms)."
             }
           },
           {
             "namespace": {
               "required": true,
+              "auto": true,
               "type": "string",
-              "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `window_size`, `dictionary_name`, need to be the same.",
-              "auto": true
+              "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `window_size`, `dictionary_name`, need to be the same."
             }
           },
           {
             "strategy": {
               "type": "string",
-              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits. Available values are: `local` and `cluster`.",
               "required": true,
-              "default": "local",
               "one_of": [
                 "cluster",
                 "redis",
                 "local"
-              ]
+              ],
+              "default": "local",
+              "description": "The rate-limiting strategy to use for retrieving and incrementing the limits. Available values are: `local` and `cluster`."
             }
           },
           {
             "dictionary_name": {
+              "required": true,
               "default": "kong_rate_limiting_counters",
               "type": "string",
-              "description": "The shared dictionary where counters are stored. When the plugin is configured to synchronize counter data externally (that is `config.strategy` is `cluster` or `redis` and `config.sync_rate` isn't `-1`), this dictionary serves as a buffer to populate counters in the data store on each synchronization cycle.",
-              "required": true
+              "description": "The shared dictionary where counters are stored. When the plugin is configured to synchronize counter data externally (that is `config.strategy` is `cluster` or `redis` and `config.sync_rate` isn't `-1`), this dictionary serves as a buffer to populate counters in the data store on each synchronization cycle."
             }
           },
           {
@@ -125,27 +123,25 @@
           },
           {
             "header_name": {
-              "description": "A string representing an HTTP header name.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           },
           {
             "path": {
               "starts_with": "/",
-              "type": "string",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
+              "type": "string",
               "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "redis": {
-              "required": true,
-              "type": "record",
               "entity_checks": [
                 {
                   "mutually_exclusive_sets": {
@@ -207,8 +203,8 @@
               "fields": [
                 {
                   "host": {
-                    "description": "A string representing a host name, such as example.com.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "A string representing a host name, such as example.com."
                   }
                 },
                 {
@@ -223,13 +219,13 @@
                 },
                 {
                   "timeout": {
-                    "default": 2000,
-                    "type": "integer",
-                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
                     "between": [
                       0,
                       2147483646
-                    ]
+                    ],
+                    "default": 2000,
+                    "type": "integer",
+                    "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
                   }
                 },
                 {
@@ -265,31 +261,31 @@
                 {
                   "username": {
                     "referenceable": true,
-                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Username to use for Redis connections. If undefined, ACL authentication won't be performed. This requires Redis v6.0.0+. The username **cannot** be set to `default`."
                   }
                 },
                 {
                   "password": {
-                    "encrypted": true,
-                    "referenceable": true,
                     "description": "Password to use for Redis connections. If undefined, no AUTH commands are sent to Redis.",
-                    "type": "string"
+                    "referenceable": true,
+                    "type": "string",
+                    "encrypted": true
                   }
                 },
                 {
                   "sentinel_username": {
                     "referenceable": true,
-                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel username to authenticate with a Redis Sentinel instance. If undefined, ACL authentication won't be performed. This requires Redis v6.2.0+."
                   }
                 },
                 {
                   "sentinel_password": {
-                    "encrypted": true,
-                    "referenceable": true,
                     "description": "Sentinel password to authenticate with a Redis Sentinel instance. If undefined, no AUTH commands are sent to Redis Sentinels.",
-                    "type": "string"
+                    "referenceable": true,
+                    "type": "string",
+                    "encrypted": true
                   }
                 },
                 {
@@ -301,13 +297,13 @@
                 },
                 {
                   "keepalive_pool_size": {
-                    "default": 256,
-                    "type": "integer",
-                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low.",
                     "between": [
                       1,
                       2147483646
-                    ]
+                    ],
+                    "default": 256,
+                    "type": "integer",
+                    "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low."
                   }
                 },
                 {
@@ -322,55 +318,55 @@
                 },
                 {
                   "sentinel_master": {
-                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Sentinel master to use for Redis connections. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_role": {
-                    "type": "string",
-                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel.",
                     "one_of": [
                       "master",
                       "slave",
                       "any"
-                    ]
+                    ],
+                    "type": "string",
+                    "description": "Sentinel role to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel."
                   }
                 },
                 {
                   "sentinel_addresses": {
                     "len_min": 1,
-                    "type": "array",
-                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "array",
+                    "description": "Sentinel addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Sentinel. Each string element must be a hostname. The minimum length of the array is 1 element."
                   }
                 },
                 {
                   "cluster_addresses": {
                     "len_min": 1,
-                    "type": "array",
-                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element.",
                     "elements": {
                       "type": "string"
-                    }
+                    },
+                    "type": "array",
+                    "description": "Cluster addresses to use for Redis connections when the `redis` strategy is defined. Defining this value implies using Redis Cluster. Each string element must be a hostname. The minimum length of the array is 1 element."
                   }
                 },
                 {
                   "ssl": {
-                    "required": false,
-                    "type": "boolean",
                     "description": "If set to true, uses SSL to connect to Redis.",
-                    "default": false
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
                   "ssl_verify": {
-                    "required": false,
-                    "type": "boolean",
                     "description": "If set to true, verifies the validity of the server SSL certificate. If setting this parameter, also configure `lua_ssl_trusted_certificate` in `kong.conf` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
-                    "default": false
+                    "default": false,
+                    "type": "boolean",
+                    "required": false
                   }
                 },
                 {
@@ -380,7 +376,9 @@
                     "description": "A string representing an SNI (server name indication) value for TLS."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
@@ -392,11 +390,11 @@
           },
           {
             "consumer_groups": {
+              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`.",
+              "type": "array",
               "elements": {
                 "type": "string"
-              },
-              "type": "array",
-              "description": "List of consumer groups allowed to override the rate limiting settings for the given Route or Service. Required if `enforce_consumer_groups` is set to `true`."
+              }
             }
           },
           {
@@ -408,10 +406,10 @@
           },
           {
             "error_code": {
+              "gt": 0,
               "default": 429,
               "type": "number",
-              "description": "Set a custom error code to return when the rate limit is exceeded.",
-              "gt": 0
+              "description": "Set a custom error code to return when the rate limit is exceeded."
             }
           },
           {
@@ -421,7 +419,9 @@
               "description": "Set a custom error message to return when the rate limit is exceeded."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/rate-limiting/3.5.x.json
+++ b/schemas/rate-limiting/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,77 +19,64 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "second": {
               "gt": 0,
-              "description": "The number of HTTP requests that can be made per second.",
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per second."
             }
           },
           {
             "minute": {
               "gt": 0,
-              "description": "The number of HTTP requests that can be made per minute.",
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per minute."
             }
           },
           {
             "hour": {
               "gt": 0,
-              "description": "The number of HTTP requests that can be made per hour.",
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per hour."
             }
           },
           {
             "day": {
               "gt": 0,
-              "description": "The number of HTTP requests that can be made per day.",
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per day."
             }
           },
           {
             "month": {
               "gt": 0,
-              "description": "The number of HTTP requests that can be made per month.",
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per month."
             }
           },
           {
             "year": {
               "gt": 0,
-              "description": "The number of HTTP requests that can be made per year.",
-              "type": "number"
+              "type": "number",
+              "description": "The number of HTTP requests that can be made per year."
             }
           },
           {
             "limit_by": {
-              "default": "consumer",
-              "type": "string",
-              "description": "The entity that is used when aggregating the limits.",
               "one_of": [
                 "consumer",
                 "credential",
@@ -89,101 +84,104 @@
                 "service",
                 "header",
                 "path"
-              ]
+              ],
+              "default": "consumer",
+              "type": "string",
+              "description": "The entity that is used when aggregating the limits."
             }
           },
           {
             "header_name": {
-              "description": "A string representing an HTTP header name.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           },
           {
             "path": {
               "starts_with": "/",
-              "type": "string",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
+              "type": "string",
               "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "policy": {
-              "len_min": 0,
               "type": "string",
-              "description": "The rate-limiting policies to use for retrieving and incrementing the limits.",
+              "len_min": 0,
               "default": "local",
               "one_of": [
                 "local",
                 "cluster",
                 "redis"
-              ]
+              ],
+              "description": "The rate-limiting policies to use for retrieving and incrementing the limits."
             }
           },
           {
             "fault_tolerant": {
+              "required": true,
               "default": true,
               "type": "boolean",
-              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party data store. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the data store is working again. If `false`, then the clients will see `500` errors.",
-              "required": true
+              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party data store. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the data store is working again. If `false`, then the clients will see `500` errors."
             }
           },
           {
             "redis_host": {
-              "description": "A string representing a host name, such as example.com.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a host name, such as example.com."
             }
           },
           {
             "redis_port": {
-              "default": 6379,
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 6379,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "redis_password": {
               "len_min": 0,
               "referenceable": true,
-              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
-              "type": "string"
+              "type": "string",
+              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server."
             }
           },
           {
             "redis_username": {
+              "referenceable": true,
               "type": "string",
-              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.",
-              "referenceable": true
+              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired."
             }
           },
           {
             "redis_ssl": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
-              "required": true
+              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server."
             }
           },
           {
             "redis_ssl_verify": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly.",
-              "required": true
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies it server SSL certificate is validated. Note that you need to configure the lua_ssl_trusted_certificate to specify the CA (or server) certificate used by your Redis server. You may also need to configure lua_ssl_verify_depth accordingly."
             }
           },
           {
             "redis_server_name": {
-              "description": "A string representing an SNI (server name indication) value for TLS.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an SNI (server name indication) value for TLS."
             }
           },
           {
@@ -202,18 +200,18 @@
           },
           {
             "hide_client_headers": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Optionally hide informative response headers.",
-              "required": true
+              "description": "Optionally hide informative response headers."
             }
           },
           {
             "error_code": {
+              "gt": 0,
               "default": 429,
               "type": "number",
-              "description": "Set a custom error code to return when the rate limit is exceeded.",
-              "gt": 0
+              "description": "Set a custom error code to return when the rate limit is exceeded."
             }
           },
           {
@@ -225,13 +223,15 @@
           },
           {
             "sync_rate": {
+              "required": true,
               "default": -1,
               "type": "number",
-              "description": "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior.",
-              "required": true
+              "description": "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/request-size-limiting/3.5.x.json
+++ b/schemas/request-size-limiting/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "allowed_payload_size": {
@@ -45,25 +43,27 @@
           {
             "size_unit": {
               "type": "string",
-              "description": "Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is not available in versions prior to Kong Gateway 1.3 and Kong Gateway (OSS) 2.0.",
               "required": true,
-              "default": "megabytes",
               "one_of": [
                 "megabytes",
                 "kilobytes",
                 "bytes"
-              ]
+              ],
+              "default": "megabytes",
+              "description": "Size unit can be set either in `bytes`, `kilobytes`, or `megabytes` (default). This configuration is not available in versions prior to Kong Gateway 1.3 and Kong Gateway (OSS) 2.0."
             }
           },
           {
             "require_content_length": {
               "required": true,
+              "default": false,
               "type": "boolean",
-              "description": "Set to `true` to ensure a valid `Content-Length` header exists before reading the request body.",
-              "default": false
+              "description": "Set to `true` to ensure a valid `Content-Length` header exists before reading the request body."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/request-termination/3.5.x.json
+++ b/schemas/request-termination/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,75 +19,67 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "status_code": {
+              "type": "integer",
+              "required": true,
               "between": [
                 100,
                 599
               ],
-              "type": "integer",
-              "description": "The response code to send. Must be an integer between 100 and 599.",
               "default": 503,
-              "required": true
+              "description": "The response code to send. Must be an integer between 100 and 599."
             }
           },
           {
             "message": {
-              "description": "The message to send, if using the default response generator.",
-              "type": "string"
+              "type": "string",
+              "description": "The message to send, if using the default response generator."
             }
           },
           {
             "content_type": {
-              "description": "Content type of the raw response configured with `config.body`.",
-              "type": "string"
+              "type": "string",
+              "description": "Content type of the raw response configured with `config.body`."
             }
           },
           {
             "body": {
-              "description": "The raw response body to send. This is mutually exclusive with the `config.message` field.",
-              "type": "string"
+              "type": "string",
+              "description": "The raw response body to send. This is mutually exclusive with the `config.message` field."
             }
           },
           {
             "echo": {
-              "required": true,
-              "type": "boolean",
               "description": "When set, the plugin will echo a copy of the request back to the client. The main usecase for this is debugging. It can be combined with `trigger` in order to debug requests on live systems without disturbing real traffic.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "trigger": {
-              "description": "A string representing an HTTP header name.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing an HTTP header name."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/request-transformer-advanced/3.5.x.json
+++ b/schemas/request-transformer-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,21 +19,11 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "http_method": {
@@ -36,8 +34,6 @@
           },
           {
             "remove": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -72,13 +68,13 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -116,13 +112,13 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -181,13 +177,13 @@
                     "type": "string"
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -241,13 +237,13 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
@@ -301,23 +297,25 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "allow": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
+                    "type": "set",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "set"
+                    }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
@@ -327,7 +325,9 @@
               "description": "Specify whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects.  See [Arrays and nested objects](#arrays-and-nested-objects)."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/request-transformer/3.5.x.json
+++ b/schemas/request-transformer/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,24 +23,14 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "http_method": {
@@ -43,16 +41,14 @@
           },
           {
             "remove": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -61,10 +57,10 @@
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -73,30 +69,30 @@
                 {
                   "querystring": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -105,43 +101,43 @@
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "querystring": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -150,23 +146,23 @@
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "querystring": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -177,21 +173,21 @@
                     "type": "string"
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -200,43 +196,43 @@
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "querystring": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -245,32 +241,36 @@
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "querystring": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/request-validator/3.5.x.json
+++ b/schemas/request-validator/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -52,64 +50,44 @@
           },
           {
             "allowed_content_types": {
+              "description": "List of allowed content types. The value can be configured with the `charset` parameter. For example, `application/json; charset=UTF-8`.",
               "default": [
                 "application/json"
               ],
               "type": "set",
-              "description": "List of allowed content types. The value can be configured with the `charset` parameter. For example, `application/json; charset=UTF-8`.",
               "elements": {
-                "required": true,
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             }
           },
           {
             "version": {
               "type": "string",
-              "description": "Which validator to use. Supported values are `kong` (default) for using Kong's own schema validator, or `draft4` for using a JSON Schema Draft 4-compliant validator.",
               "required": true,
+              "default": "kong",
               "one_of": [
                 "kong",
                 "draft4"
               ],
-              "default": "kong"
+              "description": "Which validator to use. Supported values are `kong` (default) for using Kong's own schema validator, or `draft4` for using a JSON Schema Draft 4-compliant validator."
             }
           },
           {
             "parameter_schema": {
               "required": false,
-              "type": "array",
-              "description": "Array of parameter validator specification. One of `body_schema` or `parameter_schema` must be specified.",
               "elements": {
-                "entity_checks": [
-                  {
-                    "mutually_required": [
-                      "style",
-                      "explode",
-                      "schema"
-                    ]
-                  },
-                  {
-                    "custom_entity_check": {
-                      "field_sources": [
-                        "style",
-                        "in"
-                      ]
-                    }
-                  }
-                ],
-                "type": "record",
                 "fields": [
                   {
                     "in": {
-                      "required": true,
-                      "type": "string",
                       "description": "The location of the parameter.",
                       "one_of": [
                         "query",
                         "header",
                         "path"
-                      ]
+                      ],
+                      "type": "string",
+                      "required": true
                     }
                   },
                   {
@@ -128,8 +106,6 @@
                   },
                   {
                     "style": {
-                      "type": "string",
-                      "description": "Required when `schema` and `explode` are set. Describes how the parameter value will be deserialized depending on the type of the parameter value.",
                       "one_of": [
                         "label",
                         "form",
@@ -138,34 +114,58 @@
                         "spaceDelimited",
                         "pipeDelimited",
                         "deepObject"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Required when `schema` and `explode` are set. Describes how the parameter value will be deserialized depending on the type of the parameter value."
                     }
                   },
                   {
                     "explode": {
-                      "description": "Required when `schema` and `style` are set. When `explode` is `true`, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters, this property has no effect.",
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Required when `schema` and `style` are set. When `explode` is `true`, parameter values of type `array` or `object` generate separate parameters for each value of the array or key-value pair of the map. For other types of parameters, this property has no effect."
                     }
                   },
                   {
                     "schema": {
-                      "description": "Requred when `style` and `explode` are set. This is the schema defining the type used for the parameter. It is validated using `draft4` for JSON Schema draft 4 compliant validator. In addition to being a valid JSON Schema, the parameter schema MUST have a top-level `type` property to enable proper deserialization before validating.",
-                      "type": "string"
+                      "type": "string",
+                      "description": "Requred when `style` and `explode` are set. This is the schema defining the type used for the parameter. It is validated using `draft4` for JSON Schema draft 4 compliant validator. In addition to being a valid JSON Schema, the parameter schema MUST have a top-level `type` property to enable proper deserialization before validating."
+                    }
+                  }
+                ],
+                "type": "record",
+                "entity_checks": [
+                  {
+                    "mutually_required": [
+                      "style",
+                      "explode",
+                      "schema"
+                    ]
+                  },
+                  {
+                    "custom_entity_check": {
+                      "field_sources": [
+                        "style",
+                        "in"
+                      ]
                     }
                   }
                 ]
-              }
+              },
+              "type": "array",
+              "description": "Array of parameter validator specification. One of `body_schema` or `parameter_schema` must be specified."
             }
           },
           {
             "verbose_response": {
+              "description": "If enabled, the plugin returns more verbose and detailed validation errors.",
               "default": false,
               "type": "boolean",
-              "description": "If enabled, the plugin returns more verbose and detailed validation errors.",
               "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/response-ratelimiting/3.5.x.json
+++ b/schemas/response-ratelimiting/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "header_name": {
@@ -44,88 +42,88 @@
           },
           {
             "limit_by": {
-              "default": "consumer",
-              "type": "string",
-              "description": "The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`.",
               "one_of": [
                 "consumer",
                 "credential",
                 "ip"
-              ]
+              ],
+              "default": "consumer",
+              "type": "string",
+              "description": "The entity that will be used when aggregating the limits: `consumer`, `credential`, `ip`. If the `consumer` or the `credential` cannot be determined, the system will always fallback to `ip`."
             }
           },
           {
             "policy": {
-              "default": "local",
-              "type": "string",
-              "description": "The rate-limiting policies to use for retrieving and incrementing the limits.",
               "one_of": [
                 "local",
                 "cluster",
                 "redis"
-              ]
+              ],
+              "default": "local",
+              "type": "string",
+              "description": "The rate-limiting policies to use for retrieving and incrementing the limits."
             }
           },
           {
             "fault_tolerant": {
+              "required": true,
               "default": true,
               "type": "boolean",
-              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors.",
-              "required": true
+              "description": "A boolean value that determines if the requests should be proxied even if Kong has troubles connecting a third-party datastore. If `true`, requests will be proxied anyway, effectively disabling the rate-limiting function until the datastore is working again. If `false`, then the clients will see `500` errors."
             }
           },
           {
             "redis_host": {
-              "description": "When using the `redis` policy, this property specifies the address to the Redis server.",
-              "type": "string"
+              "type": "string",
+              "description": "When using the `redis` policy, this property specifies the address to the Redis server."
             }
           },
           {
             "redis_port": {
-              "default": 6379,
-              "type": "integer",
-              "description": "When using the `redis` policy, this property specifies the port of the Redis server.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 6379,
+              "type": "integer",
+              "description": "When using the `redis` policy, this property specifies the port of the Redis server."
             }
           },
           {
             "redis_password": {
               "len_min": 0,
+              "referenceable": true,
               "type": "string",
-              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server.",
-              "referenceable": true
+              "description": "When using the `redis` policy, this property specifies the password to connect to the Redis server."
             }
           },
           {
             "redis_username": {
+              "referenceable": true,
               "type": "string",
-              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.\nThis requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-              "referenceable": true
+              "description": "When using the `redis` policy, this property specifies the username to connect to the Redis server when ACL authentication is desired.\nThis requires Redis v6.0.0+. The username **cannot** be set to `default`."
             }
           },
           {
             "redis_ssl": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server.",
-              "required": true
+              "description": "When using the `redis` policy, this property specifies if SSL is used to connect to the Redis server."
             }
           },
           {
             "redis_ssl_verify": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly.",
-              "required": true
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies if the server SSL certificate is validated. Note that you need to configure the `lua_ssl_trusted_certificate` to specify the CA (or server) certificate used by your Redis server. You may also need to configure `lua_ssl_verify_depth` accordingly."
             }
           },
           {
             "redis_server_name": {
-              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI).",
-              "type": "string"
+              "type": "string",
+              "description": "When using the `redis` policy with `redis_ssl` set to `true`, this property specifies the server name for the TLS extension Server Name Indication (SNI)."
             }
           },
           {
@@ -144,32 +142,29 @@
           },
           {
             "block_on_first_violation": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "A boolean value that determines if the requests should be blocked as soon as one limit is being exceeded. This will block requests that are supposed to consume other limits too.",
-              "required": true
+              "description": "A boolean value that determines if the requests should be blocked as soon as one limit is being exceeded. This will block requests that are supposed to consume other limits too."
             }
           },
           {
             "hide_client_headers": {
+              "required": true,
               "default": false,
               "type": "boolean",
-              "description": "Optionally hide informative response headers.",
-              "required": true
+              "description": "Optionally hide informative response headers."
             }
           },
           {
             "limits": {
-              "len_min": 1,
-              "type": "map",
-              "description": "A map that defines rate limits for the plugin.",
               "keys": {
                 "type": "string"
               },
+              "type": "map",
               "required": true,
+              "len_min": 1,
               "values": {
-                "required": true,
-                "type": "record",
                 "entity_checks": [
                   {
                     "at_least_one_of": [
@@ -219,11 +214,16 @@
                       "gt": 0
                     }
                   }
-                ]
-              }
+                ],
+                "type": "record",
+                "required": true
+              },
+              "description": "A map that defines rate limits for the plugin."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/response-transformer-advanced/3.5.x.json
+++ b/schemas/response-transformer-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,26 +19,14 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "remove": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
@@ -65,13 +61,13 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "headers": {
@@ -96,18 +92,18 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "body": {
-                    "description": "String with which to replace the entire response body.",
-                    "type": "string"
+                    "type": "string",
+                    "description": "String with which to replace the entire response body."
                   }
                 },
                 {
@@ -159,13 +155,13 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
@@ -216,13 +212,13 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
@@ -273,29 +269,29 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "allow": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
+                    "type": "set",
                     "elements": {
                       "type": "string"
-                    },
-                    "type": "set"
+                    }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "transform": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "functions": {
@@ -330,7 +326,9 @@
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
@@ -340,7 +338,9 @@
               "description": "Whether dots (for example, `customers.info.phone`) should be treated as part of a property name or used to descend into nested JSON objects.."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/response-transformer/3.5.x.json
+++ b/schemas/response-transformer/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,34 +19,22 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "remove": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
@@ -47,59 +43,65 @@
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
                       "type": "string"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "rename": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "replace": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "json_types": {
+                    "type": "array",
+                    "required": true,
+                    "default": [
+
+                    ],
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
                     "elements": {
                       "type": "string",
                       "one_of": [
@@ -107,51 +109,51 @@
                         "number",
                         "string"
                       ]
-                    },
-                    "type": "array",
-                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
-                    "required": true,
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "add": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "json_types": {
+                    "type": "array",
+                    "required": true,
+                    "default": [
+
+                    ],
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
                     "elements": {
                       "type": "string",
                       "one_of": [
@@ -159,51 +161,51 @@
                         "number",
                         "string"
                       ]
-                    },
-                    "type": "array",
-                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
-                    "required": true,
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           },
           {
             "append": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "json": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 },
                 {
                   "json_types": {
+                    "type": "array",
+                    "required": true,
+                    "default": [
+
+                    ],
+                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
                     "elements": {
                       "type": "string",
                       "one_of": [
@@ -211,32 +213,30 @@
                         "number",
                         "string"
                       ]
-                    },
-                    "type": "array",
-                    "description": "List of JSON type names. Specify the types of the JSON values returned when appending\nJSON properties. Each string element can be one of: boolean, number, or string.",
-                    "required": true,
-                    "default": [
-
-                    ]
+                    }
                   }
                 },
                 {
                   "headers": {
                     "required": true,
-                    "type": "array",
                     "default": [
 
                     ],
+                    "type": "array",
                     "elements": {
-                      "match": "^[^:]+:.*$",
-                      "type": "string"
+                      "type": "string",
+                      "match": "^[^:]+:.*$"
                     }
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/route-by-header/3.5.x.json
+++ b/schemas/route-by-header/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,54 +19,44 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "rules": {
+              "description": "Route by header rules.",
               "default": [
 
               ],
               "type": "array",
-              "description": "Route by header rules.",
               "elements": {
                 "type": "record",
                 "fields": [
                   {
                     "upstream_name": {
-                      "required": true,
-                      "type": "string"
+                      "type": "string",
+                      "required": true
                     }
                   },
                   {
                     "condition": {
-                      "len_min": 1,
-                      "type": "map",
                       "keys": {
                         "type": "string"
                       },
+                      "type": "map",
                       "required": true,
+                      "len_min": 1,
                       "values": {
                         "type": "string"
                       }
@@ -68,7 +66,9 @@
               }
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/route-transformer-advanced/3.5.x.json
+++ b/schemas/route-transformer-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -61,11 +59,13 @@
           },
           {
             "escape_path": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/saml/3.5.x.json
+++ b/schemas/saml/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -19,23 +27,15 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -112,21 +112,19 @@
             }
           }
         ],
-        "type": "record",
-        "required": true,
         "fields": [
           {
             "assertion_consumer_path": {
-              "starts_with": "/",
               "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "required": true,
+              "starts_with": "/",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
-              ]
+              ],
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
@@ -138,263 +136,264 @@
           },
           {
             "idp_certificate": {
-              "referenceable": true,
-              "description": "The public certificate provided by the IdP. This is used to validate responses from the IdP.  Only include the contents of the certificate. Do not include the header (`BEGIN CERTIFICATE`) and footer (`END CERTIFICATE`) lines.",
-              "required": false,
+              "type": "string",
               "encrypted": true,
-              "type": "string"
+              "referenceable": true,
+              "required": false,
+              "description": "The public certificate provided by the IdP. This is used to validate responses from the IdP.  Only include the contents of the certificate. Do not include the header (`BEGIN CERTIFICATE`) and footer (`END CERTIFICATE`) lines."
             }
           },
           {
             "response_encryption_key": {
-              "referenceable": true,
-              "description": "The private encryption key required to decrypt encrypted assertions.",
-              "required": false,
+              "type": "string",
               "encrypted": true,
-              "type": "string"
+              "referenceable": true,
+              "required": false,
+              "description": "The private encryption key required to decrypt encrypted assertions."
             }
           },
           {
             "request_signing_key": {
-              "referenceable": true,
-              "description": "The private key for signing requests.  If this parameter is set, requests sent to the IdP are signed.  The `request_signing_certificate` parameter must be set as well.",
-              "required": false,
+              "type": "string",
               "encrypted": true,
-              "type": "string"
+              "referenceable": true,
+              "required": false,
+              "description": "The private key for signing requests.  If this parameter is set, requests sent to the IdP are signed.  The `request_signing_certificate` parameter must be set as well."
             }
           },
           {
             "request_signing_certificate": {
-              "referenceable": true,
-              "description": "The certificate for signing requests.",
-              "required": false,
+              "type": "string",
               "encrypted": true,
-              "type": "string"
+              "referenceable": true,
+              "required": false,
+              "description": "The certificate for signing requests."
             }
           },
           {
             "request_signature_algorithm": {
               "type": "string",
-              "description": "The signature algorithm for signing Authn requests. Options available are: - `SHA256` - `SHA384` - `SHA512`",
               "required": false,
-              "default": "SHA256",
               "one_of": [
                 "SHA256",
                 "SHA384",
                 "SHA512"
-              ]
+              ],
+              "default": "SHA256",
+              "description": "The signature algorithm for signing Authn requests. Options available are: - `SHA256` - `SHA384` - `SHA512`"
             }
           },
           {
             "request_digest_algorithm": {
               "type": "string",
-              "description": "The digest algorithm for Authn requests: - `SHA256` - `SHA1`",
               "required": false,
-              "default": "SHA256",
               "one_of": [
                 "SHA256",
                 "SHA1"
-              ]
+              ],
+              "default": "SHA256",
+              "description": "The digest algorithm for Authn requests: - `SHA256` - `SHA1`"
             }
           },
           {
             "response_signature_algorithm": {
               "type": "string",
-              "description": "The algorithm for validating signatures in SAML responses. Options available are: - `SHA256` - `SHA384` - `SHA512`",
               "required": false,
-              "default": "SHA256",
               "one_of": [
                 "SHA256",
                 "SHA384",
                 "SHA512"
-              ]
+              ],
+              "default": "SHA256",
+              "description": "The algorithm for validating signatures in SAML responses. Options available are: - `SHA256` - `SHA384` - `SHA512`"
             }
           },
           {
             "response_digest_algorithm": {
               "type": "string",
-              "description": "The algorithm for verifying digest in SAML responses: - `SHA256` - `SHA1`",
               "required": false,
-              "default": "SHA256",
               "one_of": [
                 "SHA256",
                 "SHA1"
-              ]
+              ],
+              "default": "SHA256",
+              "description": "The algorithm for verifying digest in SAML responses: - `SHA256` - `SHA1`"
             }
           },
           {
             "issuer": {
-              "required": true,
+              "description": "The unique identifier of the IdP application. Formatted as a URL containing information about the IdP so the SP can validate that the SAML assertions it receives are issued from the correct IdP.",
               "type": "string",
-              "description": "The unique identifier of the IdP application. Formatted as a URL containing information about the IdP so the SP can validate that the SAML assertions it receives are issued from the correct IdP."
+              "required": true
             }
           },
           {
             "nameid_format": {
               "type": "string",
-              "description": "The requested `NameId` format. Options available are: - `Unspecified` - `EmailAddress` - `Persistent` - `Transient`",
               "required": false,
-              "default": "EmailAddress",
               "one_of": [
                 "Unspecified",
                 "EmailAddress",
                 "Persistent",
                 "Transient"
-              ]
+              ],
+              "default": "EmailAddress",
+              "description": "The requested `NameId` format. Options available are: - `Unspecified` - `EmailAddress` - `Persistent` - `Transient`"
             }
           },
           {
             "validate_assertion_signature": {
-              "required": false,
-              "type": "boolean",
               "description": "Enable signature validation for SAML responses.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": false
             }
           },
           {
             "anonymous": {
-              "required": false,
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer. If not set, a Kong Consumer must exist for the SAML IdP user credentials, mapping the username format to the Kong Consumer username.",
               "type": "string",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer. If not set, a Kong Consumer must exist for the SAML IdP user credentials, mapping the username format to the Kong Consumer username."
+              "required": false
             }
           },
           {
             "session_secret": {
+              "match": "^[0-9a-zA-Z/_+]+$",
+              "referenceable": true,
+              "type": "string",
+              "required": true,
               "len_min": 32,
               "len_max": 32,
-              "description": "The session secret. This must be a random string of 32 characters from the base64 alphabet (letters, numbers, `/`, `_` and `+`). It is used as the secret key for encrypting session data as well as state information that is sent to the IdP in the authentication exchange.",
-              "referenceable": true,
-              "required": true,
               "encrypted": true,
-              "match": "^[0-9a-zA-Z/_+]+$",
-              "type": "string"
+              "description": "The session secret. This must be a random string of 32 characters from the base64 alphabet (letters, numbers, `/`, `_` and `+`). It is used as the secret key for encrypting session data as well as state information that is sent to the IdP in the authentication exchange."
             }
           },
           {
             "session_audience": {
+              "description": "The session audience, for example \"my-application\"",
               "default": "default",
               "type": "string",
-              "description": "The session audience, for example \"my-application\"",
               "required": false
             }
           },
           {
             "session_cookie_name": {
+              "description": "The session cookie name.",
               "default": "session",
               "type": "string",
-              "description": "The session cookie name.",
               "required": false
             }
           },
           {
             "session_remember": {
+              "description": "Enables or disables persistent sessions",
               "default": false,
               "type": "boolean",
-              "description": "Enables or disables persistent sessions",
               "required": false
             }
           },
           {
             "session_remember_cookie_name": {
+              "description": "Persistent session cookie name",
               "default": "remember",
               "type": "string",
-              "description": "Persistent session cookie name",
               "required": false
             }
           },
           {
             "session_remember_rolling_timeout": {
+              "description": "Persistent session rolling timeout in seconds.",
               "default": 604800,
               "type": "number",
-              "description": "Persistent session rolling timeout in seconds.",
               "required": false
             }
           },
           {
             "session_remember_absolute_timeout": {
+              "description": "Persistent session absolute timeout in seconds.",
               "default": 2592000,
               "type": "number",
-              "description": "Persistent session absolute timeout in seconds.",
               "required": false
             }
           },
           {
             "session_idling_timeout": {
+              "description": "The session cookie idle time in seconds.",
               "default": 900,
               "type": "number",
-              "description": "The session cookie idle time in seconds.",
               "required": false
             }
           },
           {
             "session_rolling_timeout": {
+              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
               "default": 3600,
               "type": "number",
-              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
               "required": false
             }
           },
           {
             "session_absolute_timeout": {
+              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
               "default": 86400,
               "type": "number",
-              "description": "The session cookie absolute timeout in seconds. Specifies how long the session can be used until it is no longer valid.",
               "required": false
             }
           },
           {
             "session_cookie_path": {
-              "starts_with": "/",
               "type": "string",
-              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes).",
               "required": false,
+              "starts_with": "/",
+              "default": "/",
               "match_none": [
                 {
                   "pattern": "//",
                   "err": "must not have empty segments"
                 }
               ],
-              "default": "/"
+              "description": "A string representing a URL path, such as /path/to/resource. Must start with a forward slash (/) and must not contain empty segments (i.e., two consecutive forward slashes)."
             }
           },
           {
             "session_cookie_domain": {
-              "required": false,
+              "description": "The session cookie domain flag.",
               "type": "string",
-              "description": "The session cookie domain flag."
+              "required": false
             }
           },
           {
             "session_cookie_same_site": {
               "type": "string",
-              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks.",
-              "default": "Lax",
               "required": false,
               "one_of": [
                 "Strict",
                 "Lax",
                 "None",
                 "Default"
-              ]
+              ],
+              "default": "Lax",
+              "description": "Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks."
             }
           },
           {
             "session_cookie_http_only": {
+              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
               "default": true,
               "type": "boolean",
-              "description": "Forbids JavaScript from accessing the cookie, for example, through the `Document.cookie` property.",
               "required": false
             }
           },
           {
             "session_cookie_secure": {
-              "required": false,
+              "description": "The cookie is only sent to the server when a request is made with the https:scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks.",
               "type": "boolean",
-              "description": "The cookie is only sent to the server when a request is made with the https:scheme (except on localhost), and therefore is more resistant to man-in-the-middle attacks."
+              "required": false
             }
           },
           {
             "session_request_headers": {
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -406,12 +405,12 @@
                   "rolling-timeout",
                   "absolute-timeout"
                 ]
-              },
-              "type": "set"
+              }
             }
           },
           {
             "session_response_headers": {
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -423,224 +422,225 @@
                   "rolling-timeout",
                   "absolute-timeout"
                 ]
-              },
-              "type": "set"
+              }
             }
           },
           {
             "session_storage": {
               "type": "string",
-              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie. The session cannot be invalidated or revoked without changing the session secret, but is stateless, and doesn't require a database. - `memcached`: stores session data in memcached - `redis`: stores session data in Redis",
-              "default": "cookie",
               "required": false,
               "one_of": [
                 "cookie",
                 "memcache",
                 "memcached",
                 "redis"
-              ]
+              ],
+              "default": "cookie",
+              "description": "The session storage for session data: - `cookie`: stores session data with the session cookie. The session cannot be invalidated or revoked without changing the session secret, but is stateless, and doesn't require a database. - `memcached`: stores session data in memcached - `redis`: stores session data in Redis"
             }
           },
           {
             "session_store_metadata": {
+              "description": "Configures whether or not session metadata should be stored. This includes information about the active sessions for the `specific_audience` belonging to a specific subject.",
               "default": false,
               "type": "boolean",
-              "description": "Configures whether or not session metadata should be stored. This includes information about the active sessions for the `specific_audience` belonging to a specific subject.",
               "required": false
             }
           },
           {
             "session_enforce_same_subject": {
+              "description": "When set to `true`, audiences are forced to share the same subject.",
               "default": false,
               "type": "boolean",
-              "description": "When set to `true`, audiences are forced to share the same subject.",
               "required": false
             }
           },
           {
             "session_hash_subject": {
+              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
               "default": false,
               "type": "boolean",
-              "description": "When set to `true`, the value of subject is hashed before being stored. Only applies when `session_store_metadata` is enabled.",
               "required": false
             }
           },
           {
             "session_hash_storage_key": {
+              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
               "default": false,
               "type": "boolean",
-              "description": "When set to `true`, the storage key (session ID) is hashed for extra security. Hashing the storage key means it is impossible to decrypt data from the storage without a cookie.",
               "required": false
             }
           },
           {
             "session_memcached_prefix": {
-              "required": false,
+              "description": "The memcached session key prefix.",
               "type": "string",
-              "description": "The memcached session key prefix."
+              "required": false
             }
           },
           {
             "session_memcached_socket": {
-              "required": false,
+              "description": "The memcached unix socket path.",
               "type": "string",
-              "description": "The memcached unix socket path."
+              "required": false
             }
           },
           {
             "session_memcached_host": {
+              "description": "The memcached host.",
               "default": "127.0.0.1",
               "type": "string",
-              "description": "The memcached host.",
               "required": false
             }
           },
           {
             "session_memcached_port": {
+              "type": "integer",
+              "required": false,
               "between": [
                 0,
                 65535
               ],
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "required": false,
-              "default": 11211
+              "default": 11211,
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "session_redis_prefix": {
-              "required": false,
+              "description": "The Redis session key prefix.",
               "type": "string",
-              "description": "The Redis session key prefix."
+              "required": false
             }
           },
           {
             "session_redis_socket": {
-              "required": false,
+              "description": "The Redis unix socket path.",
               "type": "string",
-              "description": "The Redis unix socket path."
+              "required": false
             }
           },
           {
             "session_redis_host": {
+              "description": "The Redis host IP.",
               "default": "127.0.0.1",
               "type": "string",
-              "description": "The Redis host IP.",
               "required": false
             }
           },
           {
             "session_redis_port": {
+              "type": "integer",
+              "required": false,
               "between": [
                 0,
                 65535
               ],
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
-              "required": false,
-              "default": 6379
+              "default": 6379,
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
             "session_redis_username": {
-              "required": false,
-              "referenceable": true,
               "description": "Redis username if the `redis` session storage is defined and ACL authentication is desired.If undefined, ACL authentication will not be performed.  This requires Redis v6.0.0+. The username **cannot** be set to `default`.",
-              "type": "string"
+              "referenceable": true,
+              "type": "string",
+              "required": false
             }
           },
           {
             "session_redis_password": {
-              "referenceable": true,
-              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no auth commands are sent to Redis. This value is pulled from",
-              "required": false,
+              "type": "string",
               "encrypted": true,
-              "type": "string"
+              "referenceable": true,
+              "required": false,
+              "description": "Password to use for Redis connection when the `redis` session storage is defined. If undefined, no auth commands are sent to Redis. This value is pulled from"
             }
           },
           {
             "session_redis_connect_timeout": {
-              "required": false,
+              "description": "The Redis connection timeout in milliseconds.",
               "type": "integer",
-              "description": "The Redis connection timeout in milliseconds."
+              "required": false
             }
           },
           {
             "session_redis_read_timeout": {
-              "required": false,
+              "description": "The Redis read timeout in milliseconds.",
               "type": "integer",
-              "description": "The Redis read timeout in milliseconds."
+              "required": false
             }
           },
           {
             "session_redis_send_timeout": {
-              "required": false,
+              "description": "The Redis send timeout in milliseconds.",
               "type": "integer",
-              "description": "The Redis send timeout in milliseconds."
+              "required": false
             }
           },
           {
             "session_redis_ssl": {
+              "description": "Use SSL/TLS for the Redis connection.",
               "default": false,
               "type": "boolean",
-              "description": "Use SSL/TLS for the Redis connection.",
               "required": false
             }
           },
           {
             "session_redis_ssl_verify": {
+              "description": "Verify the Redis server certificate.",
               "default": false,
               "type": "boolean",
-              "description": "Verify the Redis server certificate.",
               "required": false
             }
           },
           {
             "session_redis_server_name": {
-              "required": false,
+              "description": "The SNI used for connecting to the Redis server.",
               "type": "string",
-              "description": "The SNI used for connecting to the Redis server."
+              "required": false
             }
           },
           {
             "session_redis_cluster_nodes": {
-              "required": false,
-              "type": "array",
               "description": "The Redis cluster node host. Takes an array of host records, with either `ip` or `host`, and `port` values.",
               "elements": {
                 "type": "record",
                 "fields": [
                   {
                     "ip": {
-                      "required": true,
-                      "type": "string",
                       "description": "A string representing a host name, such as example.com.",
-                      "default": "127.0.0.1"
+                      "default": "127.0.0.1",
+                      "type": "string",
+                      "required": true
                     }
                   },
                   {
                     "port": {
-                      "default": 6379,
-                      "type": "integer",
-                      "description": "An integer representing a port number between 0 and 65535, inclusive.",
                       "between": [
                         0,
                         65535
-                      ]
+                      ],
+                      "default": 6379,
+                      "type": "integer",
+                      "description": "An integer representing a port number between 0 and 65535, inclusive."
                     }
                   }
                 ]
-              }
+              },
+              "type": "array",
+              "required": false
             }
           },
           {
             "session_redis_cluster_max_redirections": {
-              "required": false,
+              "description": "The Redis cluster maximum redirects.",
               "type": "integer",
-              "description": "The Redis cluster maximum redirects."
+              "required": false
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/session/3.5.x.json
+++ b/schemas/session/3.5.x.json
@@ -3,13 +3,21 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -23,26 +31,18 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
@@ -84,28 +84,26 @@
             }
           }
         ],
-        "type": "record",
-        "required": true,
         "fields": [
           {
             "secret": {
-              "referenceable": true,
-              "description": "The secret that is used in keyed HMAC generation.",
-              "required": false,
-              "encrypted": true,
               "type": "string",
-              "default": "4emYUIRQFQNiaq7oFjHjfmU0XnvKvdUJVFFCcdpskXga"
+              "required": false,
+              "default": "KMMFrVmbW8X1AW0JLXrJMpGnBe4tNc3ESBmsKKe7e5Ia",
+              "referenceable": true,
+              "encrypted": true,
+              "description": "The secret that is used in keyed HMAC generation."
             }
           },
           {
             "storage": {
-              "default": "cookie",
-              "type": "string",
-              "description": "Determines where the session data is stored. `kong`: Stores encrypted session data into Kong's current database strategy; the cookie will not contain any session data. `cookie`: Stores encrypted session data within the cookie itself.",
               "one_of": [
                 "cookie",
                 "kong"
-              ]
+              ],
+              "default": "cookie",
+              "type": "string",
+              "description": "Determines where the session data is stored. `kong`: Stores encrypted session data into Kong's current database strategy; the cookie will not contain any session data. `cookie`: Stores encrypted session data within the cookie itself."
             }
           },
           {
@@ -159,21 +157,21 @@
           },
           {
             "cookie_domain": {
-              "description": "The domain with which the cookie is intended to be exchanged.",
-              "type": "string"
+              "type": "string",
+              "description": "The domain with which the cookie is intended to be exchanged."
             }
           },
           {
             "cookie_same_site": {
-              "default": "Strict",
-              "type": "string",
-              "description": "Determines whether and how a cookie may be sent with cross-site requests.",
               "one_of": [
                 "Strict",
                 "Lax",
                 "None",
                 "Default"
-              ]
+              ],
+              "default": "Strict",
+              "type": "string",
+              "description": "Determines whether and how a cookie may be sent with cross-site requests."
             }
           },
           {
@@ -220,6 +218,8 @@
           },
           {
             "response_headers": {
+              "description": "List of information to include, as headers, in the response to the downstream.",
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -231,13 +231,13 @@
                   "rolling-timeout",
                   "absolute-timeout"
                 ]
-              },
-              "type": "set",
-              "description": "List of information to include, as headers, in the response to the downstream."
+              }
             }
           },
           {
             "request_headers": {
+              "description": "List of information to include, as headers, in the response to the downstream.",
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -249,19 +249,23 @@
                   "rolling-timeout",
                   "absolute-timeout"
                 ]
-              },
-              "type": "set",
-              "description": "List of information to include, as headers, in the response to the downstream."
+              }
             }
           },
           {
             "read_body_for_logout": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "logout_methods": {
+              "description": "A set of HTTP methods that the plugin will respond to.",
+              "default": [
+                "POST",
+                "DELETE"
+              ],
+              "type": "set",
               "elements": {
                 "type": "string",
                 "one_of": [
@@ -269,13 +273,7 @@
                   "POST",
                   "DELETE"
                 ]
-              },
-              "type": "set",
-              "description": "A set of HTTP methods that the plugin will respond to.",
-              "default": [
-                "POST",
-                "DELETE"
-              ]
+              }
             }
           },
           {
@@ -292,7 +290,9 @@
               "description": "The POST argument passed to logout requests. Do not change this property."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/statsd-advanced/3.5.x.json
+++ b/schemas/statsd-advanced/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "host": {
@@ -51,13 +49,13 @@
           },
           {
             "port": {
-              "default": 8125,
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 8125,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
@@ -69,80 +67,156 @@
           },
           {
             "metrics": {
+              "description": "List of Metrics to be logged.",
               "default": [
                 {
                   "name": "request_count",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
-                  "name": "latency",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "latency"
                 },
                 {
-                  "name": "request_size",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "request_size"
                 },
                 {
                   "name": "status_count",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
-                  "name": "response_size",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "response_size"
                 },
                 {
-                  "name": "unique_users",
-                  "stat_type": "set"
+                  "stat_type": "set",
+                  "name": "unique_users"
                 },
                 {
                   "name": "request_per_user",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
-                  "name": "upstream_latency",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "upstream_latency"
                 },
                 {
-                  "name": "kong_latency",
-                  "stat_type": "timer"
+                  "stat_type": "timer",
+                  "name": "kong_latency"
                 },
                 {
                   "name": "status_count_per_user",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "status_count_per_workspace",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "status_count_per_user_per_route",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "shdict_usage",
-                  "sample_rate": 1,
-                  "stat_type": "gauge"
+                  "stat_type": "gauge",
+                  "sample_rate": 1
                 },
                 {
                   "name": "cache_datastore_hits_total",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "cache_datastore_misses_total",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 }
               ],
               "type": "array",
-              "description": "List of Metrics to be logged.",
               "elements": {
+                "fields": [
+                  {
+                    "name": {
+                      "one_of": [
+                        "kong_latency",
+                        "latency",
+                        "request_count",
+                        "request_per_user",
+                        "request_size",
+                        "response_size",
+                        "status_count",
+                        "status_count_per_user",
+                        "unique_users",
+                        "upstream_latency",
+                        "status_count_per_workspace",
+                        "status_count_per_user_per_route",
+                        "shdict_usage",
+                        "cache_datastore_hits_total",
+                        "cache_datastore_misses_total"
+                      ],
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  {
+                    "stat_type": {
+                      "one_of": [
+                        "counter",
+                        "gauge",
+                        "histogram",
+                        "meter",
+                        "set",
+                        "timer"
+                      ],
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  {
+                    "sample_rate": {
+                      "type": "number",
+                      "gt": 0
+                    }
+                  },
+                  {
+                    "consumer_identifier": {
+                      "type": "string",
+                      "one_of": [
+                        "consumer_id",
+                        "custom_id",
+                        "username"
+                      ]
+                    }
+                  },
+                  {
+                    "service_identifier": {
+                      "type": "string",
+                      "one_of": [
+                        "service_id",
+                        "service_name",
+                        "service_host",
+                        "service_name_or_host"
+                      ]
+                    }
+                  },
+                  {
+                    "workspace_identifier": {
+                      "type": "string",
+                      "one_of": [
+                        "workspace_id",
+                        "workspace_name"
+                      ]
+                    }
+                  }
+                ],
+                "type": "record",
                 "entity_checks": [
                   {
                     "conditional": {
@@ -208,105 +282,29 @@
                       "if_field": "stat_type"
                     }
                   }
-                ],
-                "type": "record",
-                "fields": [
-                  {
-                    "name": {
-                      "required": true,
-                      "type": "string",
-                      "one_of": [
-                        "kong_latency",
-                        "latency",
-                        "request_count",
-                        "request_per_user",
-                        "request_size",
-                        "response_size",
-                        "status_count",
-                        "status_count_per_user",
-                        "unique_users",
-                        "upstream_latency",
-                        "status_count_per_workspace",
-                        "status_count_per_user_per_route",
-                        "shdict_usage",
-                        "cache_datastore_hits_total",
-                        "cache_datastore_misses_total"
-                      ]
-                    }
-                  },
-                  {
-                    "stat_type": {
-                      "required": true,
-                      "type": "string",
-                      "one_of": [
-                        "counter",
-                        "gauge",
-                        "histogram",
-                        "meter",
-                        "set",
-                        "timer"
-                      ]
-                    }
-                  },
-                  {
-                    "sample_rate": {
-                      "type": "number",
-                      "gt": 0
-                    }
-                  },
-                  {
-                    "consumer_identifier": {
-                      "type": "string",
-                      "one_of": [
-                        "consumer_id",
-                        "custom_id",
-                        "username"
-                      ]
-                    }
-                  },
-                  {
-                    "service_identifier": {
-                      "type": "string",
-                      "one_of": [
-                        "service_id",
-                        "service_name",
-                        "service_host",
-                        "service_name_or_host"
-                      ]
-                    }
-                  },
-                  {
-                    "workspace_identifier": {
-                      "type": "string",
-                      "one_of": [
-                        "workspace_id",
-                        "workspace_name"
-                      ]
-                    }
-                  }
                 ]
               }
             }
           },
           {
             "allow_status_codes": {
-              "elements": {
-                "match": "^[0-9]+-[0-9]+$",
-                "type": "string"
-              },
+              "description": "List of status code ranges that are allowed to be logged in metrics.",
               "type": "array",
-              "description": "List of status code ranges that are allowed to be logged in metrics."
+              "elements": {
+                "type": "string",
+                "match": "^[0-9]+-[0-9]+$"
+              }
             }
           },
           {
             "udp_packet_size": {
-              "default": 0,
-              "type": "number",
-              "description": "Combine UDP packet up to the size configured. If zero (0), don't combine the UDP packet. Must be a number between 0 and 65507 (inclusive).",
               "between": [
                 0,
                 65507
-              ]
+              ],
+              "default": 0,
+              "type": "number",
+              "description": "Combine UDP packet up to the size configured. If zero (0), don't combine the UDP packet. Must be a number between 0 and 65507 (inclusive)."
             }
           },
           {
@@ -326,84 +324,82 @@
           {
             "consumer_identifier_default": {
               "type": "string",
-              "description": "The default consumer identifier for metrics. This will take effect when a metric's consumer identifier is omitted. Allowed values are `custom_id`, `consumer_id`, `username`.",
-              "default": "custom_id",
               "required": true,
               "one_of": [
                 "consumer_id",
                 "custom_id",
                 "username"
-              ]
+              ],
+              "default": "custom_id",
+              "description": "The default consumer identifier for metrics. This will take effect when a metric's consumer identifier is omitted. Allowed values are `custom_id`, `consumer_id`, `username`."
             }
           },
           {
             "service_identifier_default": {
               "type": "string",
-              "description": "The default service identifier for metrics. This will take effect when a metric's service identifier is omitted. Allowed values are `service_name_or_host`, `service_id`, `service_name`, `service_host`.",
-              "default": "service_name_or_host",
               "required": true,
               "one_of": [
                 "service_id",
                 "service_name",
                 "service_host",
                 "service_name_or_host"
-              ]
+              ],
+              "default": "service_name_or_host",
+              "description": "The default service identifier for metrics. This will take effect when a metric's service identifier is omitted. Allowed values are `service_name_or_host`, `service_id`, `service_name`, `service_host`."
             }
           },
           {
             "workspace_identifier_default": {
               "type": "string",
-              "description": "The default workspace identifier for metrics. This will take effect when a metric's workspace identifier is omitted. Allowed values are `workspace_id`, `workspace_name`.   ",
-              "default": "workspace_id",
               "required": true,
               "one_of": [
                 "workspace_id",
                 "workspace_name"
-              ]
+              ],
+              "default": "workspace_id",
+              "description": "The default workspace identifier for metrics. This will take effect when a metric's workspace identifier is omitted. Allowed values are `workspace_id`, `workspace_name`.   "
             }
           },
           {
             "queue": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "number",
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 10000,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
                   "max_bytes": {
-                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content.",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
@@ -415,30 +411,34 @@
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 0.01,
+                    "type": "number",
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 60,
+                    "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/statsd/3.5.x.json
+++ b/schemas/statsd/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "custom_entity_check": {
@@ -62,13 +60,13 @@
           },
           {
             "port": {
-              "default": 8125,
-              "type": "integer",
-              "description": "The port of StatsD server to send data to.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "default": 8125,
+              "type": "integer",
+              "description": "The port of StatsD server to send data to."
             }
           },
           {
@@ -80,105 +78,85 @@
           },
           {
             "metrics": {
+              "description": "List of metrics to be logged.",
               "default": [
                 {
                   "name": "request_count",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
-                  "stat_type": "timer",
-                  "name": "latency"
+                  "name": "latency",
+                  "stat_type": "timer"
                 },
                 {
                   "name": "request_size",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "status_count",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "response_size",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
-                  "stat_type": "set",
-                  "name": "unique_users"
+                  "name": "unique_users",
+                  "stat_type": "set"
                 },
                 {
                   "name": "request_per_user",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
-                  "stat_type": "timer",
-                  "name": "upstream_latency"
+                  "name": "upstream_latency",
+                  "stat_type": "timer"
                 },
                 {
-                  "stat_type": "timer",
-                  "name": "kong_latency"
+                  "name": "kong_latency",
+                  "stat_type": "timer"
                 },
                 {
                   "name": "status_count_per_user",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "status_count_per_workspace",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "status_count_per_user_per_route",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "shdict_usage",
-                  "sample_rate": 1,
-                  "stat_type": "gauge"
+                  "stat_type": "gauge",
+                  "sample_rate": 1
                 },
                 {
                   "name": "cache_datastore_hits_total",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 },
                 {
                   "name": "cache_datastore_misses_total",
-                  "sample_rate": 1,
-                  "stat_type": "counter"
+                  "stat_type": "counter",
+                  "sample_rate": 1
                 }
               ],
               "type": "array",
-              "description": "List of metrics to be logged.",
               "elements": {
-                "entity_checks": [
-                  {
-                    "conditional": {
-                      "then_field": "sample_rate",
-                      "if_match": {
-                        "one_of": [
-                          "counter",
-                          "gauge"
-                        ]
-                      },
-                      "then_match": {
-                        "required": true
-                      },
-                      "if_field": "stat_type"
-                    }
-                  }
-                ],
-                "type": "record",
                 "fields": [
                   {
                     "name": {
-                      "required": true,
-                      "type": "string",
                       "description": "StatsD metric’s name.",
                       "one_of": [
                         "kong_latency",
@@ -196,13 +174,13 @@
                         "shdict_usage",
                         "cache_datastore_hits_total",
                         "cache_datastore_misses_total"
-                      ]
+                      ],
+                      "type": "string",
+                      "required": true
                     }
                   },
                   {
                     "stat_type": {
-                      "required": true,
-                      "type": "string",
                       "description": "Determines what sort of event a metric represents.",
                       "one_of": [
                         "counter",
@@ -211,47 +189,67 @@
                         "meter",
                         "set",
                         "timer"
-                      ]
+                      ],
+                      "type": "string",
+                      "required": true
                     }
                   },
                   {
                     "sample_rate": {
                       "gt": 0,
-                      "description": "Sampling rate",
-                      "type": "number"
+                      "type": "number",
+                      "description": "Sampling rate"
                     }
                   },
                   {
                     "consumer_identifier": {
-                      "type": "string",
-                      "description": "Authenticated user detail.",
                       "one_of": [
                         "consumer_id",
                         "custom_id",
                         "username"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Authenticated user detail."
                     }
                   },
                   {
                     "service_identifier": {
-                      "type": "string",
-                      "description": "Service detail.",
                       "one_of": [
                         "service_id",
                         "service_name",
                         "service_host",
                         "service_name_or_host"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Service detail."
                     }
                   },
                   {
                     "workspace_identifier": {
-                      "type": "string",
-                      "description": "Workspace detail.",
                       "one_of": [
                         "workspace_id",
                         "workspace_name"
-                      ]
+                      ],
+                      "type": "string",
+                      "description": "Workspace detail."
+                    }
+                  }
+                ],
+                "type": "record",
+                "entity_checks": [
+                  {
+                    "conditional": {
+                      "then_field": "sample_rate",
+                      "if_match": {
+                        "one_of": [
+                          "counter",
+                          "gauge"
+                        ]
+                      },
+                      "then_match": {
+                        "required": true
+                      },
+                      "if_field": "stat_type"
                     }
                   }
                 ]
@@ -260,70 +258,70 @@
           },
           {
             "allow_status_codes": {
-              "elements": {
-                "match": "^[0-9]+-[0-9]+$",
-                "type": "string"
-              },
+              "description": "List of status code ranges that are allowed to be logged in metrics.",
               "type": "array",
-              "description": "List of status code ranges that are allowed to be logged in metrics."
+              "elements": {
+                "type": "string",
+                "match": "^[0-9]+-[0-9]+$"
+              }
             }
           },
           {
             "udp_packet_size": {
-              "default": 0,
-              "type": "number",
               "between": [
                 0,
                 65507
-              ]
+              ],
+              "default": 0,
+              "type": "number"
             }
           },
           {
             "use_tcp": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "hostname_in_prefix": {
-              "default": false,
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           },
           {
             "consumer_identifier_default": {
-              "default": "custom_id",
-              "type": "string",
-              "required": true,
               "one_of": [
                 "consumer_id",
                 "custom_id",
                 "username"
-              ]
+              ],
+              "default": "custom_id",
+              "type": "string",
+              "required": true
             }
           },
           {
             "service_identifier_default": {
-              "default": "service_name_or_host",
-              "type": "string",
-              "required": true,
               "one_of": [
                 "service_id",
                 "service_name",
                 "service_host",
                 "service_name_or_host"
-              ]
+              ],
+              "default": "service_name_or_host",
+              "type": "string",
+              "required": true
             }
           },
           {
             "workspace_identifier_default": {
-              "default": "workspace_id",
-              "type": "string",
-              "required": true,
               "one_of": [
                 "workspace_id",
                 "workspace_name"
-              ]
+              ],
+              "default": "workspace_id",
+              "type": "string",
+              "required": true
             }
           },
           {
@@ -343,58 +341,56 @@
           },
           {
             "tag_style": {
-              "required": false,
-              "type": "string",
               "one_of": [
                 "dogstatsd",
                 "influxdb",
                 "librato",
                 "signalfx"
-              ]
+              ],
+              "type": "string",
+              "required": false
             }
           },
           {
             "queue": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "number",
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 10000,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
                   "max_bytes": {
-                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content.",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
@@ -406,30 +402,34 @@
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 0.01,
+                    "type": "number",
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 60,
+                    "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/syslog/3.5.x.json
+++ b/schemas/syslog/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,38 +23,25 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "log_level": {
-              "required": true,
-              "type": "string",
-              "default": "info",
               "one_of": [
                 "debug",
                 "info",
@@ -56,14 +51,14 @@
                 "crit",
                 "alert",
                 "emerg"
-              ]
+              ],
+              "default": "info",
+              "type": "string",
+              "required": true
             }
           },
           {
             "successful_severity": {
-              "required": true,
-              "type": "string",
-              "default": "info",
               "one_of": [
                 "debug",
                 "info",
@@ -73,14 +68,14 @@
                 "crit",
                 "alert",
                 "emerg"
-              ]
+              ],
+              "default": "info",
+              "type": "string",
+              "required": true
             }
           },
           {
             "client_errors_severity": {
-              "required": true,
-              "type": "string",
-              "default": "info",
               "one_of": [
                 "debug",
                 "info",
@@ -90,14 +85,14 @@
                 "crit",
                 "alert",
                 "emerg"
-              ]
+              ],
+              "default": "info",
+              "type": "string",
+              "required": true
             }
           },
           {
             "server_errors_severity": {
-              "required": true,
-              "type": "string",
-              "default": "info",
               "one_of": [
                 "debug",
                 "info",
@@ -107,29 +102,30 @@
                 "crit",
                 "alert",
                 "emerg"
-              ]
+              ],
+              "default": "info",
+              "type": "string",
+              "required": true
             }
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
+              "type": "map",
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "type": "map",
-              "description": "Lua code as a key-value map",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "Lua code as a key-value map"
             }
           },
           {
             "facility": {
               "type": "string",
-              "description": "The facility is used by the operating system to decide how to handle each log message.",
               "required": true,
-              "default": "user",
               "one_of": [
                 "auth",
                 "authpriv",
@@ -151,10 +147,14 @@
                 "local5",
                 "local6",
                 "local7"
-              ]
+              ],
+              "default": "user",
+              "description": "The facility is used by the operating system to decide how to handle each log message."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/tcp-log/3.5.x.json
+++ b/schemas/tcp-log/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "host": {
@@ -51,13 +49,13 @@
           },
           {
             "port": {
-              "required": true,
-              "type": "integer",
-              "description": "The port to send data to on the upstream server.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "required": true,
+              "type": "integer",
+              "description": "The port to send data to on the upstream server."
             }
           },
           {
@@ -76,33 +74,35 @@
           },
           {
             "tls": {
-              "required": true,
-              "type": "boolean",
               "description": "Indicates whether to perform a TLS handshake against the remote server.",
-              "default": false
+              "default": false,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "tls_sni": {
-              "description": "An optional string that defines the SNI (Server Name Indication) hostname to send in the TLS handshake.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string that defines the SNI (Server Name Indication) hostname to send in the TLS handshake."
             }
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
               "type": "map",
-              "description": "A list of key-value pairs, where the key is the name of a log field and the value is a chunk of Lua code, whose return value sets or replaces the log field value.",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "A list of key-value pairs, where the key is the name of a log field and the value is a chunk of Lua code, whose return value sets or replaces the log field value."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/tls-handshake-modifier/3.5.x.json
+++ b/schemas/tls-handshake-modifier/3.5.x.json
@@ -3,19 +3,19 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "https",
           "grpcs"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -29,28 +29,28 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "tls_client_certificate": {
               "type": "string",
-              "description": "TLS Client Certificate",
               "required": false,
-              "default": "REQUEST",
               "one_of": [
                 "REQUEST"
-              ]
+              ],
+              "default": "REQUEST",
+              "description": "TLS Client Certificate"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/tls-metadata-headers/3.5.x.json
+++ b/schemas/tls-metadata-headers/3.5.x.json
@@ -3,19 +3,19 @@
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "https",
           "grpcs"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -29,15 +29,13 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "inject_client_cert_details": {
@@ -48,45 +46,47 @@
           },
           {
             "client_cert_header_name": {
+              "description": "Define the HTTP header name used for the PEM format URL encoded client certificate.",
               "default": "X-Client-Cert",
               "type": "string",
-              "description": "Define the HTTP header name used for the PEM format URL encoded client certificate.",
               "required": true
             }
           },
           {
             "client_serial_header_name": {
+              "description": "Define the HTTP header name used for the serial number of the client certificate.",
               "default": "X-Client-Cert-Serial",
               "type": "string",
-              "description": "Define the HTTP header name used for the serial number of the client certificate.",
               "required": true
             }
           },
           {
             "client_cert_issuer_dn_header_name": {
+              "description": "Define the HTTP header name used for the issuer DN of the client certificate.",
               "default": "X-Client-Cert-Issuer-DN",
               "type": "string",
-              "description": "Define the HTTP header name used for the issuer DN of the client certificate.",
               "required": true
             }
           },
           {
             "client_cert_subject_dn_header_name": {
+              "description": "Define the HTTP header name used for the subject DN of the client certificate.",
               "default": "X-Client-Cert-Subject-DN",
               "type": "string",
-              "description": "Define the HTTP header name used for the subject DN of the client certificate.",
               "required": true
             }
           },
           {
             "client_cert_fingerprint_header_name": {
+              "description": "Define the HTTP header name used for the SHA1 fingerprint of the client certificate.",
               "default": "X-Client-Cert-Fingerprint",
               "type": "string",
-              "description": "Define the HTTP header name used for the SHA1 fingerprint of the client certificate.",
               "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/udp-log/3.5.x.json
+++ b/schemas/udp-log/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,32 +23,22 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "host": {
@@ -51,13 +49,13 @@
           },
           {
             "port": {
-              "required": true,
-              "type": "integer",
-              "description": "An integer representing a port number between 0 and 65535, inclusive.",
               "between": [
                 0,
                 65535
-              ]
+              ],
+              "required": true,
+              "type": "integer",
+              "description": "An integer representing a port number between 0 and 65535, inclusive."
             }
           },
           {
@@ -69,19 +67,21 @@
           },
           {
             "custom_fields_by_lua": {
+              "keys": {
+                "type": "string",
+                "len_min": 1
+              },
+              "type": "map",
               "values": {
                 "len_min": 1,
                 "type": "string"
               },
-              "type": "map",
-              "description": "Lua code as a key-value map",
-              "keys": {
-                "len_min": 1,
-                "type": "string"
-              }
+              "description": "Lua code as a key-value map"
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/upstream-timeout/3.5.x.json
+++ b/schemas/upstream-timeout/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "read_timeout": {
@@ -65,7 +63,9 @@
               "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/vault-auth/3.5.x.json
+++ b/schemas/vault-auth/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,68 +19,58 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
         "type": "foreign",
-        "description": "Custom type for representing a foreign key with a null value allowed.",
         "eq": null,
-        "reference": "consumers"
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "access_token_name": {
-              "elements": {
-                "description": "A string representing an HTTP header name.",
-                "type": "string"
-              },
               "type": "string",
-              "description": "Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
+              "required": true,
               "default": "access_token",
-              "required": true
+              "description": "Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "secret_token_name": {
-              "elements": {
-                "description": "A string representing an HTTP header name.",
-                "type": "string"
-              },
               "type": "string",
-              "description": "Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
+              "required": true,
               "default": "secret_token",
-              "required": true
+              "description": "Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
+              "elements": {
+                "type": "string",
+                "description": "A string representing an HTTP header name."
+              }
             }
           },
           {
             "vault": {
-              "required": true,
-              "type": "foreign",
               "description": "A reference to an existing `vault` object within the database. `vault` entities define the connection and authentication parameters used to connect to a Vault HTTP(S) API.",
-              "reference": "vault_auth_vaults"
+              "type": "foreign",
+              "reference": "vault_auth_vaults",
+              "required": true
             }
           },
           {
@@ -84,8 +82,8 @@
           },
           {
             "anonymous": {
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "type": "string"
+              "type": "string",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request fails with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
@@ -102,7 +100,9 @@
               "description": "A boolean value that indicates whether the plugin should run (and try to authenticate) on `OPTIONS` preflight requests. If set to `false`, then `OPTIONS` requests will always be allowed."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/websocket-size-limit/3.5.x.json
+++ b/schemas/websocket-size-limit/3.5.x.json
@@ -3,11 +3,11 @@
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -20,15 +20,13 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -40,25 +38,27 @@
         "fields": [
           {
             "client_max_payload": {
-              "required": false,
-              "type": "integer",
               "between": [
                 1,
                 33554432
-              ]
+              ],
+              "type": "integer",
+              "required": false
             }
           },
           {
             "upstream_max_payload": {
-              "required": false,
-              "type": "integer",
               "between": [
                 1,
                 33554432
-              ]
+              ],
+              "type": "integer",
+              "required": false
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/websocket-validator/3.5.x.json
+++ b/schemas/websocket-validator/3.5.x.json
@@ -3,11 +3,11 @@
     {
       "protocols": {
         "required": true,
-        "type": "set",
         "default": [
           "ws",
           "wss"
         ],
+        "type": "set",
         "elements": {
           "type": "string",
           "one_of": [
@@ -20,15 +20,13 @@
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "at_least_one_of": [
@@ -40,8 +38,6 @@
         "fields": [
           {
             "client": {
-              "required": false,
-              "type": "record",
               "entity_checks": [
                 {
                   "at_least_one_of": [
@@ -53,8 +49,6 @@
               "fields": [
                 {
                   "text": {
-                    "required": false,
-                    "type": "record",
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -68,28 +62,28 @@
                     "fields": [
                       {
                         "type": {
-                          "required": true,
-                          "type": "string",
                           "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
                           "one_of": [
                             "draft4"
-                          ]
+                          ],
+                          "type": "string",
+                          "required": true
                         }
                       },
                       {
                         "schema": {
-                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
                           "type": "string",
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                          "required": true
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": false
                   }
                 },
                 {
                   "binary": {
-                    "required": false,
-                    "type": "record",
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -103,31 +97,33 @@
                     "fields": [
                       {
                         "type": {
-                          "required": true,
-                          "type": "string",
                           "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
                           "one_of": [
                             "draft4"
-                          ]
+                          ],
+                          "type": "string",
+                          "required": true
                         }
                       },
                       {
                         "schema": {
-                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
                           "type": "string",
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                          "required": true
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": false
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": false
             }
           },
           {
             "upstream": {
-              "required": false,
-              "type": "record",
               "entity_checks": [
                 {
                   "at_least_one_of": [
@@ -139,8 +135,6 @@
               "fields": [
                 {
                   "text": {
-                    "required": false,
-                    "type": "record",
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -154,28 +148,28 @@
                     "fields": [
                       {
                         "type": {
-                          "required": true,
-                          "type": "string",
                           "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
                           "one_of": [
                             "draft4"
-                          ]
+                          ],
+                          "type": "string",
+                          "required": true
                         }
                       },
                       {
                         "schema": {
-                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
                           "type": "string",
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                          "required": true
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": false
                   }
                 },
                 {
                   "binary": {
-                    "required": false,
-                    "type": "record",
                     "entity_checks": [
                       {
                         "custom_entity_check": {
@@ -189,28 +183,34 @@
                     "fields": [
                       {
                         "type": {
-                          "required": true,
-                          "type": "string",
                           "description": "The corresponding validation library for `config.upstream.binary.schema`. Currently, only `draft4` is supported.",
                           "one_of": [
                             "draft4"
-                          ]
+                          ],
+                          "type": "string",
+                          "required": true
                         }
                       },
                       {
                         "schema": {
-                          "required": true,
+                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`.",
                           "type": "string",
-                          "description": "Schema used to validate upstream-originated binary frames. The semantics of this field depend on the validation type set by `config.upstream.binary.type`."
+                          "required": true
                         }
                       }
-                    ]
+                    ],
+                    "type": "record",
+                    "required": false
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": false
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/xml-threat-protection/3.5.x.json
+++ b/schemas/xml-threat-protection/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "type": "string",
           "one_of": [
@@ -11,29 +19,19 @@
             "https"
           ]
         },
-        "type": "set",
-        "description": "A set of strings representing HTTP protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing HTTP protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "entity_checks": [
           {
             "conditional": {
@@ -75,222 +73,224 @@
         "fields": [
           {
             "checked_content_types": {
-              "elements": {
-                "required": true,
-                "type": "string",
-                "match": "^[^%s]+%/[^ ;]+$"
-              },
               "type": "set",
-              "description": "A list of Content-Type values with payloads that must be validated.",
               "required": true,
               "default": [
                 "application/xml"
-              ]
+              ],
+              "description": "A list of Content-Type values with payloads that must be validated.",
+              "elements": {
+                "type": "string",
+                "match": "^[^%s]+%/[^ ;]+$",
+                "required": true
+              }
             }
           },
           {
             "allowed_content_types": {
-              "elements": {
-                "required": true,
-                "type": "string",
-                "match": "^[^%s]+%/[^ ;]+$"
-              },
               "type": "set",
-              "description": "A list of Content-Type values with payloads that are allowed, but aren't validated.",
               "required": true,
               "default": [
 
-              ]
+              ],
+              "description": "A list of Content-Type values with payloads that are allowed, but aren't validated.",
+              "elements": {
+                "type": "string",
+                "match": "^[^%s]+%/[^ ;]+$",
+                "required": true
+              }
             }
           },
           {
             "allow_dtd": {
+              "description": "Indicates whether an XML Document Type Definition (DTD) section is allowed.",
               "default": false,
               "type": "boolean",
-              "description": "Indicates whether an XML Document Type Definition (DTD) section is allowed.",
               "required": true
             }
           },
           {
             "namespace_aware": {
+              "description": "If not parsing namespace aware, all prefixes and namespace attributes will be counted as regular attributes and element names, and validated as such.",
               "default": true,
               "type": "boolean",
-              "description": "If not parsing namespace aware, all prefixes and namespace attributes will be counted as regular attributes and element names, and validated as such.",
               "required": true
             }
           },
           {
             "max_depth": {
-              "type": "integer",
-              "description": "Maximum depth of tags. Child elements such as Text or Comments are not counted as another level.",
-              "required": true,
               "gt": 0,
-              "default": 50
+              "type": "integer",
+              "required": true,
+              "default": 50,
+              "description": "Maximum depth of tags. Child elements such as Text or Comments are not counted as another level."
             }
           },
           {
             "max_children": {
-              "type": "integer",
-              "description": "Maximum number of children allowed (Element, Text, Comment, ProcessingInstruction, CDATASection). Note: Adjacent text and CDATA sections are counted as one. For example, text-cdata-text-cdata is one child.",
-              "required": true,
               "gt": 0,
-              "default": 100
+              "type": "integer",
+              "required": true,
+              "default": 100,
+              "description": "Maximum number of children allowed (Element, Text, Comment, ProcessingInstruction, CDATASection). Note: Adjacent text and CDATA sections are counted as one. For example, text-cdata-text-cdata is one child."
             }
           },
           {
             "max_attributes": {
-              "type": "integer",
-              "description": "Maximum number of attributes allowed on a tag, including default ones. Note: If namespace-aware parsing is disabled, then the namespaces definitions are counted as attributes.",
-              "required": true,
               "gt": 0,
-              "default": 100
+              "type": "integer",
+              "required": true,
+              "default": 100,
+              "description": "Maximum number of attributes allowed on a tag, including default ones. Note: If namespace-aware parsing is disabled, then the namespaces definitions are counted as attributes."
             }
           },
           {
             "max_namespaces": {
-              "type": "integer",
-              "description": "Maximum number of namespaces defined on a tag. This value is required if parsing is namespace-aware.",
-              "required": false,
               "gt": 0,
-              "default": 20
+              "type": "integer",
+              "required": false,
+              "default": 20,
+              "description": "Maximum number of namespaces defined on a tag. This value is required if parsing is namespace-aware."
             }
           },
           {
             "document": {
-              "type": "integer",
-              "description": "Maximum size of the entire document.",
-              "required": true,
               "gt": 0,
-              "default": 10485760
+              "type": "integer",
+              "required": true,
+              "default": 10485760,
+              "description": "Maximum size of the entire document."
             }
           },
           {
             "buffer": {
-              "type": "integer",
-              "description": "Maximum size of the unparsed buffer (see below).",
-              "required": true,
               "gt": 0,
-              "default": 1048576
+              "type": "integer",
+              "required": true,
+              "default": 1048576,
+              "description": "Maximum size of the unparsed buffer (see below)."
             }
           },
           {
             "comment": {
-              "type": "integer",
-              "description": "Maximum size of comments.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of comments."
             }
           },
           {
             "localname": {
-              "type": "integer",
-              "description": "Maximum size of the localname. This applies to tags and attributes.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of the localname. This applies to tags and attributes."
             }
           },
           {
             "prefix": {
-              "type": "integer",
-              "description": "Maximum size of the prefix. This applies to tags and attributes. This value is required if parsing is namespace-aware.",
-              "required": false,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": false,
+              "default": 1024,
+              "description": "Maximum size of the prefix. This applies to tags and attributes. This value is required if parsing is namespace-aware."
             }
           },
           {
             "namespaceuri": {
-              "type": "integer",
-              "description": "Maximum size of the namespace URI. This value is required if parsing is namespace-aware.",
-              "required": false,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": false,
+              "default": 1024,
+              "description": "Maximum size of the namespace URI. This value is required if parsing is namespace-aware."
             }
           },
           {
             "attribute": {
-              "type": "integer",
-              "description": "Maximum size of the attribute value.",
-              "required": true,
               "gt": 0,
-              "default": 1048576
+              "type": "integer",
+              "required": true,
+              "default": 1048576,
+              "description": "Maximum size of the attribute value."
             }
           },
           {
             "text": {
-              "type": "integer",
-              "description": "Maximum text inside tags (counted over all adjacent text/CDATA elements combined).",
-              "required": true,
               "gt": 0,
-              "default": 1048576
+              "type": "integer",
+              "required": true,
+              "default": 1048576,
+              "description": "Maximum text inside tags (counted over all adjacent text/CDATA elements combined)."
             }
           },
           {
             "pitarget": {
-              "type": "integer",
-              "description": "Maximum size of processing instruction targets.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of processing instruction targets."
             }
           },
           {
             "pidata": {
-              "type": "integer",
-              "description": "Maximum size of processing instruction data.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of processing instruction data."
             }
           },
           {
             "entityname": {
-              "type": "integer",
-              "description": "Maximum size of entity names in EntityDecl.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of entity names in EntityDecl."
             }
           },
           {
             "entity": {
-              "type": "integer",
-              "description": "Maximum size of entity values in EntityDecl.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of entity values in EntityDecl."
             }
           },
           {
             "entityproperty": {
-              "type": "integer",
-              "description": "Maximum size of systemId, publicId, or notationName in EntityDecl.",
-              "required": true,
               "gt": 0,
-              "default": 1024
+              "type": "integer",
+              "required": true,
+              "default": 1024,
+              "description": "Maximum size of systemId, publicId, or notationName in EntityDecl."
             }
           },
           {
             "bla_max_amplification": {
-              "type": "number",
-              "description": "Sets the maximum allowed amplification. This protects against the Billion Laughs Attack.",
-              "required": true,
               "gt": 1,
-              "default": 100
+              "type": "number",
+              "required": true,
+              "default": 100,
+              "description": "Sets the maximum allowed amplification. This protects against the Billion Laughs Attack."
             }
           },
           {
             "bla_threshold": {
-              "type": "integer",
-              "description": "Sets the threshold after which the protection starts. This protects against the Billion Laughs Attack.",
-              "required": true,
               "gt": 1024,
-              "default": 8388608
+              "type": "integer",
+              "required": true,
+              "default": 8388608,
+              "description": "Sets the threshold after which the protection starts. This protects against the Billion Laughs Attack."
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],

--- a/schemas/zipkin/3.5.x.json
+++ b/schemas/zipkin/3.5.x.json
@@ -2,6 +2,14 @@
   "fields": [
     {
       "protocols": {
+        "type": "set",
+        "required": true,
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
         "elements": {
           "one_of": [
             "grpc",
@@ -15,90 +23,78 @@
             "ws",
             "wss"
           ],
-          "description": "A string representing a protocol, such as HTTP or HTTPS.",
-          "type": "string"
+          "type": "string",
+          "description": "A string representing a protocol, such as HTTP or HTTPS."
         },
-        "type": "set",
-        "description": "A set of strings representing protocols.",
-        "required": true,
-        "default": [
-          "grpc",
-          "grpcs",
-          "http",
-          "https"
-        ]
+        "description": "A set of strings representing protocols."
       }
     },
     {
       "consumer_group": {
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed.",
-        "reference": "consumer_groups"
+        "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "config": {
-        "required": true,
-        "type": "record",
         "fields": [
           {
             "local_service_name": {
-              "required": true,
-              "type": "string",
               "description": "The name of the service as displayed in Zipkin.",
-              "default": "kong"
+              "default": "kong",
+              "type": "string",
+              "required": true
             }
           },
           {
             "http_endpoint": {
-              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search.",
-              "type": "string"
+              "type": "string",
+              "description": "A string representing a URL, such as https://example.com/path/to/resource?q=search."
             }
           },
           {
             "sample_ratio": {
-              "default": 0.001,
-              "type": "number",
-              "description": "How often to sample requests that do not contain trace IDs. Set to `0` to turn sampling off, or to `1` to sample **all** requests. ",
               "between": [
                 0,
                 1
-              ]
+              ],
+              "default": 0.001,
+              "type": "number",
+              "description": "How often to sample requests that do not contain trace IDs. Set to `0` to turn sampling off, or to `1` to sample **all** requests. "
             }
           },
           {
             "default_service_name": {
-              "description": "Set a default service name to override `unknown-service-name` in the Zipkin spans.",
-              "type": "string"
+              "type": "string",
+              "description": "Set a default service name to override `unknown-service-name` in the Zipkin spans."
             }
           },
           {
             "include_credential": {
-              "required": true,
-              "type": "boolean",
               "description": "Specify whether the credential of the currently authenticated consumer should be included in metadata sent to the Zipkin server.",
-              "default": true
+              "default": true,
+              "type": "boolean",
+              "required": true
             }
           },
           {
             "traceid_byte_count": {
               "type": "integer",
-              "description": "The length in bytes of each request's Trace ID.",
               "required": true,
-              "default": 16,
               "one_of": [
                 8,
                 16
-              ]
+              ],
+              "default": 16,
+              "description": "The length in bytes of each request's Trace ID."
             }
           },
           {
             "header_type": {
               "type": "string",
-              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests",
               "required": true,
-              "default": "preserve",
               "one_of": [
                 "preserve",
                 "ignore",
@@ -110,15 +106,15 @@
                 "aws",
                 "datadog",
                 "gcp"
-              ]
+              ],
+              "default": "preserve",
+              "description": "All HTTP requests going through the plugin are tagged with a tracing HTTP request. This property codifies what kind of tracing header the plugin expects on incoming requests"
             }
           },
           {
             "default_header_type": {
               "type": "string",
-              "description": "Allows specifying the type of header to be added to requests with no pre-existing tracing headers and when `config.header_type` is set to `\"preserve\"`. When `header_type` is set to any other value, `default_header_type` is ignored.",
               "required": true,
-              "default": "b3",
               "one_of": [
                 "b3",
                 "b3-single",
@@ -128,25 +124,28 @@
                 "aws",
                 "datadog",
                 "gcp"
-              ]
+              ],
+              "default": "b3",
+              "description": "Allows specifying the type of header to be added to requests with no pre-existing tracing headers and when `config.header_type` is set to `\"preserve\"`. When `header_type` is set to any other value, `default_header_type` is ignored."
             }
           },
           {
             "tags_header": {
-              "required": true,
-              "type": "string",
               "description": "The Zipkin plugin will add extra headers to the tags associated with any HTTP requests that come with a header named as configured by this property.",
-              "default": "Zipkin-Tags"
+              "default": "Zipkin-Tags",
+              "type": "string",
+              "required": true
             }
           },
           {
             "static_tags": {
+              "description": "The tags specified on this property will be added to the generated request traces.",
+              "type": "array",
               "elements": {
                 "type": "record",
                 "fields": [
                   {
                     "name": {
-                      "required": true,
                       "type": "string",
                       "not_one_of": [
                         "error",
@@ -162,64 +161,63 @@
                         "kong.service",
                         "lc",
                         "peer.hostname"
-                      ]
+                      ],
+                      "required": true
                     }
                   },
                   {
                     "value": {
-                      "required": true,
-                      "type": "string"
+                      "type": "string",
+                      "required": true
                     }
                   }
                 ]
-              },
-              "type": "array",
-              "description": "The tags specified on this property will be added to the generated request traces."
+              }
             }
           },
           {
             "http_span_name": {
               "type": "string",
-              "description": "Specify whether to include the HTTP path in the span name.",
               "required": true,
-              "default": "method",
               "one_of": [
                 "method",
                 "method_path"
-              ]
+              ],
+              "default": "method",
+              "description": "Specify whether to include the HTTP path in the span name."
             }
           },
           {
             "connect_timeout": {
-              "default": 2000,
-              "type": "integer",
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
-              ]
+              ],
+              "default": 2000,
+              "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
             "send_timeout": {
-              "default": 5000,
-              "type": "integer",
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
-              ]
+              ],
+              "default": 5000,
+              "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
             "read_timeout": {
-              "default": 5000,
-              "type": "integer",
-              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
               "between": [
                 0,
                 2147483646
-              ]
+              ],
+              "default": 5000,
+              "type": "integer",
+              "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2."
             }
           },
           {
@@ -230,57 +228,55 @@
           {
             "phase_duration_flavor": {
               "type": "string",
-              "description": "Specify whether to include the duration of each phase as an annotation or a tag.",
               "required": true,
-              "default": "annotations",
               "one_of": [
                 "annotations",
                 "tags"
-              ]
+              ],
+              "default": "annotations",
+              "description": "Specify whether to include the duration of each phase as an annotation or a tag."
             }
           },
           {
             "queue": {
-              "required": true,
-              "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be processed at a time.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be processed at a time."
                   }
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
-                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
                     "between": [
                       0,
                       3600
-                    ]
+                    ],
+                    "default": 1,
+                    "type": "number",
+                    "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler."
                   }
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
-                    "description": "Maximum number of entries that can be waiting on the queue.",
                     "between": [
                       1,
                       1000000
-                    ]
+                    ],
+                    "default": 10000,
+                    "type": "integer",
+                    "description": "Maximum number of entries that can be waiting on the queue."
                   }
                 },
                 {
                   "max_bytes": {
-                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content.",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum number of bytes that can be waiting on a queue, requires string content."
                   }
                 },
                 {
@@ -292,30 +288,34 @@
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
-                    "description": "Time in seconds before the initial retry is made for a failing batch.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 0.01,
+                    "type": "number",
+                    "description": "Time in seconds before the initial retry is made for a failing batch."
                   }
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
-                    "description": "Maximum time in seconds between retries, caps exponential backoff.",
                     "between": [
                       0.001,
                       1000000
-                    ]
+                    ],
+                    "default": 60,
+                    "type": "number",
+                    "description": "Maximum time in seconds between retries, caps exponential backoff."
                   }
                 }
-              ]
+              ],
+              "type": "record",
+              "required": true
             }
           }
-        ]
+        ],
+        "type": "record",
+        "required": true
       }
     }
   ],


### PR DESCRIPTION
Regenerate 3.5 schemas once again, this time using the RC3 image.
There's a lot of "edits" that are just fields moving around - why does this keep happening?

Manually edited the ACL and OpenTelemetry plugins to add edits from:
* https://github.com/Kong/kong/pull/11916
* https://github.com/Kong/kong/pull/11888

The fixes for both of these plugins aren't going to make it into the 3.5 build (ACL was merged a few days ago but is still not in the build, so I think we're well past the cut-off), but we need the descriptions to be updated. They're not really dependent on versions.