### PR TITLE
Make encrypted referenceable optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+admin-spec:
+	./plugins convert_json_schema --plugins $$(ls schemas/) --version 3.10.x --skip-custom-annotations; cp -r json_schemas/* ../kong-admin-spec-generator/data/plugins

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -38,6 +38,7 @@ class ConvertJsonSchema
 
       # Fix any broken defaults
       json_schema = fix_broken_defaults(json_schema)
+      json_schema = fix_regex(json_schema)
 
       # Write the schema to the destination
       FileUtils.mkdir_p("#{@options[:destination]}/#{plugin_name}")
@@ -235,6 +236,7 @@ class ConvertJsonSchema
       # Escape forward slashes
       schema['pattern'] = schema['pattern'].gsub('%/', '\\/')
     end
+
     if schema['items']
       schema['items'] = fix_regex(schema['items'])
     end
@@ -254,8 +256,12 @@ class ConvertJsonSchema
     if schema['properties']
       schema['properties'].each do |k, v|
         schema['properties'][k] = fix_broken_defaults(v)
-        schema['properties'][k] = fix_regex(v)
+        schema['properties'][k] = fix_regex(schema['properties'][k])
       end
+    end
+
+    if schema['items']
+      schema['items'] = fix_broken_defaults(schema['items'])
     end
 
     return schema

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -85,21 +85,24 @@ class ConvertJsonSchema
         fields['format'] = 'uuid'
       end
 
-      if k == 'encrypted'
-        note = 'This field is [encrypted](/gateway/keyring/).'
-        if fields.key?('description')
-          fields['description'] << "\n#{note}"
-        else
-          fields['description'] = note
-        end
-      end
 
-      if k == 'referenceable'
-        note = 'This field is [referenceable](/gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault).'
-        if fields.key?('description')
-          fields['description'] << "\n#{note}"
-        else
-          fields['description'] = note
+      if !@options[:skip_custom_annotations]
+        if k == 'encrypted'
+          note = 'This field is [encrypted](/gateway/keyring/).'
+          if fields.key?('description')
+            fields['description'] << "\n#{note}"
+          else
+            fields['description'] = note
+          end
+        end
+
+        if k == 'referenceable'
+          note = 'This field is [referenceable](/gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault).'
+          if fields.key?('description')
+            fields['description'] << "\n#{note}"
+          else
+            fields['description'] = note
+          end
         end
       end
 
@@ -182,7 +185,7 @@ class ConvertJsonSchema
       end
 
     end
-    
+
 
     schema
   end


### PR DESCRIPTION
We don't want the encrypted/referenceable description in the spec for Terraform etc for now. Add a flag to skip this annotation + fix a recursion bug with regex replacement