### PR TITLE
Add command that generates the plugins' priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ For example, running:
 ```
 generates a file `./data/referenceable_fields/3.4.x.json` containing a list of plugins that have referenceable fields, and their corresponding referenceable fields.
 
+### Generate Plugin Priorities
+
+| Options | Descriptions  |
+|--------------------------- |-----|
+| `version` | **Required**. Kong Gateway release version, e.g. `3.3.x`. |
+| `plugins` | **Required**. Space separated list of plugins to use, .e.g. `acme acl`. |
+| `host`    | Name of the host in which the API is running. Default: `localhost`.  |
+| `port`    | Port in which the API is listening. Default: `8001`. |
+| `type`    | Whether the API is running the `Enterprise` or `OSS` edition. Enum: `oss` or `ee`.  |
+| `destination` | Path to the root folder in which the file will be stored. Default: `./data`  |
+
+For example, running:
+```bash
+./plugins generate_plugin_priorities --type=ee --version 3.4.x --plugins $(ls ./schemas)
+```
+generates a file `./data/priorities/ee/3.4.x.json` containing a list of plugins and their corresponded priorities order by priority (desc).
+
 ## Updating the repo after a new release
 
 Whenever a new version of Kong Gateway is released, we need run the following commands in order. For all of them, specify all the plugins `--plugins $(ls ./schemas)`
@@ -103,3 +120,4 @@ Whenever a new version of Kong Gateway is released, we need run the following co
 1. Copy Examples - specify the previous version `_x.x.y` of the example that gets copied
 1. Validate Examples  - specify the new version `_x.x.x`
 1. Generate Referenceable Fields List - specify the new version `x.x.x`
+1. Generate Priorities List - for `oss` and `ee` and specify the new version `x.x.x`

--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -30,5 +30,13 @@ module API
         puts e.message
       end
     end
+
+    def root
+      begin
+        Net::HTTP.get_response(URI("#{@base_url}/"))
+      rescue Errno::ECONNREFUSED => e
+        puts e.message
+      end
+    end
   end
 end

--- a/lib/plugin_priorities.rb
+++ b/lib/plugin_priorities.rb
@@ -1,0 +1,65 @@
+require 'json'
+require 'fileutils'
+require_relative 'api/client'
+
+class PluginPriorities
+  def self.run!(plugins:, options:)
+    new(plugins:, options:).run!
+  end
+
+  def initialize(plugins:, options:)
+    @plugins = plugins
+    @options = options
+    @client  = API::Client.new(host: @options[:host], port: @options[:port])
+  end
+
+  def run!
+    create_folders
+
+    @res = @client.root
+
+    process_response
+  end
+
+  private
+
+  def process_response
+    if success?
+      @response = JSON.parse(@res.body)
+
+      if @options['verbose']
+        puts 'Plugins ordered by priority'
+        puts JSON.pretty_generate(priorities)
+      else
+        puts "#{success? ? '✅' : '❌'}"
+      end
+
+      write_to_file(priorities)
+    end
+  end
+
+  def success?
+    @res && @res.code == '200'
+  end
+
+  def priorities
+    @priorities ||= @response
+      .dig('plugins', 'available_on_server')
+      .each_with_object({}) { |(k, v), hash| hash[k] = v['priority'] }
+      .sort_by { |k, v| -v }
+      .to_h
+  end
+
+  def write_to_file(priorities)
+    File.write(file_path, JSON.pretty_generate(priorities))
+  end
+
+  def file_path
+    "#{@options[:destination]}/priorities/#{@options[:type]}/#{@options[:version]}.json"
+  end
+
+  def create_folders
+    FileUtils.mkdir_p("#{@options[:destination]}/priorities/ee")
+    FileUtils.mkdir_p("#{@options[:destination]}/priorities/oss")
+  end
+end

--- a/plugins
+++ b/plugins
@@ -4,6 +4,7 @@ require_relative 'lib/schema_downloader'
 require_relative 'lib/example_validator'
 require_relative 'lib/example_copier'
 require_relative 'lib/referenceable_fields'
+require_relative 'lib/plugin_priorities'
 
 class Plugins < Thor
   class_option :verbose, :type => :boolean
@@ -67,6 +68,21 @@ class Plugins < Thor
     puts 'Finding referenceable fields...'
 
     ReferenceableFields.run!(plugins: options[:plugins], options: options)
+
+    puts 'Done!'
+  end
+
+  desc 'generate_plugin_priorities', 'Generates a json object listing all the plugins and their corresponding priorities'
+  option :version,     aliases: '-v',    type: :string,    required: true,       desc: 'Kong Version'
+  option :plugins,     aliases: '-p',    type: :array,     required: true,       desc: 'List containing the name of the plugins'
+  option :host,        aliases: '-d',    type: :string,    default: 'localhost', desc: 'Hostname of the server running the API.'
+  option :port,        aliases: '-h',    type: :numeric,   default: 8001,        desc: 'Port number'
+  option :type,        aliases: '-t',    enum: %w(oss ee), required: true,       desc: 'Specify whether the API running is the OSS or Enterprise version'
+  option :destination, aliases: '-dest', type: :string,    default: './data',    desc: 'Destination folder where the json object containing the plugins and their priorities will be written'
+  def generate_plugin_priorities
+    puts 'Listing plugins and their priorities...'
+
+    PluginPriorities.run!(plugins: options[:plugins], options: options)
 
     puts 'Done!'
   end


### PR DESCRIPTION
Add a command that generates the plugins' priorities so we can build the [plugin-priority table](https://github.com/Kong/docs.konghq.com/blob/main/app/_includes/md/plugin-priority.md) from source

TODO: Generate the files for all the versions and `ee`/`oss`