### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/copy-examples.yml
+++ b/.github/workflows/copy-examples.yml
@@ -1,0 +1,32 @@
+name: Copy Latest Examples
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: |
+          Kong Gateway release, e.x. 3.4.x.
+          Used by some commands for storing files in the corresponding folder.
+
+jobs:
+  copy-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/reusable-steps/install-deps
+      - name: Run copy_examples
+        run: |
+          bundle exec ./plugins copy_examples --version=${{ github.event.inputs.version }} --plugins $(ls ./schemas) --verbose
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PAT }}
+          title: "Copy latest examples to ${{ github.event.inputs.version }}"
+          branch: copy-latest-examples
+          commit-message: "Copy latest examples to ${{ github.event.inputs.version }}"
+          delete-branch: true
+          add-paths: |
+            ./examples/*

--- a/.github/workflows/copy-schemas.yml
+++ b/.github/workflows/copy-schemas.yml
@@ -1,0 +1,32 @@
+name: Copy Latest Schemas
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: |
+          Kong Gateway release, e.x. 3.4.x.
+          Used by some commands for storing files in the corresponding folder.
+
+jobs:
+  copy-schemas:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/reusable-steps/install-deps
+      - name: Run copy_schemas
+        run: |
+          bundle exec ./plugins copy_schemas --version=${{ github.event.inputs.version }} --plugins $(ls ./schemas) --verbose
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PAT }}
+          title: "Copy latest schemas to ${{ github.event.inputs.version }}"
+          branch: copy-latest-schemas
+          commit-message: "Copy latest schemas to ${{ github.event.inputs.version }}"
+          delete-branch: true
+          add-paths: |
+            ./schemas/*

--- a/.github/workflows/generate-plugin-priorities.yml
+++ b/.github/workflows/generate-plugin-priorities.yml
@@ -1,0 +1,58 @@
+name: Generate Plugin Priorities
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-tag:
+        required: true
+        type: string
+        description: |
+          Kong Docker image tag to run, 3.6.1.4.
+      version:
+        required: true
+        type: string
+        description: |
+          Kong Gateway release, e.x. 3.4.x.
+          Used by some commands for storing files in the corresponding folder.
+      kong-edition:
+        required: true
+        type: choice
+        options:
+          - oss
+          - ee
+        description: Whether the API running is the OSS or Enterprise version
+
+jobs:
+  generate-plugin-priorities:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/reusable-steps/install-deps
+      - name: Run Kong EE
+        if: ${{ github.event.inputs.kong-edition == 'ee' }}
+        uses: ./.github/reusable-steps/run-kong-ee
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+      - name: Run Kong OSS
+        if: ${{ github.event.inputs.kong-edition == 'oss' }}
+        uses: ./.github/reusable-steps/run-kong-oss
+        with:
+          kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+      - name: Run generate_plugin_priorities
+        run: |
+          bundle exec ./plugins generate_plugin_priorities --type=${{ github.event.inputs.kong-edition }} --version=${{ github.event.inputs.version }} --verbose
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PAT }}
+          title: "Plugin Priorities for ${{ github.event.inputs.version }}"
+          branch: plugin-priorities
+          commit-message: "Plugin Priorities for ${{ github.event.inputs.version }}"
+          delete-branch: true
+          add-paths: |
+            ./data/priorities/*
+      - name: Cleanup
+        if: always()
+        uses: ./.github/reusable-steps/cleanup

--- a/.github/workflows/generate-referenceable-fields.yml
+++ b/.github/workflows/generate-referenceable-fields.yml
@@ -1,0 +1,53 @@
+name: Generate Referenceable Fields
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-tag:
+        required: true
+        type: string
+        description: |
+          Kong Docker image tag to run, 3.6.1.4.
+      version:
+        required: true
+        type: string
+        description: |
+          Kong Gateway release, e.x. 3.4.x.
+          Used by some commands for storing files in the corresponding folder.
+      kong-image-name:
+        type: choice
+        description: |
+          Kong Docker image name to use, e.g. kong-gateway, kong-gateway-dev.
+        options:
+          - kong-gateway
+          - kong-gateway-dev
+
+jobs:
+  generate-referenceable-fields:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/reusable-steps/install-deps
+      - name: Run Kong EE
+        uses: ./.github/reusable-steps/run-kong-ee
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+          kong-image-name: ${{ github.event.inputs.kong-image-name }}
+      - name: Run generate_referenceable_fields_list
+        run: |
+          bundle exec ./plugins generate_referenceable_fields_list --version=${{ github.event.inputs.version }} --plugins $(ls ./schemas) --verbose
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PAT }}
+          title: "Referenceable fields for ${{ github.event.inputs.version }}"
+          branch: referenceable-fields
+          commit-message: "Referenceable fields for ${{ github.event.inputs.version }}"
+          delete-branch: true
+          add-paths: |
+            ./data/referenceable_fields/*
+      - name: Cleanup
+        if: always()
+        uses: ./.github/reusable-steps/cleanup

--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -1,0 +1,43 @@
+name: Validate Examples
+on:
+  workflow_dispatch:
+    inputs:
+      kong-image-tag:
+        required: true
+        type: string
+        description: |
+          Kong Docker image tag to run, 3.6.1.4.
+      version:
+        required: true
+        type: string
+        description: |
+          Kong Gateway release, e.x. 3.4.x.
+          Used by some commands for storing files in the corresponding folder.
+      kong-image-name:
+        type: choice
+        description: |
+          Kong Docker image name to use, e.g. kong-gateway, kong-gateway-dev.
+        options:
+          - kong-gateway
+          - kong-gateway-dev
+
+jobs:
+  validate-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        uses: ./.github/reusable-steps/install-deps
+      - name: Run Kong EE
+        uses: ./.github/reusable-steps/run-kong-ee
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          kong-image-tag: ${{ github.event.inputs.kong-image-tag }}
+          kong-image-name: ${{ github.event.inputs.kong-image-name }}
+      - name: Run validate_examples
+        run: |
+          bundle exec ./plugins validate_examples --version=${{ github.event.inputs.version }} --plugins $(ls ./schemas) --verbose
+      - name: Cleanup
+        if: always()
+        uses: ./.github/reusable-steps/cleanup

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Validates plugin examples config against the plugin schema using the [Admin API]
 
 | Options | Descriptions  |
 |--------------------------- |-----|
-| `version` | **Required**. Kong Gateway release version, e.g. `_3.3.x`. |
+| `version` | **Required**. Kong Gateway release version, e.g. `3.3.x`. |
 | `plugins` | **Required**. Space separated list of plugins to use, .e.g. `acme acl`. |
 | `host` | Name of the host in which the API is running. Default: `localhost`.  |
 | `port` | Port in which the API is listening. Default: `8001`. |
@@ -59,7 +59,7 @@ Validates plugin examples config against the plugin schema using the [Admin API]
 
 For example, running:
 ```
-./plugins validate_examples --version _3.4.x --plugins acme --verbose
+./plugins validate_examples --version 3.4.x --plugins acme --verbose
 ```
 reads the file `./examples/acme/_3.4.x.yaml` and validates it against the schema using the API.
 
@@ -134,7 +134,7 @@ copies the previous schema (assuming the previous version is `3.4.x`,  it copies
 Whenever a new version of Kong Gateway is released, we need run the following commands in order. For all of them, specify all the plugins `--plugins $(ls ./schemas)`
 
 1. Download Schemas - specify the new version `x.x.x`
-1. Copy Examples - specify the previous version `_x.x.y` of the example that gets copied
-1. Validate Examples  - specify the new version `_x.x.x`
+1. Copy Examples - specify the previous version `x.x.y` of the example that gets copied
+1. Validate Examples  - specify the new version `x.x.x`
 1. Generate Referenceable Fields List - specify the new version `x.x.x`
 1. Generate Priorities List - for `oss` and `ee` and specify the new version `x.x.x`

--- a/lib/example_validator.rb
+++ b/lib/example_validator.rb
@@ -50,6 +50,6 @@ class ExampleValidator < Action
   end
 
   def file_path
-    File.join(@options[:source], @plugin, "#{@options[:version]}.yaml")
+    File.join(@options[:source], @plugin, "_#{@options[:version]}.yaml")
   end
 end


### PR DESCRIPTION
Standardize the way we pass versions to commands, some required the version to be prefixed with `_`.

Add github actions for the rest of the commands, i.e.:
* copy-examples
* copy-schemas
* generate-plugins-priorities
* generate-referenceable-fields
* validate-examples
