### PR TITLE
Fix AI prompt decorator examples

### DIFF
--- a/examples/ai-prompt-decorator/_3.6.x.yaml
+++ b/examples/ai-prompt-decorator/_3.6.x.yaml
@@ -1,12 +1,13 @@
 name: ai-prompt-decorator
 config:
-  prepend:
-    - role: "system"
-      content: "You are data scientist, specialising in survey analytics."
-    - role: "user"
-      content: "Classify this test result set as positive, negative, or neutral."
-    - role: "assistant"
-      content: "These tests are NEUTRAL."
-  append:
-    - role: "user"
-      content: "Do not mention any real participants name in your justification."
+  prompts:
+    prepend:
+      - role: "system"
+        content: "You are data scientist, specialising in survey analytics."
+      - role: "user"
+        content: "Classify this test result set as positive, negative, or neutral."
+      - role: "assistant"
+        content: "These tests are NEUTRAL."
+    append:
+      - role: "user"
+        content: "Do not mention any real participants name in your justification."

--- a/examples/ai-prompt-decorator/_3.7.x.yaml
+++ b/examples/ai-prompt-decorator/_3.7.x.yaml
@@ -1,12 +1,13 @@
 name: ai-prompt-decorator
 config:
-  prepend:
-    - role: "system"
-      content: "You are data scientist, specialising in survey analytics."
-    - role: "user"
-      content: "Classify this test result set as positive, negative, or neutral."
-    - role: "assistant"
-      content: "These tests are NEUTRAL."
-  append:
-    - role: "user"
-      content: "Do not mention any real participants name in your justification."
+  prompts:
+    prepend:
+      - role: "system"
+        content: "You are data scientist, specialising in survey analytics."
+      - role: "user"
+        content: "Classify this test result set as positive, negative, or neutral."
+      - role: "assistant"
+        content: "These tests are NEUTRAL."
+    append:
+      - role: "user"
+        content: "Do not mention any real participants name in your justification."

--- a/examples/ai-prompt-decorator/_3.8.x.yaml
+++ b/examples/ai-prompt-decorator/_3.8.x.yaml
@@ -1,12 +1,13 @@
 name: ai-prompt-decorator
 config:
-  prepend:
-    - role: "system"
-      content: "You are data scientist, specialising in survey analytics."
-    - role: "user"
-      content: "Classify this test result set as positive, negative, or neutral."
-    - role: "assistant"
-      content: "These tests are NEUTRAL."
-  append:
-    - role: "user"
-      content: "Do not mention any real participants name in your justification."
+  prompts:
+    prepend:
+      - role: "system"
+        content: "You are data scientist, specialising in survey analytics."
+      - role: "user"
+        content: "Classify this test result set as positive, negative, or neutral."
+      - role: "assistant"
+        content: "These tests are NEUTRAL."
+    append:
+      - role: "user"
+        content: "Do not mention any real participants name in your justification."


### PR DESCRIPTION
Plugin config was missing the `prompts` key. Tested locally, examples pass validation now.