### PR TITLE
chore: Generate schemas for 3.6.1

### DIFF
--- a/schemas/ldap-auth-advanced/3.6.x.json
+++ b/schemas/ldap-auth-advanced/3.6.x.json
@@ -22,6 +22,7 @@
           "wss"
         ],
         "elements": {
+          "type": "string",
           "one_of": [
             "grpc",
             "grpcs",
@@ -29,37 +30,35 @@
             "https",
             "ws",
             "wss"
-          ],
-          "type": "string"
+          ]
         }
       }
     },
     {
       "consumer_group": {
-        "reference": "consumer_groups",
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
         "description": "Custom type for representing a foreign key with a null value allowed."
       }
     },
     {
       "consumer": {
-        "reference": "consumers",
         "type": "foreign",
-        "eq": null,
-        "description": "Custom type for representing a foreign key with a null value allowed."
+        "reference": "consumers",
+        "description": "Custom type for representing a foreign key with a null value allowed.",
+        "eq": null
       }
     },
     {
       "config": {
-        "required": true,
         "type": "record",
         "fields": [
           {
             "ldap_host": {
-              "required": true,
+              "description": "Host on which the LDAP server is running.",
               "type": "string",
-              "description": "Host on which the LDAP server is running."
+              "required": true
             }
           },
           {
@@ -72,9 +71,9 @@
           },
           {
             "ldap_port": {
+              "description": "TCP port where the LDAP server is listening. 389 is the default port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is configured, you must use port 636.",
               "type": "number",
-              "default": 389,
-              "description": "TCP port where the LDAP server is listening. 389 is the default port for non-SSL LDAP and AD. 636 is the port required for SSL LDAP and AD. If `ldaps` is configured, you must use port 636."
+              "default": 389
             }
           },
           {
@@ -86,110 +85,110 @@
           },
           {
             "ldaps": {
-              "required": true,
+              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled.",
               "type": "boolean",
               "default": false,
-              "description": "Set it to `true` to use `ldaps`, a secure protocol (that can be configured to TLS) to connect to the LDAP server. When `ldaps` is configured, you must use port 636. If the `ldap` setting is enabled, ensure the `start_tls` setting is disabled."
+              "required": true
             }
           },
           {
             "start_tls": {
-              "required": true,
+              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled.",
               "type": "boolean",
               "default": false,
-              "description": "Set it to `true` to issue StartTLS (Transport Layer Security) extended operation over `ldap` connection. If the `start_tls` setting is enabled, ensure the `ldaps` setting is disabled."
+              "required": true
             }
           },
           {
             "verify_ldap_host": {
-              "required": true,
+              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive.",
               "type": "boolean",
               "default": false,
-              "description": "Set to `true` to authenticate LDAP server. The server certificate will be verified according to the CA certificates specified by the `lua_ssl_trusted_certificate` directive."
+              "required": true
             }
           },
           {
             "base_dn": {
-              "required": true,
+              "description": "Base DN as the starting point for the search; e.g., 'dc=example,dc=com'.",
               "type": "string",
-              "description": "Base DN as the starting point for the search; e.g., 'dc=example,dc=com'."
+              "required": true
             }
           },
           {
             "attribute": {
-              "required": true,
+              "description": "Attribute to be used to search the user; e.g., \"cn\".",
               "type": "string",
-              "description": "Attribute to be used to search the user; e.g., \"cn\"."
+              "required": true
             }
           },
           {
             "cache_ttl": {
-              "required": true,
+              "description": "Cache expiry time in seconds.",
               "type": "number",
               "default": 60,
-              "description": "Cache expiry time in seconds."
+              "required": true
             }
           },
           {
             "hide_credentials": {
+              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request.",
               "type": "boolean",
-              "default": false,
-              "description": "An optional boolean value telling the plugin to hide the credential to the upstream server. It will be removed by Kong before proxying the request."
+              "default": false
             }
           },
           {
             "timeout": {
+              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server.",
               "type": "number",
-              "default": 10000,
-              "description": "An optional timeout in milliseconds when waiting for connection with LDAP server."
+              "default": 10000
             }
           },
           {
             "keepalive": {
+              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed.",
               "type": "number",
-              "default": 60000,
-              "description": "An optional value in milliseconds that defines how long an idle connection to LDAP server will live before being closed."
+              "default": 60000
             }
           },
           {
             "anonymous": {
-              "default": "",
+              "len_min": 0,
               "type": "string",
-              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`.",
-              "len_min": 0
+              "default": "",
+              "description": "An optional string (consumer UUID or username) value to use as an “anonymous” consumer if authentication fails. If empty (default null), the request will fail with an authentication failure `4xx`. Note that this value must refer to the consumer `id` or `username` attribute, and **not** its `custom_id`."
             }
           },
           {
             "header_type": {
+              "description": "An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to \"basic\", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `'ldap'` and `'basic'`.",
               "type": "string",
-              "default": "ldap",
-              "description": "An optional string to use as part of the Authorization header. By default, a valid Authorization header looks like this: `Authorization: ldap base64(username:password)`. If `header_type` is set to \"basic\", then the Authorization header would be `Authorization: basic base64(username:password)`. Note that `header_type` can take any string, not just `'ldap'` and `'basic'`."
+              "default": "ldap"
             }
           },
           {
             "consumer_optional": {
-              "required": false,
+              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user.",
               "type": "boolean",
               "default": false,
-              "description": "Whether consumer mapping is optional. If `consumer_optional=true`, the plugin will not attempt to associate a consumer with the LDAP authenticated user."
+              "required": false
             }
           },
           {
             "consumer_by": {
-              "elements": {
-                "one_of": [
-                  "username",
-                  "custom_id"
-                ],
-                "type": "string"
-              },
               "type": "array",
+              "required": false,
+              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both.",
               "default": [
                 "username",
                 "custom_id"
               ],
-              "required": false,
-              "description": "Whether to authenticate consumers based on `username`, `custom_id`, or both."
+              "elements": {
+                "type": "string",
+                "one_of": [
+                  "username",
+                  "custom_id"
+                ]
+              }
             }
           },
           {
@@ -206,30 +205,31 @@
           },
           {
             "group_member_attribute": {
+              "description": "Sets the attribute holding the members of the LDAP group. This field is case-sensitive.",
               "type": "string",
-              "default": "memberOf",
-              "description": "Sets the attribute holding the members of the LDAP group. This field is case-sensitive."
+              "default": "memberOf"
             }
           },
           {
             "log_search_results": {
-              "required": false,
+              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment.",
               "type": "boolean",
               "default": false,
-              "description": "Displays all the LDAP search results received from the LDAP server for debugging purposes. Not recommended to be enabled in a production environment."
+              "required": false
             }
           },
           {
             "groups_required": {
-              "required": false,
-              "type": "array",
               "description": "The groups required to be present in the LDAP search result for successful authorization. This config parameter works in both **AND** / **OR** cases. - When `[\"group1 group2\"]` are in the same array indices, both `group1` AND `group2` need to be present in the LDAP search result. - When `[\"group1\", \"group2\"]` are in different array indices, either `group1` OR `group2` need to be present in the LDAP search result.",
+              "type": "array",
+              "required": false,
               "elements": {
                 "type": "string"
               }
             }
           }
-        ]
+        ],
+        "required": true
       }
     }
   ]

