### PR TITLE
Fix composite action steps

### DIFF
--- a/.github/reusable-steps/install-deps/action.yml
+++ b/.github/reusable-steps/install-deps/action.yml
@@ -3,7 +3,6 @@ runs:
   using: composite
   steps:
     - name: Set up Ruby
-      shell: bash
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: .ruby-version

--- a/.github/reusable-steps/run-kong-ee/action.yml
+++ b/.github/reusable-steps/run-kong-ee/action.yml
@@ -14,10 +14,8 @@ runs:
   using: composite
   steps:
     - name: Download quickstart script
-      shell: bash
       uses: ./.github/reusable-steps/download-quickstart-script
     - name: Download Kong License
-      shell: bash
       uses: Kong/kong-license@master
       id: getLicense
       with:

--- a/.github/reusable-steps/run-kong-oss/action.yml
+++ b/.github/reusable-steps/run-kong-oss/action.yml
@@ -9,7 +9,6 @@ runs:
   using: composite
   steps:
     - name: Download quickstart script
-      shell: bash
       uses: ./.github/reusable-steps/download-quickstart-script
     - name: Run Kong
       shell: bash


### PR DESCRIPTION
    If a step in a composite action has the key `uses` it shouldn't have the `shell` key,
    otherwise it errors. Steps that don't have the `uses` key, must have the
    `shell` key.