### PR TITLE
Allow auto fields in plugin schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 admin-spec:
-	./plugins convert_json_schema --plugins $$(ls schemas/) --version 3.10.x --skip-custom-annotations; cp -r json_schemas/* ../kong-admin-spec-generator/data/plugins
+	./plugins convert_json_schema --plugins $$(ls schemas/) --version 3.11.x --skip-custom-annotations --allow-auto-fields; cp -r json_schemas/* ../kong-admin-spec-generator/data/plugins

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -56,8 +56,15 @@ class ConvertJsonSchema
   end
 
   def convert_to_json_schema(props)
+    is_required = true
+
     # Remove required if default is set
-    props.delete("required") unless props["default"].nil?
+    is_required = false unless props['default'].nil?
+
+    # If there's an auto field, and we allow auto fields
+    is_required = false if @options[:allow_auto_fields] && !props['auto'].nil?
+
+    props.delete("required") unless is_required
 
     # Loop through each field
     props = props.each_with_object({}) do |(k, v), fields|

--- a/plugins
+++ b/plugins
@@ -120,7 +120,7 @@ class Plugins < Thor
   option :source,      aliases: '-s',    type: :string,                 default: './schemas', desc: 'Source folder containing the schemas'
   option :destination, aliases: '--dest', type: :string,                   default: './json_schemas', desc: 'Destination folder where the schemas will be written'
   option :skip_custom_annotations, aliases: '--skip-custom-annotations', type: :boolean,                   default: false, desc: 'Skip custom annotations'
-  option :allow_auto_fields, aliases: '--allow-auto-fields', type: :boolean,                   default: false, desc: 'Do not make a field require if it has auto: true'
+  option :allow_auto_fields, aliases: '--allow-auto-fields', type: :boolean,                   default: false, desc: 'Do not make a field required if it has auto: true'
   def convert_json_schema
     puts 'Converting plugins to JSON schema...'
 

--- a/plugins
+++ b/plugins
@@ -120,6 +120,7 @@ class Plugins < Thor
   option :source,      aliases: '-s',    type: :string,                 default: './schemas', desc: 'Source folder containing the schemas'
   option :destination, aliases: '--dest', type: :string,                   default: './json_schemas', desc: 'Destination folder where the schemas will be written'
   option :skip_custom_annotations, aliases: '--skip-custom-annotations', type: :boolean,                   default: false, desc: 'Skip custom annotations'
+  option :allow_auto_fields, aliases: '--allow-auto-fields', type: :boolean,                   default: false, desc: 'Do not make a field require if it has auto: true'
   def convert_json_schema
     puts 'Converting plugins to JSON schema...'
 


### PR DESCRIPTION
We broke customers by making `namespace` required even though it's an auto field. We'll disable this capability in the next major version, but for now we remove `required` if `auto` is set