### PR TITLE
fix AI RLA examples based on real config

### DIFF
--- a/examples/ai-rate-limiting-advanced/_3.7.x.yaml
+++ b/examples/ai-rate-limiting-advanced/_3.7.x.yaml
@@ -1,12 +1,9 @@
 name: ai-rate-limiting-advanced
 config:
-  model_providers:
-    - openai
-    - mistral
-  model_providers_limit: 
-    - 1000
-    - 100
-  models_providers_window_size:
-    - 3600
-    - 60
-  sync_rate: 10
+  llm_providers:
+    - name: openai
+      limit: 1000
+      window_size: 3600
+    - name: mistral
+      limit: 100
+      window_size: 60

--- a/examples/ai-rate-limiting-advanced/_3.8.x.yaml
+++ b/examples/ai-rate-limiting-advanced/_3.8.x.yaml
@@ -1,12 +1,9 @@
 name: ai-rate-limiting-advanced
 config:
-  model_providers:
-    - openai
-    - mistral
-  model_providers_limit: 
-    - 1000
-    - 100
-  models_providers_window_size:
-    - 3600
-    - 60
-  sync_rate: 10
+  llm_providers:
+    - name: openai
+      limit: 1000
+      window_size: 3600
+    - name: mistral
+      limit: 100
+      window_size: 60


### PR DESCRIPTION
The AI RLA plugin examples are wrong because they were using placeholder values from before the plugin existed. Fixed and validated the example to use real config options and values, they all work now.

Fixes https://github.com/Kong/docs.konghq.com/issues/7655.