### PR TITLE
Fix 3.4.x schemas

### DIFF
--- a/schemas/openid-connect/3.4.x.json
+++ b/schemas/openid-connect/3.4.x.json
@@ -527,6 +527,14 @@
             }
           },
           {
+            "unauthorized_destroy_session": {
+              "default": true,
+              "description": "Destroy any active session for the unauthorized requests.",
+              "type": "boolean",
+              "required": false
+            }
+          },
+          {
             "unauthorized_redirect_uri": {
               "required": false,
               "type": "array",
@@ -627,15 +635,15 @@
           },
           {
             "scopes_claim": {
+              "required": false,
               "elements": {
                 "type": "string"
               },
-              "type": "array",
               "description": "The claim that contains the scopes. If multiple values are set, it means the claim is inside a nested object of the token payload.",
-              "required": false,
               "default": [
                 "scope"
-              ]
+              ],
+              "type": "array"
             }
           },
           {
@@ -650,15 +658,15 @@
           },
           {
             "audience_claim": {
+              "required": false,
               "elements": {
                 "type": "string"
               },
-              "type": "array",
               "description": "The claim that contains the audience. If multiple values are set, it means the claim is inside a nested object of the token payload.",
-              "required": false,
               "default": [
                 "aud"
-              ]
+              ],
+              "type": "array"
             }
           },
           {
@@ -673,15 +681,15 @@
           },
           {
             "groups_claim": {
+              "required": false,
               "elements": {
                 "type": "string"
               },
-              "type": "array",
               "description": "The claim that contains the groups. If multiple values are set, it means the claim is inside a nested object of the token payload.",
-              "required": false,
               "default": [
                 "groups"
-              ]
+              ],
+              "type": "array"
             }
           },
           {
@@ -696,22 +704,22 @@
           },
           {
             "roles_claim": {
+              "required": false,
               "elements": {
                 "type": "string"
               },
-              "type": "array",
               "description": "The claim that contains the roles. If multiple values are set, it means the claim is inside a nested object of the token payload.",
-              "required": false,
               "default": [
                 "roles"
-              ]
+              ],
+              "type": "array"
             }
           },
           {
             "domains": {
-              "required": false,
               "type": "array",
               "description": "The allowed values for the `hd` claim.",
+              "required": false,
               "elements": {
                 "type": "string"
               }
@@ -719,16 +727,16 @@
           },
           {
             "max_age": {
-              "required": false,
               "type": "number",
-              "description": "The maximum age (in seconds) compared to the `auth_time` claim."
+              "description": "The maximum age (in seconds) compared to the `auth_time` claim.",
+              "required": false
             }
           },
           {
             "authenticated_groups_claim": {
-              "required": false,
               "type": "array",
               "description": "The claim that contains authenticated groups. This setting can be used together with ACL plugin, but it also enables IdP managed groups with other applications and integrations. If multiple values are set, it means the claim is inside a nested object of the token payload.",
+              "required": false,
               "elements": {
                 "type": "string"
               }
@@ -774,8 +782,8 @@
           {
             "authorization_rolling_timeout": {
               "default": 600,
-              "type": "number",
               "description": "Specifies how long the session used for the authorization code flow can be used in seconds until it needs to be renewed. 0 disables the checks and rolling.",
+              "type": "number",
               "required": false
             }
           },
@@ -1236,40 +1244,40 @@
           {
             "session_remember_rolling_timeout": {
               "default": 604800,
-              "type": "number",
               "description": "Specifies how long the persistent session is considered valid in seconds. 0 disables the checks and rolling.",
+              "type": "number",
               "required": false
             }
           },
           {
             "session_remember_absolute_timeout": {
               "default": 2592000,
-              "type": "number",
               "description": "Limits how long the persistent session can be renewed in seconds, until re-authentication is required. 0 disables the checks.",
+              "type": "number",
               "required": false
             }
           },
           {
             "session_idling_timeout": {
               "default": 900,
-              "type": "number",
               "description": "Specifies how long the session can be inactive until it is considered invalid in seconds. 0 disables the checks and touching.",
+              "type": "number",
               "required": false
             }
           },
           {
             "session_rolling_timeout": {
               "default": 3600,
-              "type": "number",
               "description": "Specifies how long the session can be used in seconds until it needs to be renewed. 0 disables the checks and rolling.",
+              "type": "number",
               "required": false
             }
           },
           {
             "session_absolute_timeout": {
               "default": 86400,
-              "type": "number",
               "description": "Limits how long the session can be renewed in seconds, until re-authentication is required. 0 disables the checks.",
+              "type": "number",
               "required": false
             }
           },
@@ -1491,23 +1499,23 @@
           },
           {
             "session_redis_connect_timeout": {
-              "required": false,
               "type": "integer",
-              "description": "Session redis connection timeout in milliseconds."
+              "description": "Session redis connection timeout in milliseconds.",
+              "required": false
             }
           },
           {
             "session_redis_read_timeout": {
-              "required": false,
               "type": "integer",
-              "description": "Session redis read timeout in milliseconds."
+              "description": "Session redis read timeout in milliseconds.",
+              "required": false
             }
           },
           {
             "session_redis_send_timeout": {
-              "required": false,
               "type": "integer",
-              "description": "Session redis send timeout in milliseconds."
+              "description": "Session redis send timeout in milliseconds.",
+              "required": false
             }
           },
           {
@@ -2378,8 +2386,8 @@
           {
             "expose_error_code": {
               "default": true,
-              "type": "boolean",
-              "description": "Specifies whether to expose the error code header, as defined in RFC 6750. If an authorization request fails, this header is sent in the response. Set to `false` to disable."
+              "description": "Specifies whether to expose the error code header, as defined in RFC 6750. If an authorization request fails, this header is sent in the response. Set to `false` to disable.",
+              "type": "boolean"
             }
           },
           {
@@ -2387,6 +2395,13 @@
               "default": false,
               "type": "boolean",
               "description": "Include the scope in the token cache key, so token with different scopes are considered diffrent tokens."
+            }
+          },
+          {
+            "using_pseudo_issuer": {
+              "type": "boolean",
+              "description": "If the plugin uses a pseudo issuer. When set to true, the plugin will not discover the configuration from the issuer URL.",
+              "default": false
             }
           }
         ]

--- a/schemas/proxy-cache-advanced/3.4.x.json
+++ b/schemas/proxy-cache-advanced/3.4.x.json
@@ -262,13 +262,13 @@
                 },
                 {
                   "keepalive_pool_size": {
-                    "default": 256,
+                    "type": "integer",
                     "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low.",
+                    "default": 30,
                     "between": [
                       1,
                       2147483646
-                    ],
-                    "type": "integer"
+                    ]
                   }
                 },
                 {

--- a/schemas/rate-limiting-advanced/3.4.x.json
+++ b/schemas/rate-limiting-advanced/3.4.x.json
@@ -80,10 +80,10 @@
           },
           {
             "namespace": {
-              "auto": true,
-              "type": "string",
+              "required": true,
               "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `window_size`, `dictionary_name`, need to be the same.",
-              "required": true
+              "auto": true,
+              "type": "string"
             }
           },
           {
@@ -239,13 +239,13 @@
                 },
                 {
                   "keepalive_pool_size": {
-                    "default": 256,
+                    "type": "integer",
                     "description": "The size limit for every cosocket connection pool associated with every remote server, per worker process. If neither `keepalive_pool_size` nor `keepalive_backlog` is specified, no pool is created. If `keepalive_pool_size` isn't specified but `keepalive_backlog` is specified, then the pool uses the default value. Try to increase (e.g. 512) this value if latency is high or throughput is low.",
+                    "default": 30,
                     "between": [
                       1,
                       2147483646
-                    ],
-                    "type": "integer"
+                    ]
                   }
                 },
                 {


### PR DESCRIPTION
Some values were missing and others were wrong after we backported them from 3.5.x

@lena-larionova I'm not sure about the descriptions though. I left the ones from 3.4.x, should we keep the ones from 3.5.x instead? 