### PR TITLE
Fix Required props

### DIFF
--- a/json_schemas/acl/3.11.json
+++ b/json_schemas/acl/3.11.json
@@ -5,7 +5,6 @@
         "allow": {
           "description": "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified.",
           "items": {
-            "required": [],
             "type": "string"
           },
           "type": "array"
@@ -18,7 +17,6 @@
         "deny": {
           "description": "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified.",
           "items": {
-            "required": [],
             "type": "string"
           },
           "type": "array"
@@ -34,7 +32,6 @@
           "type": "boolean"
         }
       },
-      "required": [],
       "type": "object"
     },
     "protocols": {
@@ -52,7 +49,6 @@
           "http",
           "https"
         ],
-        "required": [],
         "type": "string"
       },
       "type": "array"
@@ -65,7 +61,6 @@
           "type": "string"
         }
       },
-      "required": [],
       "type": "object"
     },
     "service": {
@@ -76,9 +71,7 @@
           "type": "string"
         }
       },
-      "required": [],
       "type": "object"
     }
-  },
-  "required": []
+  }
 }

--- a/json_schemas/acl/3.11.json
+++ b/json_schemas/acl/3.11.json
@@ -5,6 +5,7 @@
         "allow": {
           "description": "Arbitrary group names that are allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified.",
           "items": {
+            "required": [],
             "type": "string"
           },
           "type": "array"
@@ -17,6 +18,7 @@
         "deny": {
           "description": "Arbitrary group names that are not allowed to consume the service or route. One of `config.allow` or `config.deny` must be specified.",
           "items": {
+            "required": [],
             "type": "string"
           },
           "type": "array"
@@ -32,6 +34,7 @@
           "type": "boolean"
         }
       },
+      "required": [],
       "type": "object"
     },
     "protocols": {
@@ -49,6 +52,7 @@
           "http",
           "https"
         ],
+        "required": [],
         "type": "string"
       },
       "type": "array"
@@ -61,6 +65,7 @@
           "type": "string"
         }
       },
+      "required": [],
       "type": "object"
     },
     "service": {
@@ -71,7 +76,9 @@
           "type": "string"
         }
       },
+      "required": [],
       "type": "object"
     }
-  }
+  },
+  "required": []
 }

--- a/json_schemas/acme/3.12.json
+++ b/json_schemas/acme/3.12.json
@@ -4,7 +4,6 @@
       "properties": {
         "account_email": {
           "description": "The account identifier. Can be reused in a different plugin instance.\nThis field is [encrypted](/gateway/keyring/).\nThis field is [referenceable](/gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault).",
-          "pattern": "[a-zA-Z0-9]*[!-/:-@[-`{-~]*@+[a-zA-Z0-9]*%.?[a-zA-Z0-9]*",
           "type": "string"
         },
         "account_key": {

--- a/json_schemas/ai-proxy-advanced/3.12.json
+++ b/json_schemas/ai-proxy-advanced/3.12.json
@@ -264,9 +264,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "azure"
-                  ],
                   "type": "object"
                 },
                 "provider": {
@@ -910,8 +907,6 @@
           "required": [
             "dimensions",
             "distance_metric",
-            "pgvector",
-            "redis",
             "strategy",
             "threshold"
           ],

--- a/json_schemas/ai-proxy-advanced/3.12.json
+++ b/json_schemas/ai-proxy-advanced/3.12.json
@@ -649,7 +649,6 @@
               }
             },
             "required": [
-              "logging",
               "model",
               "route_type"
             ],

--- a/json_schemas/ai-rag-injector/3.12.json
+++ b/json_schemas/ai-rag-injector/3.12.json
@@ -164,9 +164,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "azure"
-                  ],
                   "type": "object"
                 },
                 "provider": {

--- a/json_schemas/ai-semantic-cache/3.12.json
+++ b/json_schemas/ai-semantic-cache/3.12.json
@@ -174,9 +174,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "azure"
-                  ],
                   "type": "object"
                 },
                 "provider": {

--- a/json_schemas/ai-semantic-prompt-guard/3.12.json
+++ b/json_schemas/ai-semantic-prompt-guard/3.12.json
@@ -164,9 +164,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "azure"
-                  ],
                   "type": "object"
                 },
                 "provider": {

--- a/json_schemas/ai-semantic-response-guard/3.12.json
+++ b/json_schemas/ai-semantic-response-guard/3.12.json
@@ -164,9 +164,6 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "azure"
-                  ],
                   "type": "object"
                 },
                 "provider": {

--- a/json_schemas/confluent-consume/3.12.json
+++ b/json_schemas/confluent-consume/3.12.json
@@ -283,9 +283,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "authentication"
-              ],
               "type": "object"
             }
           },

