### PR TITLE
Chore: Placeholder schemas and examples for new AI plugins in 3.7

### DIFF
--- a/examples/ai-azure-content-safety/_3.7.x.yaml
+++ b/examples/ai-azure-content-safety/_3.7.x.yaml
@@ -1,0 +1,9 @@
+name: ai-azure-content-safety
+config:
+  content_safety_url: http//<host>:<port>
+  azure_use_managed_identity: false
+  reveal_failure_reason: true
+  content_safety_key: anything
+  categories:
+    - "Hate"
+    - "Violence"

--- a/examples/ai-rate-limiting-advanced/_3.7.x.yaml
+++ b/examples/ai-rate-limiting-advanced/_3.7.x.yaml
@@ -1,0 +1,12 @@
+name: ai-rate-limiting-advanced
+config:
+  model_providers:
+    - openai
+    - mistral
+  model_providers_limit: 
+    - 1000
+    - 100
+  models_providers_window_size:
+    - 3600
+    - 60
+  sync_rate: 10

--- a/schemas/ai-azure-content-safety/3.7.x.json
+++ b/schemas/ai-azure-content-safety/3.7.x.json
@@ -1,0 +1,80 @@
+{
+  "fields": [
+    {
+      "protocols": {
+        "type": "set",
+        "elements": {
+          "type": "string",
+          "one_of": [
+            "grpc",
+            "grpcs",
+            "http",
+            "https"
+          ]
+        },
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
+        "required": true,
+        "description": "A set of strings representing HTTP protocols."
+      }
+    },
+    {
+      "config": {
+        "type": "record",
+        "fields": [
+          {
+            "allow_patterns": {
+              "type": "array",
+              "elements": {
+                "len_max": 50,
+                "type": "string",
+                "len_min": 1
+              },
+              "default": [
+
+              ],
+              "description": "Array of valid patterns, or valid questions from the 'user' role in chat.",
+              "len_max": 10
+            }
+          },
+          {
+            "deny_patterns": {
+              "type": "array",
+              "elements": {
+                "len_max": 50,
+                "type": "string",
+                "len_min": 1
+              },
+              "default": [
+
+              ],
+              "description": "Array of invalid patterns, or invalid questions from the 'user' role in chat.",
+              "len_max": 10
+            }
+          },
+          {
+            "allow_all_conversation_history": {
+              "type": "boolean",
+              "description": "If true, will ignore all previous chat prompts from the conversation history.",
+              "default": false,
+              "required": true
+            }
+          }
+        ],
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.allow_patterns",
+        "config.deny_patterns"
+      ]
+    }
+  ]
+}

--- a/schemas/ai-rate-limiting-advanced/3.7.x.json
+++ b/schemas/ai-rate-limiting-advanced/3.7.x.json
@@ -1,0 +1,80 @@
+{
+  "fields": [
+    {
+      "protocols": {
+        "type": "set",
+        "elements": {
+          "type": "string",
+          "one_of": [
+            "grpc",
+            "grpcs",
+            "http",
+            "https"
+          ]
+        },
+        "default": [
+          "grpc",
+          "grpcs",
+          "http",
+          "https"
+        ],
+        "required": true,
+        "description": "A set of strings representing HTTP protocols."
+      }
+    },
+    {
+      "config": {
+        "type": "record",
+        "fields": [
+          {
+            "allow_patterns": {
+              "type": "array",
+              "elements": {
+                "len_max": 50,
+                "type": "string",
+                "len_min": 1
+              },
+              "default": [
+
+              ],
+              "description": "Array of valid patterns, or valid questions from the 'user' role in chat.",
+              "len_max": 10
+            }
+          },
+          {
+            "deny_patterns": {
+              "type": "array",
+              "elements": {
+                "len_max": 50,
+                "type": "string",
+                "len_min": 1
+              },
+              "default": [
+
+              ],
+              "description": "Array of invalid patterns, or invalid questions from the 'user' role in chat.",
+              "len_max": 10
+            }
+          },
+          {
+            "allow_all_conversation_history": {
+              "type": "boolean",
+              "description": "If true, will ignore all previous chat prompts from the conversation history.",
+              "default": false,
+              "required": true
+            }
+          }
+        ],
+        "required": true
+      }
+    }
+  ],
+  "entity_checks": [
+    {
+      "at_least_one_of": [
+        "config.allow_patterns",
+        "config.deny_patterns"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We have a [docs PR open](https://github.com/Kong/docs.konghq.com/pull/7214) for the AI Rate Limiting Advanced plugin, which is not yet merged into 3.7. We'll also have an Azure Content Safety plugin coming soon.

Generating some placeholder content for the schemas, which we will replace when we run the toolkit against the RC for 3.7, and making my best guesses at the examples.