### PR TITLE
feat: New oidc parameter unauthorized_destroy_session in 2.8.x

### DIFF
--- a/schemas/openid-connect/2.8.x.json
+++ b/schemas/openid-connect/2.8.x.json
@@ -450,6 +450,14 @@
             }
           },
           {
+            "unauthorized_destroy_session": {
+              "description": "Destroy any active session for the unauthorized requests.",
+              "default": true,
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
             "unauthorized_redirect_uri": {
               "required": false,
               "elements": {


### PR DESCRIPTION
The OpenID Connect plugin's `unauthorized_destroy_session` parameter has been backported into 2.8.4.5: https://github.com/Kong/docs.konghq.com/pull/6569/files#diff-c2d9c755d22ea9844e88d58c0184e3c5d63133ceb82c327596483c7ad20c672dR3202