--- a/json_schemas/confluent-consume/3.12.json
+++ b/json_schemas/confluent-consume/3.12.json
@@ -485,9 +485,6 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "authentication"
-                    ],
                     "type": "object"
                   }
                 },
@@ -495,8 +492,7 @@
               }
             },
             "required": [
-              "name",
-              "schema_registry"
+              "name"
             ],
             "type": "object"
           },

--- a/json_schemas/confluent/3.12.json
+++ b/json_schemas/confluent/3.12.json
@@ -353,9 +353,6 @@
                   "type": "object"
                 }
               },
-              "required": [
-                "authentication"
-              ],
               "type": "object"
             }
           },

--- a/json_schemas/datadog/3.12.json
+++ b/json_schemas/datadog/3.12.json
@@ -63,7 +63,6 @@
               "tags": {
                 "description": "List of tags",
                 "items": {
-                  "pattern": "^.*[^:]$",
                   "type": "string"
                 },
                 "type": "array"

--- a/json_schemas/datakit/3.12.json
+++ b/json_schemas/datakit/3.12.json
@@ -48,21 +48,18 @@
                     },
                     "maxLength": 64,
                     "minLength": 1,
-                    "required": false,
                     "type": "array"
                   },
                   "input": {
                     "description": "branch node input",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "output": {
                     "description": "branch node output",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "outputs": {
@@ -72,18 +69,15 @@
                         "description": "node output",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "then": {
                         "description": "node output",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       }
                     },
-                    "required": false,
                     "type": "object"
                   },
                   "then": {
@@ -97,7 +91,6 @@
                     },
                     "maxLength": 64,
                     "minLength": 1,
-                    "required": false,
                     "type": "array"
                   }
                 },
@@ -113,7 +106,6 @@
                     "description": "cache node input",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "inputs": {
@@ -123,32 +115,27 @@
                         "description": "The data to be cached.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "key": {
                         "description": "The cache key.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "ttl": {
                         "description": "The TTL in seconds.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       }
                     },
-                    "required": false,
                     "type": "object"
                   },
                   "output": {
                     "description": "cache node output",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "outputs": {
@@ -158,32 +145,27 @@
                         "description": "The data that was cached.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "hit": {
                         "description": "Signals a cache hit.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "miss": {
                         "description": "Signals a cache miss.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "stored": {
                         "description": "Signals whether data was stored in cache.",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       }
                     },
-                    "required": false,
                     "type": "object"
                   },
                   "ttl": {
@@ -199,7 +181,6 @@
                     "description": "call node input",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "inputs": {
@@ -209,25 +190,21 @@
                         "description": "HTTP request body",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "headers": {
                         "description": "HTTP request headers",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "query": {
                         "description": "HTTP request query",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       }
                     },
-                    "required": false,
                     "type": "object"
                   },
                   "method": {
@@ -242,7 +219,6 @@
                     "description": "call node output",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "outputs": {
@@ -252,25 +228,21 @@
                         "description": "HTTP response body",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "headers": {
                         "description": "HTTP response headers",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "status": {
                         "description": "HTTP response status code",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       }
                     },
-                    "required": false,
                     "type": "object"
                   },
                   "ssl_server_name": {
@@ -298,7 +270,6 @@
                     "description": "exit node input",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "inputs": {
@@ -308,18 +279,15 @@
                         "description": "HTTP response body",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       },
                       "headers": {
                         "description": "HTTP response headers",
                         "maxLength": 255,
                         "minLength": 1,
-                        "required": false,
                         "type": "string"
                       }
                     },
-                    "required": false,
                     "type": "object"
                   },
                   "status": {
@@ -330,7 +298,6 @@
                     "type": "integer"
                   },
                   "warn_headers_sent": {
-                    "required": false,
                     "type": "boolean"
                   }
                 },
