### PR TITLE
Add `referenceable` to the field's description in json_schemas

### DIFF
--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -85,6 +85,14 @@ class ConvertJsonSchema
         fields['format'] = 'uuid'
       end
 
+      if  k =='referenceable'
+        note = 'This field is *referenceable*.'
+        if fields.key?('description')
+          fields['description'] << "\n#{note}"
+        else
+          fields['description'] = note
+        end
+      end
 
       # Remove unused fields
       next if [

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -86,7 +86,7 @@ class ConvertJsonSchema
       end
 
       if  k =='referenceable'
-        note = 'This field is *referenceable*.'
+        note = 'This field is [referenceable](/gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault).'
         if fields.key?('description')
           fields['description'] << "\n#{note}"
         else


### PR DESCRIPTION
The spec-renderer doesn't support this property, so we have to manually add it to the descriptions.