--- a/schemas/opentelemetry/3.6.x.json
+++ b/schemas/opentelemetry/3.6.x.json
@@ -5,30 +5,30 @@
   "fields": [
     {
       "protocols": {
-        "elements": {
-          "one_of": [
-            "grpc",
-            "grpcs",
-            "http",
-            "https"
-          ],
-          "type": "string"
-        },
         "type": "set",
+        "required": true,
+        "description": "A set of strings representing HTTP protocols.",
         "default": [
           "grpc",
           "grpcs",
           "http",
           "https"
         ],
-        "required": true,
-        "description": "A set of strings representing HTTP protocols."
+        "elements": {
+          "type": "string",
+          "one_of": [
+            "grpc",
+            "grpcs",
+            "http",
+            "https"
+          ]
+        }
       }
     },
     {
       "consumer_group": {
-        "reference": "consumer_groups",
         "type": "foreign",
+        "reference": "consumer_groups",
         "eq": null,
         "description": "Custom type for representing a foreign key with a null value allowed."
       }
@@ -57,12 +57,12 @@
           },
           {
             "headers": {
+              "description": "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend.",
+              "type": "map",
               "keys": {
                 "description": "A string representing an HTTP header name.",
                 "type": "string"
               },
-              "type": "map",
-              "description": "The custom headers to be added in the HTTP request sent to the OTLP server. This setting is useful for adding the authentication headers (token) for the APM backend.",
               "values": {
                 "referenceable": true,
                 "type": "string"
@@ -71,27 +71,29 @@
           },
           {
             "resource_attributes": {
-              "keys": {
-                "required": true,
-                "type": "string"
-              },
               "type": "map",
+              "keys": {
+                "type": "string",
+                "required": true
+              },
               "values": {
-                "required": true,
-                "type": "string"
+                "type": "string",
+                "required": true
               }
             }
           },
           {
             "queue": {
-              "required": true,
+              "default": {
+                "max_batch_size": 200
+              },
               "type": "record",
               "fields": [
                 {
                   "max_batch_size": {
-                    "default": 1,
-                    "type": "integer",
                     "description": "Maximum number of entries that can be processed at a time.",
+                    "type": "integer",
+                    "default": 1,
                     "between": [
                       1,
                       1000000
@@ -100,9 +102,9 @@
                 },
                 {
                   "max_coalescing_delay": {
-                    "default": 1,
-                    "type": "number",
                     "description": "Maximum number of (fractional) seconds to elapse after the first entry was queued before the queue starts calling the handler.",
+                    "type": "number",
+                    "default": 1,
                     "between": [
                       0,
                       3600
@@ -111,9 +113,9 @@
                 },
                 {
                   "max_entries": {
-                    "default": 10000,
-                    "type": "integer",
                     "description": "Maximum number of entries that can be waiting on the queue.",
+                    "type": "integer",
+                    "default": 10000,
                     "between": [
                       1,
                       1000000
@@ -128,16 +130,16 @@
                 },
                 {
                   "max_retry_time": {
+                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch.",
                     "type": "number",
-                    "default": 60,
-                    "description": "Time in seconds before the queue gives up calling a failed handler for a batch."
+                    "default": 60
                   }
                 },
                 {
                   "initial_retry_delay": {
-                    "default": 0.01,
-                    "type": "number",
                     "description": "Time in seconds before the initial retry is made for a failing batch.",
+                    "type": "number",
+                    "default": 0.01,
                     "between": [
                       0.001,
                       1000000
@@ -146,16 +148,17 @@
                 },
                 {
                   "max_retry_delay": {
-                    "default": 60,
-                    "type": "number",
                     "description": "Maximum time in seconds between retries, caps exponential backoff.",
+                    "type": "number",
+                    "default": 60,
                     "between": [
                       0.001,
                       1000000
                     ]
                   }
                 }
-              ]
+              ],
+              "required": true
             }
           },
           {
@@ -172,9 +175,9 @@
           },
           {
             "connect_timeout": {
-              "default": 1000,
-              "type": "integer",
               "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
+              "default": 1000,
               "between": [
                 0,
                 2147483646
@@ -183,9 +186,9 @@
           },
           {
             "send_timeout": {
-              "default": 5000,
-              "type": "integer",
               "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
+              "default": 5000,
               "between": [
                 0,
                 2147483646
@@ -194,9 +197,9 @@
           },
           {
             "read_timeout": {
-              "default": 5000,
-              "type": "integer",
               "description": "An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2.",
+              "type": "integer",
+              "default": 5000,
               "between": [
                 0,
                 2147483646
@@ -210,9 +213,6 @@
           },
           {
             "header_type": {
-              "required": false,
-              "type": "string",
-              "default": "preserve",
               "one_of": [
                 "preserve",
                 "ignore",
@@ -224,14 +224,17 @@
                 "aws",
                 "gcp",
                 "datadog"
-              ]
+              ],
+              "type": "string",
+              "default": "preserve",
+              "required": false
             }
           },
           {
             "sampling_rate": {
-              "required": false,
-              "type": "number",
               "description": "Tracing sampling rate for configuring the probability-based sampler. When set, this value supersedes the global `tracing_sampling_rate` setting from kong.conf.",
+              "type": "number",
+              "required": false,
               "between": [
                 0,
                 1


### PR DESCRIPTION
Upcoming 3.6.1 and 3.6.1.0 patches have changes to the Opentelemetry and LDAP auth adv plugins.

 I don't _think_ there's actually a schema change for ldap auth adv, but doesn't hurt to generate it (hard to tell with the way the fields move around).