@@ -343,13 +310,11 @@
                     "description": "filter input(s)",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "inputs": {
                     "additionalProperties": true,
                     "description": "filter input(s)",
-                    "required": false,
                     "type": "object"
                   },
                   "jq": {
@@ -363,7 +328,6 @@
                     "description": "filter output(s)",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   }
                 },
@@ -379,21 +343,18 @@
                       "application/octet-stream",
                       "text/plain"
                     ],
-                    "required": false,
                     "type": "string"
                   },
                   "input": {
                     "description": "Property input source. When connected, this node operates in SET mode and writes input data to the property. Otherwise, the node operates in GET mode and reads the property.",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "output": {
                     "description": "Property output. This can be connected regardless of whether the node is operating in GET mode or SET mode.",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "property": {
@@ -414,13 +375,11 @@
                     "description": "The entire `.values` map",
                     "maxLength": 255,
                     "minLength": 1,
-                    "required": false,
                     "type": "string"
                   },
                   "outputs": {
                     "additionalProperties": true,
                     "description": "Individual items from `.values`, referenced by key",
-                    "required": false,
                     "type": "object"
                   }
                 },
@@ -612,10 +571,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "memory",
-                "redis"
-              ],
               "type": "object"
             },
             "vault": {

--- a/json_schemas/datakit/3.12.json
+++ b/json_schemas/datakit/3.12.json
@@ -212,7 +212,6 @@
                     "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
                     "maxLength": 32,
                     "minLength": 1,
-                    "pattern": "^%u+$",
                     "type": "string"
                   },
                   "output": {

--- a/json_schemas/file-log/3.12.json
+++ b/json_schemas/file-log/3.12.json
@@ -9,7 +9,6 @@
         },
         "path": {
           "description": "The file path of the output log file. The plugin creates the log file if it doesn't exist yet.",
-          "pattern": "^[^[\\t\\n\\v\\f\\r ]*&%%\\`][^*&%%\\`]*[^[\\t\\n\\v\\f\\r ]*&%%\\`]$",
           "type": "string"
         },
         "reopen": {

--- a/json_schemas/injection-protection/3.12.json
+++ b/json_schemas/injection-protection/3.12.json
@@ -3,7 +3,6 @@
     "config": {
       "properties": {
         "custom_injections": {
-          "default": null,
           "description": "Custom regexes to check for.",
           "items": {
             "properties": {

--- a/json_schemas/kafka-consume/3.12.json
+++ b/json_schemas/kafka-consume/3.12.json
@@ -501,9 +501,6 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "authentication"
-                    ],
                     "type": "object"
                   }
                 },
@@ -511,8 +508,7 @@
               }
             },
             "required": [
-              "name",
-              "schema_registry"
+              "name"
             ],
             "type": "object"
           },

--- a/json_schemas/kafka-consume/3.12.json
+++ b/json_schemas/kafka-consume/3.12.json
@@ -291,9 +291,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "authentication"
-              ],
               "type": "object"
             }
           },

--- a/json_schemas/kafka-log/3.12.json
+++ b/json_schemas/kafka-log/3.12.json
@@ -340,9 +340,6 @@
                   "type": "object"
                 }
               },
-              "required": [
-                "authentication"
-              ],
               "type": "object"
             }
           },

--- a/json_schemas/kafka-upstream/3.12.json
+++ b/json_schemas/kafka-upstream/3.12.json
@@ -370,9 +370,6 @@
                   "type": "object"
                 }
               },
-              "required": [
-                "authentication"
-              ],
               "type": "object"
             }
           },

--- a/json_schemas/konnect-application-auth/3.12.json
+++ b/json_schemas/konnect-application-auth/3.12.json
@@ -56,7 +56,6 @@
                   }
                 },
                 "required": [
-                  "config",
                   "strategy_id"
                 ],
                 "type": "object"
@@ -1991,7 +1990,6 @@
                       }
                     },
                     "required": [
-                      "cluster_cache_redis",
                       "issuer"
                     ],
                     "type": "object"

