### PR TITLE
Add a github action that dispatches an event when `main` is updated

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,17 @@
+name: Sync submodule in docs
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  sync-repo:
+    name: Sync submodule in docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: Kong/docs.konghq.com
+          event-type: PLUGINS_UPDATED


### PR DESCRIPTION
Dispatch an event to the docs repo so that it updates the submodule when `main` is updated.

I need to add the secret and update [this action](https://github.com/Kong/docs.konghq.com/blob/main/.github/workflows/sync-submodules.yml#L2)  to listen to the event so that it triggers the workflow and updates the submodule

Related https://github.com/Kong/docs.konghq.com/pull/7262