### PR TITLE
Add action that runs download_schemas

### DIFF
--- a/.github/reusable-steps/cleanup/action.yml
+++ b/.github/reusable-steps/cleanup/action.yml
@@ -1,0 +1,8 @@
+name: Run Quickstart cleanup
+description: Runs ./quickstart.sh -d
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        ./quickstart.sh -d

--- a/.github/reusable-steps/download-quickstart-script/action.yml
+++ b/.github/reusable-steps/download-quickstart-script/action.yml
@@ -1,0 +1,10 @@
+name: Download Quickstart script
+description: Downloads https://get.konghq.com/quickstart
+runs:
+  using: composite
+  steps:
+    - name: Donwload script
+      shell: bash
+      run: |
+        curl -Ls get.konghq.com/quickstart -o quickstart.sh
+        chmod +x quickstart.sh

--- a/.github/reusable-steps/install-deps/action.yml
+++ b/.github/reusable-steps/install-deps/action.yml
@@ -1,0 +1,10 @@
+name: Install deps
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      shell: bash
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true

--- a/.github/reusable-steps/run-kong-ee/action.yml
+++ b/.github/reusable-steps/run-kong-ee/action.yml
@@ -1,0 +1,33 @@
+name: Run Kong EE
+inputs:
+  op-token:
+    required: true
+  kong-image-tag:
+    required: true
+    description: |
+      Kong Docker image tag to run, 3.6.1.4.
+  kong-image-name:
+    description: |
+      Kong Docker image name to use, e.g. kong-gateway, kong-gateway-dev.
+
+runs:
+  using: composite
+  steps:
+    - name: Download quickstart script
+      shell: bash
+      uses: ./.github/reusable-steps/download-quickstart-script
+    - name: Download Kong License
+      shell: bash
+      uses: Kong/kong-license@master
+      id: getLicense
+      with:
+        op-token: ${{ inputs.op-token }}
+    - name: Run Kong
+      shell: bash
+      env:
+        KONG_PLUGINS: 'bundled,app-dynamics'
+        KONG_LICENSE_DATA: ${{ steps.getLicense.outputs.license }}
+        KONG_IMAGE_TAG: ${{ inputs.kong-image-tag }}
+        KONG_IMAGE_NAME: ${{ inputs.kong-image-name }}
+      run: |
+        ./quickstart.sh -e "KONG_LICENSE_DATA" -e "KONG_PLUGINS" -e "KONG_IMAGE_TAG" -e "KONG_IMAGE_NAME"

--- a/.github/reusable-steps/run-kong-oss/action.yml
+++ b/.github/reusable-steps/run-kong-oss/action.yml
@@ -1,0 +1,21 @@
+name: Run Kong OSS
+inputs:
+  kong-image-tag:
+    required: true
+    description: |
+      Kong Docker image tag to run, 3.6.1.
+
+runs:
+  using: composite
+  steps:
+    - name: Download quickstart script
+      shell: bash
+      uses: ./.github/reusable-steps/download-quickstart-script
+    - name: Run Kong
+      shell: bash
+      env:
+        KONG_PLUGINS: 'bundled'
+        KONG_IMAGE_TAG: ${{ inputs.kong-image-tag }}
+        KONG_IMAGE_NAME: 'kong'
+      run: |
+        ./quickstart.sh  -e "KONG_PLUGINS" -e "KONG_IMAGE_TAG" -e "KONG_IMAGE_NAME"

--- a/.github/workflows/download-schemas.yml
+++ b/.github/workflows/download-schemas.yml
@@ -1,0 +1,53 @@
+name: Download Schemas
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-tag:
+        required: true
+        type: string
+        description: |
+          Kong Docker image tag to run, 3.6.1.4.
+      version:
+        required: true
+        type: string
+        description: |
+          Kong Gateway release, e.x. 3.4.x.
+          Used by some commands for storing files in the corresponding folder.
+      kong-image-name:
+        type: choice
+        description: |
+          Kong Docker image name to use, e.g. kong-gateway, kong-gateway-dev.
+        options:
+          - kong-gateway
+          - kong-gateway-dev
+
+jobs:
+  download-schemas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/reusable-steps/install-deps
+      - name: Run Kong EE
+        uses: ./.github/reusable-steps/run-kong-ee
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+          kong-image-name: ${{ github.event.inputs.kong-image-name }}
+      - name: Run download_schemas
+        run: |
+          bundle exec ./plugins download_schemas --version=${{ github.event.inputs.version }} --plugins $(ls ./schemas) --verbose
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        token: ${{ secrets.PAT }}
+        title: "Download Schemas for ${{ github.event.inputs.version }}"
+        branch: download-schemas
+        commit-message: "Download Schemas for ${{ github.event.inputs.version }}"
+        delete-branch: true
+        with:
+          add-paths: |
+            ./schemas/*
+      - name: Cleanup
+        if: always()
+        uses: ./.github/reusable-steps/cleanup

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'thor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    thor (1.3.1)
+
+PLATFORMS
+  arm64-darwin-23
+  ruby
+
+DEPENDENCIES
+  thor
+
+BUNDLED WITH
+   2.5.9


### PR DESCRIPTION
Github Action that runs `download_schemas`
It takes the following params:
* kong-image-tag: Kong Docker image tag to run, e.g. `3.6.1.4`.
* kong-image-name: Kong Docker image name to use as `enum`, e.g. `kong-gateway`, `kong-gateway-dev`.
* version:  Kong Gateway release, used by the command to store the schemas under that name, e.g. `3.6.x`.

The action  executes the following steps.
* installs kong using the quickstart script, using the image name + tag provided
* installs the repo's dependencies
* runs the `donwload_schemas` command 
* creates a PR with the changes
* runs quickstart -d. Destroy containers, volumes, etc. 