--- a/json_schemas/oauth2/3.12.json
+++ b/json_schemas/oauth2/3.12.json
@@ -98,9 +98,6 @@
           "type": "number"
         }
       },
-      "required": [
-        "provision_key"
-      ],
       "type": "object"
     },
     "protocols": {
@@ -146,8 +143,5 @@
       },
       "type": "object"
     }
-  },
-  "required": [
-    "config"
-  ]
+  }
 }

--- a/json_schemas/rate-limiting-advanced/3.12.json
+++ b/json_schemas/rate-limiting-advanced/3.12.json
@@ -322,7 +322,6 @@
       },
       "required": [
         "limit",
-        "namespace",
         "window_size"
       ],
       "type": "object"

--- a/json_schemas/request-callout/3.12.json
+++ b/json_schemas/request-callout/3.12.json
@@ -360,7 +360,6 @@
                   "method": {
                     "default": "GET",
                     "description": "The HTTP method that will be requested.",
-                    "pattern": "^[A-Z]+$",
                     "type": "string"
                   },
                   "query": {

--- a/json_schemas/request-callout/3.12.json
+++ b/json_schemas/request-callout/3.12.json
@@ -384,11 +384,6 @@
                   }
                 },
                 "required": [
-                  "body",
-                  "error",
-                  "headers",
-                  "http_opts",
-                  "query",
                   "url"
                 ],
                 "type": "object"
@@ -427,18 +422,12 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "body",
-                  "headers"
-                ],
                 "type": "object"
               }
             },
             "required": [
-              "cache",
               "name",
-              "request",
-              "response"
+              "request"
             ],
             "type": "object"
           },

--- a/json_schemas/request-transformer-advanced/3.12.json
+++ b/json_schemas/request-transformer-advanced/3.12.json
@@ -102,7 +102,6 @@
         },
         "http_method": {
           "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
-          "pattern": "^[A-Z]+$",
           "type": "string"
         },
         "remove": {

--- a/json_schemas/request-transformer/3.12.json
+++ b/json_schemas/request-transformer/3.12.json
@@ -14,7 +14,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -41,7 +40,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -58,7 +56,6 @@
         },
         "http_method": {
           "description": "A string representing an HTTP method, such as GET, POST, PUT, or DELETE. The string must contain only uppercase letters.",
-          "pattern": "^[A-Z]+$",
           "type": "string"
         },
         "remove": {
@@ -99,7 +96,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -126,7 +122,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"

--- a/json_schemas/response-transformer-advanced/3.12.json
+++ b/json_schemas/response-transformer-advanced/3.12.json
@@ -125,7 +125,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"

--- a/json_schemas/response-transformer/3.12.json
+++ b/json_schemas/response-transformer/3.12.json
@@ -7,7 +7,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -15,7 +14,6 @@
             "json": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -41,7 +39,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -49,7 +46,6 @@
             "json": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -94,7 +90,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -102,7 +97,6 @@
             "json": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -115,7 +109,6 @@
             "headers": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"
@@ -123,7 +116,6 @@
             "json": {
               "default": [],
               "items": {
-                "pattern": "^[^:]+:.*$",
                 "type": "string"
               },
               "type": "array"

--- a/json_schemas/route-by-header/3.12.json
+++ b/json_schemas/route-by-header/3.12.json
@@ -17,7 +17,6 @@
               }
             },
             "required": [
-              "condition",
               "upstream_name"
             ],
             "type": "object"

--- a/json_schemas/saml/3.12.json
+++ b/json_schemas/saml/3.12.json
@@ -387,7 +387,6 @@
           "description": "The session secret. This must be a random string of 32 characters from the base64 alphabet (letters, numbers, `/`, `_` and `+`). It is used as the secret key for encrypting session data as well as state information that is sent to the IdP in the authentication exchange.\nThis field is [referenceable](/gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault).\nThis field is [encrypted](/gateway/keyring/).",
           "maxLength": 32,
           "minLength": 32,
-          "pattern": "^[0-9a-zA-Z/_+]+$",
           "type": "string"
         },
         "session_storage": {

--- a/json_schemas/service-protection/3.12.json
+++ b/json_schemas/service-protection/3.12.json
@@ -234,7 +234,6 @@
       },
       "required": [
         "limit",
-        "namespace",
         "window_size"
       ],
       "type": "object"

