### PR TITLE
Fix non array lists

### DIFF
--- a/json_schemas/jwt-signer/3.12.json
+++ b/json_schemas/jwt-signer/3.12.json
@@ -257,16 +257,10 @@
         },
         "channel_token_introspection_authorization": {
           "description": "When using `opaque` channel tokens, and you want to turn on channel token introspection, you need to specify the OAuth 2.0 introspection endpoint URI with this configuration parameter. Otherwise the plugin will not try introspection, and instead returns `401 Unauthorized` when using opaque channel tokens.",
-          "items": {
-            "type": "string"
-          },
           "type": "string"
         },
         "channel_token_introspection_body_args": {
           "description": "If you need to pass additional body arguments to introspection endpoint when the plugin introspects the opaque channel token, you can use this config parameter to specify them. You should URL encode the value. For example: `resource=` or `a=1&b=&c`.",
-          "items": {
-            "type": "string"
-          },
           "type": "string"
         },
         "channel_token_introspection_consumer_by": {
@@ -298,9 +292,6 @@
         },
         "channel_token_introspection_hint": {
           "description": "If you need to give `hint` parameter when introspecting a channel token, you can use this parameter to specify the value of such parameter. By default, a `hint` isn't sent with channel token introspection.",
-          "items": {
-            "type": "string"
-          },
           "type": "string"
         },
         "channel_token_introspection_jwt_claim": {

--- a/json_schemas/vault-auth/3.12.json
+++ b/json_schemas/vault-auth/3.12.json
@@ -5,10 +5,6 @@
         "access_token_name": {
           "default": "access_token",
           "description": "Describes an array of comma-separated parameter names where the plugin looks for an access token. The client must send the access token in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
-          "items": {
-            "description": "A string representing an HTTP header name.",
-            "type": "string"
-          },
           "type": "string"
         },
         "anonymous": {
@@ -28,10 +24,6 @@
         "secret_token_name": {
           "default": "secret_token",
           "description": "Describes an array of comma-separated parameter names where the plugin looks for a secret token. The client must send the secret in one of those key names, and the plugin will try to read the credential from a header or the querystring parameter with the same name. The key names can only contain [a-z], [A-Z], [0-9], [_], and [-].",
-          "items": {
-            "description": "A string representing an HTTP header name.",
-            "type": "string"
-          },
           "type": "string"
         },
         "tokens_in_body": {

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -39,6 +39,7 @@ class ConvertJsonSchema
       # Fix any broken defaults
       json_schema = fix_broken_defaults(json_schema)
       json_schema = fix_regex(json_schema)
+      json_schema = fix_non_array_elements(json_schema)
 
       # Write the schema to the destination
       FileUtils.mkdir_p("#{@options[:destination]}/#{plugin_name}")
@@ -304,6 +305,20 @@ class ConvertJsonSchema
 
     if schema['items']
       schema['items'] = fix_broken_defaults(schema['items'])
+    end
+
+    return schema
+  end
+
+  def fix_non_array_elements(schema)
+    if schema['items'] && schema['type'] != 'array'
+      schema.delete('items')
+    end
+
+    if schema['properties']
+      schema['properties'].each do |k, v|
+        schema['properties'][k] = fix_non_array_elements(v)
+      end
     end
 
     return schema


### PR DESCRIPTION
When `type` is not `array`, then `items` should not exist.

Sample broken schema (we should ignore `elements`):

```
          {
            "channel_token_introspection_hint": {
              "description": "If you need to give `hint` parameter when introspecting a channel token, you can use this parameter to specify the value of such parameter. By default, a `hint` isn't sent with channel token introspection.",
              "elements": {
                "type": "string"
              },
              "required": false,
              "type": "string"
            }
          },
```