### PR TITLE
[DOCU-3785] Add command that downloads the JWT Credential schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ For example, running:
 ```
 generates a file `./data/priorities/ee/3.4.x.json` containing a list of plugins and their corresponded priorities order by priority (desc).
 
+### Generate JWT Credential Schema
+
+| Options | Descriptions  |
+|--------------------------- |-----|
+| `version` | **Required**. Kong Gateway release version, e.g. `3.3.x`. |
+| `host`    | Name of the host in which the API is running. Default: `localhost`.  |
+| `port`    | Port in which the API is listening. Default: `8001`. |
+| `destination` | Path to the root folder in which the file will be stored. Default: `./data`  |
+
+For example, running:
+```bash
+./plugins generate_jwt_credential --version 3.4.x
+```
+generates a file `./data/jwt_credential/3.4.x.json` containing the schema of a JWT credential.
+
 ## Updating the repo after a new release
 
 Whenever a new version of Kong Gateway is released, we need run the following commands in order. For all of them, specify all the plugins `--plugins $(ls ./schemas)`
@@ -122,3 +137,4 @@ Whenever a new version of Kong Gateway is released, we need run the following co
 1. Validate Examples  - specify the new version `_x.x.x`
 1. Generate Referenceable Fields List - specify the new version `x.x.x`
 1. Generate Priorities List - for `oss` and `ee` and specify the new version `x.x.x`
+1. Generate JWT Credential Schema - specify the new version `x.x.x`

--- a/data/jwt_credential/3.6.x.json
+++ b/data/jwt_credential/3.6.x.json
@@ -1,0 +1,94 @@
+{
+  "entity_checks": [
+    {
+      "conditional": {
+        "if_field": "algorithm",
+        "then_field": "rsa_public_key",
+        "if_match": {
+          "match_any": {
+            "patterns": [
+              "^RS256$",
+              "^RS384$",
+              "^RS512$"
+            ]
+          }
+        },
+        "then_match": {
+          "required": true
+        }
+      }
+    }
+  ],
+  "fields": [
+    {
+      "id": {
+        "type": "string",
+        "auto": true,
+        "description": "A string representing a UUID (universally unique identifier).",
+        "uuid": true
+      }
+    },
+    {
+      "created_at": {
+        "type": "integer",
+        "auto": true,
+        "description": "An integer representing an automatic Unix timestamp in seconds.",
+        "timestamp": true
+      }
+    },
+    {
+      "consumer": {
+        "required": true,
+        "reference": "consumers",
+        "on_delete": "cascade",
+        "type": "foreign"
+      }
+    },
+    {
+      "key": {
+        "required": false,
+        "auto": true,
+        "type": "string",
+        "unique": true
+      }
+    },
+    {
+      "secret": {
+        "type": "string",
+        "auto": true
+      }
+    },
+    {
+      "rsa_public_key": {
+        "type": "string"
+      }
+    },
+    {
+      "algorithm": {
+        "type": "string",
+        "default": "HS256",
+        "one_of": [
+          "HS256",
+          "HS384",
+          "HS512",
+          "RS256",
+          "RS384",
+          "RS512",
+          "ES256",
+          "ES384"
+        ]
+      }
+    },
+    {
+      "tags": {
+        "type": "set",
+        "description": "A set of strings representing tags.",
+        "elements": {
+          "type": "string",
+          "description": "A string representing a tag.",
+          "required": true
+        }
+      }
+    }
+  ]
+}

--- a/lib/api/client.rb
+++ b/lib/api/client.rb
@@ -38,5 +38,15 @@ module API
         puts e.message
       end
     end
+
+    def jwt_credential_schema
+      begin
+        Net::HTTP.get_response(
+          URI("#{@base_url}/schemas/jwt_secrets")
+        )
+      rescue Errno::ECONNREFUSED => e
+        puts e.message
+      end
+    end
   end
 end

--- a/lib/jwt_credential.rb
+++ b/lib/jwt_credential.rb
@@ -1,0 +1,55 @@
+require 'json'
+require 'fileutils'
+require_relative 'api/client'
+
+class JWTCredential
+  def self.run!(options:)
+    new(options:).run!
+  end
+
+  def initialize(options:)
+    @options = options
+    @client  = API::Client.new(host: @options[:host], port: @options[:port])
+  end
+
+  def run!
+    create_folder
+
+    @res = @client.jwt_credential_schema
+
+    process_response
+  end
+
+  private
+
+  def process_response
+    if success?
+      @response = JSON.parse(@res.body)
+
+      if @options['verbose']
+        puts 'JWT Credential schema'
+        puts JSON.pretty_generate(@response)
+      else
+        puts "#{success? ? '✅' : '❌'}"
+      end
+
+      write_to_file(@response)
+    end
+  end
+
+  def success?
+    @res && @res.code == '200'
+  end
+
+  def create_folder
+    FileUtils.mkdir_p("#{@options[:destination]}/jwt_credential")
+  end
+
+  def write_to_file(jwt_credential)
+    File.write(file_path, JSON.pretty_generate(jwt_credential))
+  end
+
+  def file_path
+    "#{@options[:destination]}/jwt_credential/#{@options[:version]}.json"
+  end
+end

--- a/plugins
+++ b/plugins
@@ -5,6 +5,7 @@ require_relative 'lib/example_validator'
 require_relative 'lib/example_copier'
 require_relative 'lib/referenceable_fields'
 require_relative 'lib/plugin_priorities'
+require_relative 'lib/jwt_credential'
 
 class Plugins < Thor
   class_option :verbose, :type => :boolean
@@ -82,6 +83,19 @@ class Plugins < Thor
     puts 'Listing plugins and their priorities...'
 
     PluginPriorities.run!(options: options)
+
+    puts 'Done!'
+  end
+
+  desc 'generate_jwt_credential', 'Generates a json object representing the schema of a jwt credential'
+  option :version,     aliases: '-v',    type: :string,  required: true,       desc: 'Kong Version'
+  option :host,        aliases: '-d',    type: :string,  default: 'localhost', desc: 'Hostname of the server running the API.'
+  option :port,        aliases: '-h',    type: :numeric, default: 8001,        desc: 'Port number'
+  option :destination, aliases: '-dest', type: :string,  default: './data',    desc: 'Destination folder where the json object containing the plugins and their priorities will be written'
+  def generate_jwt_credential
+    puts 'Downloading jwt credential schema...'
+
+    JWTCredential.run!(options: options)
 
     puts 'Done!'
   end


### PR DESCRIPTION
Download the JWT Credential schema using  the `/schemas/jwt_secrets/` endpoint.
Now we can generate the table containing the schema ([here](https://docs.konghq.com/hub/kong-inc/jwt/#create-a-jwt-credential)) from source.

**TODO:** Generate the schema for every version.