--- a/json_schemas/statsd-advanced/3.12.json
+++ b/json_schemas/statsd-advanced/3.12.json
@@ -5,7 +5,6 @@
         "allow_status_codes": {
           "description": "List of status code ranges that are allowed to be logged in metrics.",
           "items": {
-            "pattern": "^[0-9]+-[0-9]+$",
             "type": "string"
           },
           "type": "array"

--- a/json_schemas/statsd/3.12.json
+++ b/json_schemas/statsd/3.12.json
@@ -5,7 +5,6 @@
         "allow_status_codes": {
           "description": "List of status code ranges that are allowed to be logged in metrics.",
           "items": {
-            "pattern": "^[0-9]+-[0-9]+$",
             "type": "string"
           },
           "type": "array"

--- a/json_schemas/xml-threat-protection/3.12.json
+++ b/json_schemas/xml-threat-protection/3.12.json
@@ -11,7 +11,6 @@
           "default": [],
           "description": "A list of Content-Type values with payloads that are allowed, but aren't validated.",
           "items": {
-            "pattern": "^[^\\t\\n\\v\\f\\r ]+\\/[^ ;]+$",
             "type": "string"
           },
           "type": "array"
@@ -44,7 +43,6 @@
           ],
           "description": "A list of Content-Type values with payloads that must be validated.",
           "items": {
-            "pattern": "^[^\\t\\n\\v\\f\\r ]+\\/[^ ;]+$",
             "type": "string"
           },
           "type": "array"

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -57,7 +57,7 @@ class ConvertJsonSchema
   end
 
   def convert_to_json_schema(props, parent)
-    is_required = true
+    is_required = props['required'] || false
 
     # The default value may be in the parent schema if this is
     # a reusable schema with an overridden value

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -152,7 +152,8 @@ class ConvertJsonSchema
         'match_all',
         'examples',
         'not_one_of',
-        'uuid'
+        'uuid',
+        'pattern'
       ].include?(k)
 
       if k == 'type' && v == 'foreign'

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -232,7 +232,7 @@ class ConvertJsonSchema
   def remove_object_required_optional_children(schema)
     if schema['required'] && schema['properties']
       unused = []
-      schema['required'].each do |k|
+      schema['properties'].each do |k, v|
         next unless schema['properties'][k]['type'] == 'object'
 
         schema['properties'][k] = remove_object_required_optional_children(schema['properties'][k])

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -34,7 +34,7 @@ class ConvertJsonSchema
 
       # If an entity is required, but no children are required
       # it's not actually required
-      json_schema = remove_object_required_optional_children(json_schema)
+      json_schema = remove_object_required_optional_children(json_schema, plugin_name)
 
       # Fix any broken defaults
       json_schema = fix_broken_defaults(json_schema)
@@ -229,19 +229,21 @@ class ConvertJsonSchema
     schema
   end
 
-  def remove_object_required_optional_children(schema)
-    if schema['required'] && schema['properties']
+  def remove_object_required_optional_children(schema, path)
+    if schema['properties']
       unused = []
       schema['properties'].each do |k, v|
         next unless schema['properties'][k]['type'] == 'object'
 
-        schema['properties'][k] = remove_object_required_optional_children(schema['properties'][k])
+        schema['properties'][k] = remove_object_required_optional_children(schema['properties'][k], "#{path}.#{k}")
         if !schema['properties'][k]['required'] || schema['properties'][k]['required'].size == 0
           unused.push(k)
         end
       end
 
-      schema['required'] -= unused
+      if schema['required']
+        schema['required'] -= unused
+      end
     end
     if schema['required']&.length == 0
       schema.delete('required')

--- a/lib/convert_json_schema.rb
+++ b/lib/convert_json_schema.rb
@@ -305,6 +305,10 @@ class ConvertJsonSchema
       end
     end
 
+    if schema['default'].nil?
+      schema.delete('default')
+    end
+
     if schema['items']
       schema['items'] = fix_broken_defaults(schema['items'])
     end


### PR DESCRIPTION
Some props e.g. `config.embeddings.model` in `ai-rag-injector` were mistakenly marked as required due to misleading schemas (parent marked required, but no children are required).