### PR TITLE
Update the 3.8 example for AI Semantic Cache

### DIFF
--- a/examples/ai-semantic-cache/_3.8.x.yaml
+++ b/examples/ai-semantic-cache/_3.8.x.yaml
@@ -1,10 +1,12 @@
 name: ai-semantic-cache
 config:
   embeddings:
-    provider: openai
-    name: text-embedding-3-large
+    model:
+      provider: openai
+      name: text-embedding-3-large
   vectordb:
-    dimensions: 1024
-    distance_metric: cosine
     strategy: redis
+    dimensions: 3072
     threshold: 0.1
+    distance_metric: cosine
+    redis:

--- a/examples/ai-semantic-cache/_3.8.x.yaml
+++ b/examples/ai-semantic-cache/_3.8.x.yaml
@@ -10,3 +10,5 @@ config:
     threshold: 0.1
     distance_metric: cosine
     redis:
+      host: exampleredis.com
+      port: 80


### PR DESCRIPTION
Updating the 3.8 example for AI Semantic Cache since we merged in the fixed schema